### PR TITLE
feat: support querying all orders by date and sorted by unix timestamp.

### DIFF
--- a/bin/stacks/dynamo-stack.ts
+++ b/bin/stacks/dynamo-stack.ts
@@ -117,6 +117,19 @@ export class DynamoStack extends cdk.NestedStack {
       projectionType: aws_dynamo.ProjectionType.ALL,
     })
 
+    this.ordersTable.addGlobalSecondaryIndex({
+      indexName: `${TABLE_KEY.DATE}-${TABLE_KEY.CREATED_AT}-all`,
+      partitionKey: {
+        name: TABLE_KEY.DATE,
+        type: aws_dynamo.AttributeType.STRING,
+      },
+      sortKey: {
+        name: TABLE_KEY.CREATED_AT,
+        type: aws_dynamo.AttributeType.NUMBER,
+      },
+      projectionType: aws_dynamo.ProjectionType.ALL,
+    })
+
     /* Nonces Table
      * This is needed because we want to do strongly-consistent reads on the nonce value,
      *  which is not possible to do on secondary indexes (if we work with only the Orders table).

--- a/jest-dynamodb-config.js
+++ b/jest-dynamodb-config.js
@@ -13,12 +13,24 @@ module.exports = {
         { AttributeName: 'filler_offerer', AttributeType: 'S' },
         { AttributeName: 'filler_offerer_orderStatus', AttributeType: 'S' },
         { AttributeName: 'createdAt', AttributeType: 'N' },
+        { AttributeName: 'date', AttributeType: 'S' },
       ],
       GlobalSecondaryIndexes: [
         {
           IndexName: 'offerer-createdAt-all',
           KeySchema: [
             { AttributeName: 'offerer', KeyType: 'HASH' },
+            { AttributeName: 'createdAt', KeyType: 'RANGE' },
+          ],
+          Projection: {
+            ProjectionType: 'ALL',
+          },
+          ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+        },
+        {
+          IndexName: 'date-createdAt-all',
+          KeySchema: [
+            { AttributeName: 'date', KeyType: 'HASH' },
             { AttributeName: 'createdAt', KeyType: 'RANGE' },
           ],
           Projection: {

--- a/lib/config/dynamodb.ts
+++ b/lib/config/dynamodb.ts
@@ -21,4 +21,5 @@ export enum TABLE_KEY {
   CREATED_AT_MONTH = 'createdAtMonth',
   FILLER = 'filler',
   TX_HASH = 'txHash',
+  DATE = 'date',
 }

--- a/lib/handlers/get-api-docs-json/schema/index.ts
+++ b/lib/handlers/get-api-docs-json/schema/index.ts
@@ -90,6 +90,13 @@ const OPENAPI_SCHEMA: GetJsonResponse = {
             schema: getOrderParamProperties.filler,
           },
           {
+            name: 'date',
+            in: 'query',
+            description: 'Filter by date. Use this parameter to page through all orders sorted by timestamp.',
+            required: false,
+            schema: getOrderParamProperties.date,
+          },
+          {
             name: 'sortKey',
             in: 'query',
             description: 'Order the query results by the sort key.',

--- a/lib/handlers/get-orders/injector.ts
+++ b/lib/handlers/get-orders/injector.ts
@@ -57,6 +57,7 @@ export class GetOrdersInjector extends ApiInjector<ContainerInjected, RequestInj
     const sort = requestQueryParams?.sort ?? defaultSort
     const filler = requestQueryParams?.filler
     const cursor = requestQueryParams?.cursor
+    const date = requestQueryParams?.date
 
     return {
       limit: limit,
@@ -67,6 +68,7 @@ export class GetOrdersInjector extends ApiInjector<ContainerInjected, RequestInj
         ...(sortKey && { sortKey: sortKey }),
         ...(filler && { filler: filler }),
         ...(sort && { sort: sort }),
+        ...(date && { date: date }),
       },
       requestId,
       log,

--- a/lib/handlers/get-orders/schema/index.ts
+++ b/lib/handlers/get-orders/schema/index.ts
@@ -6,6 +6,7 @@ const indexKeyJoi = Joi.object({
   orderStatus: FieldValidator.isValidOrderStatus(),
   offerer: FieldValidator.isValidEthAddress(),
   filler: FieldValidator.isValidEthAddress(),
+  date: FieldValidator.isValidDate(),
 })
 const sortKeyJoi = FieldValidator.isValidSortKey()
 
@@ -21,7 +22,7 @@ export const GetOrdersQueryParamsJoi = Joi.object({
   cursor: FieldValidator.isValidCursor(),
 }).when('.sortKey', {
   is: Joi.exist(),
-  then: indexKeyJoi.or('orderStatus', 'offerer', 'filler'),
+  then: indexKeyJoi.or('orderStatus', 'offerer', 'filler', 'date'),
   otherwise: indexKeyJoi,
 })
 
@@ -34,6 +35,7 @@ export type GetOrdersQueryParams = {
   sort?: string
   filler?: string
   cursor?: string
+  date?: string
 }
 
 export type GetOrdersResponse = {
@@ -90,4 +92,5 @@ export enum GET_QUERY_PARAMS {
   SORT_KEY = 'sortKey',
   SORT = 'sort',
   FILLER = 'filler',
+  DATE = 'date',
 }

--- a/lib/util/field-validator.ts
+++ b/lib/util/field-validator.ts
@@ -15,6 +15,7 @@ export default class FieldValidator {
   private static readonly UUIDV4_JOI = Joi.string().guid({
     version: ['uuidv4'],
   })
+  private static readonly DATE_JOI = Joi.string().regex(/^\d{4}-\d{2}-\d{2}$/)
   private static readonly BIG_NUMBER_JOI = Joi.string()
     .min(1)
     .max(78) // 2^256 - 1 in base 10 is 78 digits long
@@ -110,6 +111,10 @@ export default class FieldValidator {
 
   public static isValidAmount(): StringSchema {
     return this.BIG_NUMBER_JOI
+  }
+
+  public static isValidDate(): StringSchema {
+    return this.DATE_JOI
   }
 
   private static getHexiDecimalRegex(length?: number, maxLength = false): RegExp {

--- a/lib/util/time.ts
+++ b/lib/util/time.ts
@@ -1,1 +1,2 @@
 export const currentTimestampInSeconds = () => Math.floor(Date.now() / 1000).toString()
+export const currentYearMonthDate = () => new Date().toISOString().split('T')[0]

--- a/test/handlers/get-orders.test.ts
+++ b/test/handlers/get-orders.test.ts
@@ -94,11 +94,15 @@ describe('Testing get orders handler.', () => {
       [{ sortKey: 'createdBy' }, 'must be [createdAt]'],
       [
         { sortKey: 'createdAt' },
-        '{"detail":"\\"value\\" must contain at least one of [orderStatus, offerer, filler]","errorCode":"VALIDATION_ERROR"}',
+        '{"detail":"\\"value\\" must contain at least one of [orderStatus, offerer, filler, date]","errorCode":"VALIDATION_ERROR"}',
       ],
       [{ sort: 'foo(bar)' }, '"foo(bar)\\" fails to match the required pattern'],
       [{ cursor: 1 }, 'must be a string'],
       [{ sort: 'gt(4)' }, '{"detail":"\\"sortKey\\" is required","errorCode":"VALIDATION_ERROR"}'],
+      [
+        { date: '200-01-09' },
+        '{"detail":"\\"date\\" with value \\"200-01-09\\" fails to match the required pattern: /^\\\\d{4}-\\\\d{2}-\\\\d{2}$/","errorCode":"VALIDATION_ERROR"}',
+      ],
     ])('Throws 400 with invalid query param %p', async (invalidQueryParam, bodyMsg) => {
       const invalidEvent = {
         ...event,

--- a/test/util/field-validator.test.ts
+++ b/test/util/field-validator.test.ts
@@ -238,4 +238,20 @@ describe('Testing each field on the FieldValidator class.', () => {
       )
     })
   })
+
+  describe('Testing date field.', () => {
+    it('should validate field.', async () => {
+      const date = '1997-04-30'
+      expect(FieldValidator.isValidDate().validate(date)).toEqual({ value: date })
+    })
+
+    it('should invalidate field.', async () => {
+      const invalidDate = '199-02-50'
+      const validatedField = FieldValidator.isValidDate().validate(invalidDate)
+      expect(validatedField.error).toBeTruthy()
+      expect(validatedField.error?.details[0].message).toEqual(
+        `"value" with value "${invalidDate}" fails to match the required pattern: /^\\d{4}-\\d{2}-\\d{2}$/`
+      )
+    })
+  })
 })

--- a/test/util/time.test.ts
+++ b/test/util/time.test.ts
@@ -1,0 +1,15 @@
+import { currentTimestampInSeconds, currentYearMonthDate } from '../../lib/util/time'
+
+jest.useFakeTimers().setSystemTime(new Date('2020-01-01'))
+
+describe('current time in seconds test', () => {
+  it('should generate an in-range nonce with prefixed gouda bits', () => {
+    expect(currentTimestampInSeconds()).toEqual('1577836800')
+  })
+})
+
+describe('current year month date test', () => {
+  it('should generate an in-range nonce with prefixed gouda bits', () => {
+    expect(currentYearMonthDate()).toEqual('2020-01-01')
+  })
+})


### PR DESCRIPTION
## Summary
This PR does the following:

1. Adds an additional index for `date` (ex. YYYY-Month-Day) to our DB.
2. Adds the date to newly created orders on the post endpoint.
3. Supports querying by date with a sorting param.

This work is a follow up from the following discussion linked [here](https://uniswapteam.slack.com/archives/C04MDJ56DR9/p1678151762364049). The TLDR; we don't currently make it easy for consumers to query all the order types in our database sorted by time. This new index allows consumers to query all order for a given date and in sorted order. 

This **PR does not** allow consumers to query all orders by date **and** other query parameters such as `offerer`, `orderStatus`, etc. 

The logic in this PR follows a design discussed in [this](https://stackoverflow.com/questions/70792706/using-millisecond-timestamp-as-the-global-secondary-index-in-dynamoddb-for-range) stack overflow post.

## Testing
Deployed this branch to my local AWS account and submitted new orders to it. Then queried by date and confirmed only orders created on the specified date were returned. Also manually inspected the DB to make sure the records were being properly created. 