### PR TITLE
fix: use a larger build environment to run IntegTests build step

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -1,6 +1,6 @@
 import * as cdk from 'aws-cdk-lib'
 import { CfnOutput, SecretValue, Stack, StackProps, Stage, StageProps } from 'aws-cdk-lib'
-import { BuildEnvironmentVariableType, BuildSpec } from 'aws-cdk-lib/aws-codebuild'
+import { BuildEnvironmentVariableType, BuildSpec, ComputeType } from 'aws-cdk-lib/aws-codebuild'
 import * as sm from 'aws-cdk-lib/aws-secretsmanager'
 import { CodeBuildStep, CodePipeline, CodePipelineSource } from 'aws-cdk-lib/pipelines'
 import { Construct } from 'constructs'
@@ -143,6 +143,7 @@ export class APIPipeline extends Stack {
       },
       buildEnvironment: {
         buildImage: cdk.aws_codebuild.LinuxBuildImage.STANDARD_6_0,
+        computeType: ComputeType.MEDIUM,
         environmentVariables: {
           NPM_TOKEN: {
             value: 'npm-private-repo-access-token',


### PR DESCRIPTION
Currently AWS deployment is failing at `GoudaService-IntegTests-beta-us-east-2` because of the following error:
```
$ jest --testPathPattern=integ/
--
84 |  
85 | <--- Last few GCs --->
86 |  
87 | [341:0x6a23720]    51554 ms: Scavenge 1532.9 (1564.1) -> 1531.6 (1564.4) MB, 5.5 / 0.0 ms  (average mu = 0.448, current mu = 0.395) allocation failure
88 | [341:0x6a23720]    53337 ms: Mark-sweep (reduce) 1534.8 (1565.6) -> 1533.5 (1563.9) MB, 1166.4 / 0.0 ms  (+ 77.6 ms in 16 steps since start of marking, biggest step 18.4 ms, walltime since start of marking 1445 ms) (average mu = 0.388, current mu = 0.316)
89 |  
90 | <--- JS stacktrace --->
91 |  
92 | FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```
This PR attempts to fix deployment by using a larger `computeType`