### PR TITLE
fix: remove dup `prod` from swagger

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -3,7 +3,7 @@
   "servers": [
     {
       "description": "Uniswap Trade APIs",
-      "url": "https://6q5qkya37k.execute-api.us-east-2.amazonaws.com/prod"
+      "url": "https://6q5qkya37k.execute-api.us-east-2.amazonaws.com"
     }
   ],
   "info": {


### PR DESCRIPTION
# Description
Removes the duplicate `prod` from swagger.