### PR TITLE
fix: delete nonces table

### DIFF
--- a/bin/stacks/dynamo-stack.ts
+++ b/bin/stacks/dynamo-stack.ts
@@ -7,7 +7,6 @@ export interface DynamoStackProps extends cdk.NestedStackProps {}
 
 export class DynamoStack extends cdk.NestedStack {
   public readonly ordersTable: aws_dynamo.Table
-  public readonly nonceTable: aws_dynamo.Table
 
   constructor(scope: Construct, id: string, props: DynamoStackProps) {
     super(scope, id, props)
@@ -63,17 +62,6 @@ export class DynamoStack extends cdk.NestedStack {
       },
       projectionType: aws_dynamo.ProjectionType.INCLUDE,
       nonKeyAttributes: ['orderHash', 'encodedOrder', 'signature'],
-    })
-
-    /* nonce table */
-    this.nonceTable = new aws_dynamo.Table(this, `${SERVICE_NAME}NoncesTable`, {
-      tableName: 'Nonces',
-      partitionKey: {
-        name: 'creator',
-        type: aws_dynamo.AttributeType.STRING,
-      },
-      // in us-east-2, $1.25 per million WRU, $0.25 per million RRU
-      billingMode: aws_dynamo.BillingMode.PAY_PER_REQUEST,
     })
   }
 }


### PR DESCRIPTION
We want to try using the Orders table to manage nonce, so this is no longer needed.