### PR TITLE
chore: reduce provisioned concurrency

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -109,7 +109,7 @@ export class APIPipeline extends Stack {
     // Beta us-east-2
     const betaUsEast2Stage = new APIStage(this, 'beta-us-east-2', {
       env: { account: '321377678687', region: 'us-east-2' },
-      provisionedConcurrency: 20,
+      provisionedConcurrency: 5,
       stage: STAGE.BETA,
     })
 
@@ -120,7 +120,7 @@ export class APIPipeline extends Stack {
     // Prod us-east-2
     const prodUsEast2Stage = new APIStage(this, 'prod-us-east-2', {
       env: { account: '316116520258', region: 'us-east-2' },
-      provisionedConcurrency: 100,
+      provisionedConcurrency: 20,
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       stage: STAGE.PROD,
     })


### PR DESCRIPTION
This PR reduces the provisioned concurrency setting for GoudaServiceStack so that it doesn't cost > $2k at idle.

<img width="382" alt="Screen Shot 2022-11-16 at 10 38 35 AM" src="https://user-images.githubusercontent.com/11896690/203130206-0a2ab5ca-c5a4-4f64-a3f3-d71b43066e90.png">
<img width="412" alt="Screen Shot 2022-11-16 at 10 39 38 AM" src="https://user-images.githubusercontent.com/11896690/203130224-674738fe-2af1-423f-aace-0851cb16859e.png">
