### PR TITLE
fix: use --detectOpenHandles for integ-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "rm -rf dist cdk.out",
     "watch": "tsc -w",
     "test": "jest --detectOpenHandles --forceExit --testPathIgnorePatterns=integ/ dist/",
-    "integ-test": "jest --testPathPattern=integ/",
+    "integ-test": "jest --detectOpenHandles --testPathPattern=integ/",
     "cdk": "cdk",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"lib/**/*.ts\" --write",


### PR DESCRIPTION
otherwise we will get
`TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
`
error when running integration tests