### PR TITLE
Add timeouts to ddb client, add logs

### DIFF
--- a/lib/handlers/get-orders/injector.ts
+++ b/lib/handlers/get-orders/injector.ts
@@ -22,7 +22,7 @@ export interface ContainerInjected {
 export class GetOrdersInjector extends ApiInjector<ContainerInjected, RequestInjected, void, RawGetOrdersQueryParams> {
   public async buildContainerInjected(): Promise<ContainerInjected> {
     return {
-      dbInterface: DynamoOrdersRepository.create(new DynamoDB.DocumentClient()),
+      dbInterface: DynamoOrdersRepository.create(new DynamoDB.DocumentClient({ maxRetries: 3, httpOptions: { timeout: 1000 } })),
     }
   }
 

--- a/lib/handlers/post-order/injector.ts
+++ b/lib/handlers/post-order/injector.ts
@@ -31,7 +31,7 @@ export class PostOrderInjector extends ApiInjector<ContainerInjected, ApiRInj, P
       }
     })
     return {
-      dbInterface: DynamoOrdersRepository.create(new DynamoDB.DocumentClient()),
+      dbInterface: DynamoOrdersRepository.create(new DynamoDB.DocumentClient({ maxRetries: 3, httpOptions: { timeout: 1000 } })),
       orderValidator: new OrderValidator(() => new Date().getTime() / 1000),
       onchainValidatorByChainId,
     }


### PR DESCRIPTION
By default the aws sdk will retry 10 times with exponential backoff, with a 10s timeout, so you can end up timing out a lambda pretty easily if your request gets stuck. Setting some reasonable values for the ddb clients

Also adding logs for next time