### PR TITLE
feat: bump read/write capacity

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -11,6 +11,7 @@ import { Construct } from 'constructs'
 import { STAGE } from '../../lib/util/stage'
 import { SERVICE_NAME } from '../constants'
 import { DashboardStack } from './dashboard-stack'
+import { TableCapacityOptions } from './dynamo-stack'
 import { LambdaStack } from './lambda-stack'
 
 export class APIStack extends cdk.Stack {
@@ -26,11 +27,13 @@ export class APIStack extends cdk.Stack {
       chatbotSNSArn?: string
       stage: string
       envVars: { [key: string]: string }
+      tableCapacityOptions: TableCapacityOptions
     }
   ) {
     super(parent, name, props)
 
-    const { throttlingOverride, chatbotSNSArn, stage, provisionedConcurrency, internalApiKey } = props
+    const { throttlingOverride, chatbotSNSArn, stage, provisionedConcurrency, internalApiKey, tableCapacityOptions } =
+      props
 
     const {
       getOrdersLambdaAlias,
@@ -47,6 +50,7 @@ export class APIStack extends cdk.Stack {
       provisionedConcurrency,
       stage: stage as STAGE,
       envVars: props.envVars,
+      tableCapacityOptions,
     })
 
     const accessLogGroup = new aws_logs.LogGroup(this, `${SERVICE_NAME}APIGAccessLogs`)

--- a/bin/stacks/dynamo-stack.ts
+++ b/bin/stacks/dynamo-stack.ts
@@ -8,7 +8,16 @@ import { Construct } from 'constructs'
 import { TABLE_KEY } from '../../lib/config/dynamodb'
 import { SERVICE_NAME } from '../constants'
 
-export type DynamoStackProps = { chatbotSNSArn?: string } & cdk.NestedStackProps
+export type TableCapacityOptions = {
+  billingMode: aws_dynamo.BillingMode
+  readCapacity?: number
+  writeCapacity?: number
+}
+
+export type DynamoStackProps = {
+  chatbotSNSArn?: string
+  tableCapacityOptions: TableCapacityOptions
+} & cdk.NestedStackProps
 
 export class DynamoStack extends cdk.NestedStack {
   public readonly ordersTable: aws_dynamo.Table
@@ -17,7 +26,7 @@ export class DynamoStack extends cdk.NestedStack {
   constructor(scope: Construct, id: string, props: DynamoStackProps) {
     super(scope, id, props)
 
-    const { chatbotSNSArn } = props
+    const { chatbotSNSArn, tableCapacityOptions } = props
 
     /* orders table */
     const ordersTable = new aws_dynamo.Table(this, `${SERVICE_NAME}OrdersTable`, {
@@ -27,9 +36,9 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.STRING,
       },
       stream: aws_dynamo.StreamViewType.NEW_IMAGE,
-      billingMode: aws_dynamo.BillingMode.PAY_PER_REQUEST,
       deletionProtection: true,
       pointInTimeRecovery: true,
+      ...tableCapacityOptions,
     })
     this.ordersTable = ordersTable
 

--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -11,13 +11,14 @@ import * as path from 'path'
 import { SUPPORTED_CHAINS } from '../../lib/util/chain'
 import { STAGE } from '../../lib/util/stage'
 import { SERVICE_NAME } from '../constants'
-import { DynamoStack } from './dynamo-stack'
+import { DynamoStack, TableCapacityOptions } from './dynamo-stack'
 import { StepFunctionStack } from './step-function-stack'
 
 export interface LambdaStackProps extends cdk.NestedStackProps {
   provisionedConcurrency: number
   stage: STAGE
   envVars: { [key: string]: string }
+  tableCapacityOptions: TableCapacityOptions
 }
 export class LambdaStack extends cdk.NestedStack {
   public readonly postOrderLambda: aws_lambda_nodejs.NodejsFunction
@@ -38,7 +39,7 @@ export class LambdaStack extends cdk.NestedStack {
 
   constructor(scope: Construct, name: string, props: LambdaStackProps) {
     super(scope, name, props)
-    const { provisionedConcurrency } = props
+    const { provisionedConcurrency, tableCapacityOptions } = props
 
     const lambdaName = `${SERVICE_NAME}Lambda`
 
@@ -51,7 +52,7 @@ export class LambdaStack extends cdk.NestedStack {
       ],
     })
 
-    const databaseStack = new DynamoStack(this, `${SERVICE_NAME}DynamoStack`, {})
+    const databaseStack = new DynamoStack(this, `${SERVICE_NAME}DynamoStack`, { tableCapacityOptions })
 
     const sfnStack = new StepFunctionStack(this, `${SERVICE_NAME}SfnStack`, {
       stage: props.stage as STAGE,


### PR DESCRIPTION
## Summary
- Read [this article](https://repost.aws/knowledge-center/dynamodb-table-throttled) and [this](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual) to determine read/write capacity 
- Starting high for both read/write then we can lower as we see traffic