### PR TITLE
fix: EXACT_OUT archive orders logging

### DIFF
--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -1,2 +1,3 @@
 export const WEBHOOK_CONFIG_BUCKET = 'order-webhook-notification-config'
 export const PRODUCTION_WEBHOOK_CONFIG_KEY = 'production.json'
+export const NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,0 +1,28 @@
+import { DutchOrderInfo, OrderType, REACTOR_ADDRESS_MAPPING } from '@uniswap/uniswapx-sdk'
+import { BigNumber } from 'ethers'
+
+export const ORDER_INFO: DutchOrderInfo = {
+  deadline: 10,
+  swapper: '0x0000000000000000000000000000000000000001',
+  reactor: REACTOR_ADDRESS_MAPPING[1][OrderType.Dutch].toLowerCase(),
+  decayStartTime: 20,
+  decayEndTime: 25,
+  input: {
+    token: '0x0000000000000000000000000000000000000003',
+    endAmount: BigNumber.from(30),
+    startAmount: BigNumber.from(30),
+  },
+  nonce: BigNumber.from('40'),
+  outputs: [
+    {
+      endAmount: BigNumber.from(50),
+      startAmount: BigNumber.from(60),
+      recipient: '0x0000000000000000000000000000000000000004',
+      token: '0x0000000000000000000000000000000000000005',
+    },
+  ],
+  exclusiveFiller: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+  exclusivityOverrideBps: BigNumber.from(5),
+  additionalValidationContract: '0x0000000000000000000000000000000000000000',
+  additionalValidationData: '0x',
+}

--- a/test/handlers/post-order.test.ts
+++ b/test/handlers/post-order.test.ts
@@ -1,12 +1,12 @@
-var parserMock = jest.fn()
+const parserMock = jest.fn()
 
 import { SFNClient, StartExecutionCommand } from '@aws-sdk/client-sfn'
-import { DutchOrderInfo, OrderType, OrderValidation, REACTOR_ADDRESS_MAPPING } from '@uniswap/uniswapx-sdk'
+import { OrderType, OrderValidation, REACTOR_ADDRESS_MAPPING } from '@uniswap/uniswapx-sdk'
 import { mockClient } from 'aws-sdk-client-mock'
-import { BigNumber } from 'ethers'
 import { ORDER_STATUS } from '../../lib/entities'
 import { ErrorCode } from '../../lib/handlers/base'
 import { PostOrderHandler } from '../../lib/handlers/post-order/handler'
+import { ORDER_INFO } from '../fixtures'
 
 const MOCK_ARN_1 = 'MOCK_ARN_1'
 const MOCK_ARN_5 = 'MOCK_ARN_5'
@@ -33,32 +33,6 @@ mockSfnClient
     input: MOCK_START_EXECUTION_INPUT,
   })
   .resolves({})
-
-const ORDER_INFO: DutchOrderInfo = {
-  deadline: 10,
-  swapper: '0x0000000000000000000000000000000000000001',
-  reactor: REACTOR_ADDRESS_MAPPING[1][OrderType.Dutch].toLowerCase(),
-  decayStartTime: 20,
-  decayEndTime: 25,
-  input: {
-    token: '0x0000000000000000000000000000000000000003',
-    endAmount: BigNumber.from(30),
-    startAmount: BigNumber.from(30),
-  },
-  nonce: BigNumber.from('40'),
-  outputs: [
-    {
-      endAmount: BigNumber.from(50),
-      startAmount: BigNumber.from(60),
-      recipient: '0x0000000000000000000000000000000000000004',
-      token: '0x0000000000000000000000000000000000000005',
-    },
-  ],
-  exclusiveFiller: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
-  exclusivityOverrideBps: BigNumber.from(5),
-  additionalValidationContract: '0x0000000000000000000000000000000000000000',
-  additionalValidationData: '0x',
-}
 
 const DECODED_ORDER = {
   info: ORDER_INFO,


### PR DESCRIPTION
## Summary
We are currently logging token transfers for the input on EXACT_OUT and ETH out orders. This fix logging for both cases.
## Testing
Tested locally using local gouda service + bot for filling.
- exact out
- exact out ETH out
- exact in ETH out
- exact in 