### PR TITLE
update throttling

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -129,7 +129,7 @@ export class APIStack extends cdk.Stack {
           priority: 1,
           statement: {
             rateBasedStatement: {
-              limit: throttlingOverride ? parseInt(throttlingOverride) : 100,
+              limit: throttlingOverride ? parseInt(throttlingOverride) : 300,
               aggregateKeyType: 'FORWARDED_IP',
               scopeDownStatement: {
                 regexMatchStatement: {
@@ -170,7 +170,7 @@ export class APIStack extends cdk.Stack {
           priority: 2,
           statement: {
             rateBasedStatement: {
-              limit: throttlingOverride ? parseInt(throttlingOverride) : 600,
+              limit: throttlingOverride ? parseInt(throttlingOverride) : 900,
               aggregateKeyType: 'FORWARDED_IP',
               scopeDownStatement: {
                 byteMatchStatement: {
@@ -212,7 +212,7 @@ export class APIStack extends cdk.Stack {
           priority: 3,
           statement: {
             rateBasedStatement: {
-              limit: throttlingOverride ? parseInt(throttlingOverride) : 150,
+              limit: throttlingOverride ? parseInt(throttlingOverride) : 450,
               aggregateKeyType: 'FORWARDED_IP',
               scopeDownStatement: {
                 byteMatchStatement: {
@@ -256,6 +256,21 @@ export class APIStack extends cdk.Stack {
             rateBasedStatement: {
               limit: throttlingOverride ? parseInt(throttlingOverride) : 100,
               aggregateKeyType: 'FORWARDED_IP',
+              scopeDownStatement: {
+                byteMatchStatement: {
+                  searchString: 'docs',
+                  fieldToMatch: {
+                    uriPath: {},
+                  },
+                  textTransformations: [
+                    {
+                      priority: 0,
+                      type: 'NONE',
+                    },
+                  ],
+                  positionalConstraint: 'CONTAINS',
+                },
+              },
               forwardedIpConfig: {
                 headerName: 'X-Forwarded-For',
                 fallbackBehavior: 'MATCH',


### PR DESCRIPTION
Changing ip rate limiting to be per endpoint, and dropping numbers especially for post order:

Previously we allowed 4 TPS across all endpoints, so this actually allows a higher TPS in aggregate, but puts more restrictions on POST order

Let me know if we feel this is too low for anything:

POST order: 100 per 5 mins, i.e. 1 every 3 seconds
GET orders: 900 per 5 mins, i.e. 3 TPS
GET nonce: 150 per 5 mins, i.e. 1 every 2 seconds
GET docs: 100 per 5 mins, i.e. 1 every 3 seconds

Also the first rule, which is first priority, allows requests with api key through with no throttle
