### PR TITLE
fix: remove 60 second deadline check

### DIFF
--- a/lib/util/order-validator.ts
+++ b/lib/util/order-validator.ts
@@ -10,7 +10,7 @@ export type OrderValidationResponse = {
 const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365
 
 export class OrderValidator {
-  constructor(private readonly getCurrentTime: () => number, private readonly minOffset = 60) {}
+  constructor(private readonly getCurrentTime: () => number) {}
 
   validate(order: DutchLimitOrder): OrderValidationResponse {
     const deadlineValidation = this.validateDeadline(order.info.deadline)
@@ -63,10 +63,10 @@ export class OrderValidator {
   }
 
   private validateDeadline(deadline: number): OrderValidationResponse {
-    if (deadline < this.getCurrentTime() + this.minOffset) {
+    if (deadline < this.getCurrentTime()) {
       return {
         valid: false,
-        errorString: `Insufficient Deadline`,
+        errorString: 'Deadline must be in the future',
       }
     }
     /* 

--- a/test/util/order-validator.test.ts
+++ b/test/util/order-validator.test.ts
@@ -3,7 +3,7 @@ import { DutchLimitOrder } from 'gouda-sdk'
 import { OrderValidator } from '../../lib/util/order-validator'
 
 const CURRENT_TIME = 10
-const validationProvider = new OrderValidator(() => CURRENT_TIME, 1)
+const validationProvider = new OrderValidator(() => CURRENT_TIME)
 const INPUT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000022'
 const OUTPUT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000033'
 const ONE_YEAR = 60 * 60 * 24 * 365
@@ -36,7 +36,7 @@ describe('Testing off chain validation', () => {
     it('Testing deadline < current time.', async () => {
       const order = newOrder({ deadline: 9 })
       const validationResp = validationProvider.validate(order)
-      expect(validationResp).toEqual({ errorString: 'Insufficient Deadline', valid: false })
+      expect(validationResp).toEqual({ errorString: 'Deadline must be in the future', valid: false })
     })
     it('Testing deadline longer than one year.', async () => {
       const order = newOrder({ deadline: CURRENT_TIME + ONE_YEAR + 1 })


### PR DESCRIPTION
Accordingly to discussion in team channel, remove the requirement that `deadline must be current time + 60 seconds`