### PR TITLE
added back github workflow coverage annotations

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,4 +45,3 @@ jobs:
         with:
           package-manager: yarn
           test-script: yarn test --coverage
-          annotations: failed-tests


### PR DESCRIPTION
by default, jest coverage report action does both coverage annotations and test annotations