### PR TITLE
Add DutchLimit type to joi reponse validation.

### DIFF
--- a/lib/util/field-validator.ts
+++ b/lib/util/field-validator.ts
@@ -4,6 +4,7 @@ import { BigNumber, ethers } from 'ethers'
 import Joi, { CustomHelpers, NumberSchema, StringSchema } from 'joi'
 import { ORDER_STATUS, SORT_FIELDS } from '../entities'
 import { SUPPORTED_CHAINS } from './chain'
+import { DUTCH_LIMIT } from './order'
 
 export const SORT_REGEX = /(\w+)\(([0-9]+)(?:,([0-9]+))?\)/
 const UINT256_MAX = BigNumber.from(1).shl(256).sub(1)
@@ -44,7 +45,10 @@ export default class FieldValidator {
   )
   private static readonly SORT_KEY_JOI = Joi.string().valid(SORT_FIELDS.CREATED_AT)
   private static readonly SORT_JOI = Joi.string().regex(SORT_REGEX)
-  private static readonly ORDER_TYPE_JOI = Joi.string().valid(OrderType.Dutch)
+
+  // TODO: DutchLimit type is deprecated but we allow it in the response to remain backwards compatible.
+  // Remove this field from Joi once we have purge job to delete all DutchLimit orders from the database.
+  private static readonly ORDER_TYPE_JOI = Joi.string().valid(OrderType.Dutch, DUTCH_LIMIT)
 
   private static readonly ETH_ADDRESS_JOI = Joi.string().custom((value: string, helpers: CustomHelpers<any>) => {
     if (!ethers.utils.isAddress(value)) {

--- a/lib/util/order.ts
+++ b/lib/util/order.ts
@@ -2,6 +2,8 @@ import { DutchOrder, OrderType } from '@uniswap/gouda-sdk'
 import { DynamoDBRecord } from 'aws-lambda'
 import { OrderEntity, ORDER_STATUS } from '../entities'
 
+export const DUTCH_LIMIT = 'DutchLimit'
+
 type ParsedOrder = {
   encodedOrder: string
   signature: string

--- a/test/util/field-validator.test.ts
+++ b/test/util/field-validator.test.ts
@@ -256,4 +256,17 @@ describe('Testing each field on the FieldValidator class.', () => {
       )
     })
   })
+
+  describe('Testing orderType field.', () => {
+    it.each([['Dutch'], ['DutchLimit']])('Validates orderType %p', async (orderType) => {
+      expect(FieldValidator.isValidOrderType().validate(orderType)).toEqual({ value: orderType })
+    })
+
+    it('should invalidate field.', async () => {
+      const orderType = 'LimitOrder'
+      const validatedField = FieldValidator.isValidOrderType().validate(orderType)
+      expect(validatedField.error).toBeTruthy()
+      expect(validatedField.error?.details[0].message).toEqual('"value" must be one of [Dutch, DutchLimit]')
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Fix joi validation that is currently breaking the endpoint. We have old orders in the DB with `orderType` as `DutchLimit`. This type is now deprecated in favor of `Dutch`. 