### PR TITLE
chore: reduce provisioned concurrency

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -108,7 +108,7 @@ export class APIPipeline extends Stack {
     // Beta us-east-2
     const betaUsEast2Stage = new APIStage(this, 'beta-us-east-2', {
       env: { account: '321377678687', region: 'us-east-2' },
-      provisionedConcurrency: 5,
+      provisionedConcurrency: 2,
       stage: STAGE.BETA,
     })
 
@@ -119,7 +119,7 @@ export class APIPipeline extends Stack {
     // Prod us-east-2
     const prodUsEast2Stage = new APIStage(this, 'prod-us-east-2', {
       env: { account: '316116520258', region: 'us-east-2' },
-      provisionedConcurrency: 20,
+      provisionedConcurrency: 5,
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       stage: STAGE.PROD,
     })


### PR DESCRIPTION
Service not actively used, so it makes sense to scale it down