### PR TITLE
fix: env var names

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -104,7 +104,7 @@ export class APIPipeline extends Stack {
 
     const jsonRpcUrls: { [chain: string]: string } = {}
     Object.values(SUPPORTED_CHAINS).forEach((chainId) => {
-      const key = `WEB3_RPC_${chainId}`
+      const key = `RPC_${chainId}`
       jsonRpcUrls[key] = jsonRpcProvidersSecret.secretValueFromJson(key).toString()
     })
 
@@ -208,7 +208,7 @@ Object.values(SUPPORTED_CHAINS).forEach((chainId) => {
   envVars[`WEB3_RPC_${chainId}`] = process.env[`RPC_${chainId}`] || ''
 })
 
-envVars['WEB3_RPC_TENDERLY'] = process.env[`RPC_TENDERLY`] || ''
+envVars['RPC_TENDERLY'] = process.env[`RPC_TENDERLY`] || ''
 envVars['DL_REACTOR_TENDERLY'] = process.env[`DL_REACTOR_TENDERLY`] || ''
 envVars['QUOTER_TENDERLY'] = process.env[`QUOTER_TENDERLY`] || ''
 envVars['PERMIT2_TENDERLY'] = process.env[`PERMIT2_TENDERLY`] || ''

--- a/lib/handlers/check-order-status/injector.ts
+++ b/lib/handlers/check-order-status/injector.ts
@@ -46,7 +46,7 @@ export class CheckOrderStatusInjector extends SfnInjector<ContainerInjected, Req
       chainId = event.chainId
     }
 
-    const provider = new ethers.providers.JsonRpcProvider(process.env[`WEB3_RPC_${chainId}`])
+    const provider = new ethers.providers.JsonRpcProvider(process.env[`RPC_${chainId}`])
     const quoter = new OrderValidator(
       provider,
       parseInt(event.chainId as string),


### PR DESCRIPTION
RPC secrets stored in Pipeline account's scrt mgr has has different names than we we used to retrieve the values