### PR TITLE
feat: add dynamic index capacity

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -1,0 +1,21 @@
+import { BillingMode } from 'aws-cdk-lib/aws-dynamodb'
+import { IndexCapacityConfig, TableCapacityConfig } from './stacks/dynamo-stack'
+
+export const PROD_INDEX_CAPACITY: IndexCapacityConfig = {
+  orderStatus: { readCapacity: 10000, writeCapacity: 100 },
+  offerer: { readCapacity: 2000, writeCapacity: 1000 },
+  filler: { readCapacity: 2000, writeCapacity: 1000 },
+  fillerOrderStatus: { readCapacity: 2000, writeCapacity: 1000 },
+  fillerOfferer: { readCapacity: 2000, writeCapacity: 1000 },
+  fillerOrderStatusOfferer: { readCapacity: 2000, writeCapacity: 1000 },
+  offererOrderStatus: { readCapacity: 2000, writeCapacity: 1000 },
+  chainId: { readCapacity: 2000, writeCapacity: 1000 },
+  chainIdFiller: { readCapacity: 2000, writeCapacity: 1000 },
+  chaindIdOrderStatus: { readCapacity: 2000, writeCapacity: 1000 },
+  chainIdFillerOrderStatus: { readCapacity: 2000, writeCapacity: 1000 },
+}
+
+export const PROD_TABLE_CAPACITY: TableCapacityConfig = {
+  order: { billingMode: BillingMode.PROVISIONED, readCapacity: 2000, writeCapacity: 1000 },
+  nonce: { billingMode: BillingMode.PROVISIONED, readCapacity: 2000, writeCapacity: 1000 },
+}

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -11,7 +11,7 @@ import { Construct } from 'constructs'
 import { STAGE } from '../../lib/util/stage'
 import { SERVICE_NAME } from '../constants'
 import { DashboardStack } from './dashboard-stack'
