### PR TITLE
fix: access secret manager value directly in CodeBuild instead

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -172,7 +172,7 @@ export class APIPipeline extends Stack {
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
           GOUDA_SERVICE_URL: {
-            value: 'prod/gouda-service/url',
+            value: `${apiStage.stageName}/gouda-service/url`,
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
         },


### PR DESCRIPTION
Got `Error: Plaintext environment variable 'GOUDA_SERVICE_URL' contains a secret value! This means the value of this variable will be visible in plain text in the AWS Console. Please consider using CodeBuild's SecretsManager environment variables feature instead.` error with the previous PR 