-import { TableCapacityOptions } from './dynamo-stack'
+import { IndexCapacityConfig, TableCapacityConfig } from './dynamo-stack'
 import { LambdaStack } from './lambda-stack'
 
 export class APIStack extends cdk.Stack {
@@ -27,13 +27,21 @@ export class APIStack extends cdk.Stack {
       chatbotSNSArn?: string
       stage: string
       envVars: { [key: string]: string }
-      tableCapacityOptions: TableCapacityOptions
+      tableCapacityConfig: TableCapacityConfig
+      indexCapacityConfig?: IndexCapacityConfig
     }
   ) {
     super(parent, name, props)
 
-    const { throttlingOverride, chatbotSNSArn, stage, provisionedConcurrency, internalApiKey, tableCapacityOptions } =
-      props
+    const {
+      throttlingOverride,
+      chatbotSNSArn,
+      stage,
+      provisionedConcurrency,
+      internalApiKey,
+      tableCapacityConfig,
+      indexCapacityConfig,
+    } = props
 
     const {
       getOrdersLambdaAlias,
@@ -50,7 +58,8 @@ export class APIStack extends cdk.Stack {
       provisionedConcurrency,
       stage: stage as STAGE,
       envVars: props.envVars,
-      tableCapacityOptions,
+      tableCapacityConfig,
+      indexCapacityConfig,
     })
 
     const accessLogGroup = new aws_logs.LogGroup(this, `${SERVICE_NAME}APIGAccessLogs`)

--- a/bin/stacks/dynamo-stack.ts
+++ b/bin/stacks/dynamo-stack.ts
@@ -8,15 +8,38 @@ import { Construct } from 'constructs'
 import { TABLE_KEY } from '../../lib/config/dynamodb'
 import { SERVICE_NAME } from '../constants'
 
-export type TableCapacityOptions = {
-  billingMode: aws_dynamo.BillingMode
+type CapacityOptions = {
   readCapacity?: number
   writeCapacity?: number
 }
 
+type TableCapacityOptions = {
+  billingMode: aws_dynamo.BillingMode
+} & CapacityOptions
+
+export type IndexCapacityConfig = {
+  orderStatus?: CapacityOptions
+  offerer?: CapacityOptions
+  filler?: CapacityOptions
+  fillerOrderStatus?: CapacityOptions
+  fillerOfferer?: CapacityOptions
+  fillerOrderStatusOfferer?: CapacityOptions
+  offererOrderStatus?: CapacityOptions
+  chainId?: CapacityOptions
+  chainIdFiller?: CapacityOptions
+  chaindIdOrderStatus?: CapacityOptions
+  chainIdFillerOrderStatus?: CapacityOptions
+}
+
+export type TableCapacityConfig = {
+  order: TableCapacityOptions
+  nonce: TableCapacityOptions
+}
+
 export type DynamoStackProps = {
   chatbotSNSArn?: string
-  tableCapacityOptions: TableCapacityOptions
+  tableCapacityConfig: TableCapacityConfig
+  indexCapacityConfig?: IndexCapacityConfig
 } & cdk.NestedStackProps
 
 export class DynamoStack extends cdk.NestedStack {
@@ -26,7 +49,7 @@ export class DynamoStack extends cdk.NestedStack {
   constructor(scope: Construct, id: string, props: DynamoStackProps) {
     super(scope, id, props)
 
-    const { chatbotSNSArn, tableCapacityOptions } = props
+    const { chatbotSNSArn, tableCapacityConfig, indexCapacityConfig } = props
 
     /* orders table */
     const ordersTable = new aws_dynamo.Table(this, `${SERVICE_NAME}OrdersTable`, {
@@ -38,7 +61,7 @@ export class DynamoStack extends cdk.NestedStack {
       stream: aws_dynamo.StreamViewType.NEW_IMAGE,
       deletionProtection: true,
       pointInTimeRecovery: true,
-      ...tableCapacityOptions,
+      ...tableCapacityConfig.order,
     })
     this.ordersTable = ordersTable
 
@@ -54,8 +77,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.offerer,
     })
 
     this.ordersTable.addGlobalSecondaryIndex({
@@ -69,8 +91,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.orderStatus,
     })
 
     this.ordersTable.addGlobalSecondaryIndex({
@@ -84,8 +105,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.filler,
     })
 
     this.ordersTable.addGlobalSecondaryIndex({
@@ -99,8 +119,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.fillerOrderStatus,
     })
 
     this.ordersTable.addGlobalSecondaryIndex({
@@ -114,8 +133,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.fillerOfferer,
     })
 
     this.ordersTable.addGlobalSecondaryIndex({
@@ -129,8 +147,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.fillerOrderStatusOfferer,
     })
 
     this.ordersTable.addGlobalSecondaryIndex({
@@ -144,8 +161,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.offererOrderStatus,
     })
 
     this.ordersTable.addGlobalSecondaryIndex({
@@ -159,8 +175,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.chainId,
     })
 
     this.ordersTable.addGlobalSecondaryIndex({
@@ -174,8 +189,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.chainIdFiller,
     })
 
     this.ordersTable.addGlobalSecondaryIndex({
@@ -189,8 +203,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.chaindIdOrderStatus,
     })
 
     this.ordersTable.addGlobalSecondaryIndex({
@@ -204,8 +217,7 @@ export class DynamoStack extends cdk.NestedStack {
         type: aws_dynamo.AttributeType.NUMBER,
       },
       projectionType: aws_dynamo.ProjectionType.ALL,
-      ...(tableCapacityOptions.readCapacity && { readCapacity: tableCapacityOptions.readCapacity }),
-      ...(tableCapacityOptions.writeCapacity && { writeCapacity: tableCapacityOptions.writeCapacity }),
+      ...indexCapacityConfig?.chainIdFillerOrderStatus,
     })
 
     this.ordersTable = ordersTable
@@ -222,7 +234,7 @@ export class DynamoStack extends cdk.NestedStack {
       },
       deletionProtection: true,
       pointInTimeRecovery: true,
-      ...tableCapacityOptions,
+      ...tableCapacityConfig.nonce,
     })
     this.nonceTable = nonceTable
 

--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -11,14 +11,15 @@ import * as path from 'path'
 import { SUPPORTED_CHAINS } from '../../lib/util/chain'
 import { STAGE } from '../../lib/util/stage'
 import { SERVICE_NAME } from '../constants'
-import { DynamoStack, TableCapacityOptions } from './dynamo-stack'
+import { DynamoStack, IndexCapacityConfig, TableCapacityConfig } from './dynamo-stack'
 import { StepFunctionStack } from './step-function-stack'
 
 export interface LambdaStackProps extends cdk.NestedStackProps {
   provisionedConcurrency: number
   stage: STAGE
   envVars: { [key: string]: string }
-  tableCapacityOptions: TableCapacityOptions
+  tableCapacityConfig: TableCapacityConfig
+  indexCapacityConfig?: IndexCapacityConfig
 }
 export class LambdaStack extends cdk.NestedStack {
   public readonly postOrderLambda: aws_lambda_nodejs.NodejsFunction
@@ -39,7 +40,7 @@ export class LambdaStack extends cdk.NestedStack {
 
   constructor(scope: Construct, name: string, props: LambdaStackProps) {
     super(scope, name, props)
-    const { provisionedConcurrency, tableCapacityOptions } = props
+    const { provisionedConcurrency, tableCapacityConfig, indexCapacityConfig } = props
 
     const lambdaName = `${SERVICE_NAME}Lambda`
 
@@ -52,7 +53,10 @@ export class LambdaStack extends cdk.NestedStack {
       ],
     })
 
-    const databaseStack = new DynamoStack(this, `${SERVICE_NAME}DynamoStack`, { tableCapacityOptions })
+    const databaseStack = new DynamoStack(this, `${SERVICE_NAME}DynamoStack`, {
+      tableCapacityConfig,
+      indexCapacityConfig,
+    })
 
     const sfnStack = new StepFunctionStack(this, `${SERVICE_NAME}SfnStack`, {
       stage: props.stage as STAGE,


### PR DESCRIPTION
## Summary
- adds per index  and per table capacity configs
- bumps just the orderStatus from `2000 RCU -> 10,000 RCU` and lowers `1000 WCU -> 100 WCU`