### PR TITLE
chore: remove provisioned db capacity

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -11,7 +11,7 @@ import dotenv from 'dotenv'
 import 'source-map-support/register'
 import { SUPPORTED_CHAINS } from '../lib/util/chain'
 import { STAGE } from '../lib/util/stage'
-import { PROD_INDEX_CAPACITY, PROD_TABLE_CAPACITY } from './config'
+import { PROD_TABLE_CAPACITY } from './config'
 import { SERVICE_NAME } from './constants'
 import { APIStack } from './stacks/api-stack'
 import { IndexCapacityConfig, TableCapacityConfig } from './stacks/dynamo-stack'
@@ -181,7 +181,6 @@ export class APIPipeline extends Stack {
         THROTTLE_PER_FIVE_MINS: '3000',
       },
       tableCapacityConfig: PROD_TABLE_CAPACITY,
-      indexCapacityConfig: PROD_INDEX_CAPACITY,
     })
 
     const prodUsEast2AppStage = pipeline.addStage(prodUsEast2Stage)


### PR DESCRIPTION
## Summary
Remove provisioned capacity for DynamoDB. We should switch to the auto scaling and PAY_PER_REQUEST set up. Our usage is so low I don't think it make sense to provision this. All of the usage charts for indexes look like the below chart.
<img width="1458" alt="Screenshot 2023-11-06 at 2 46 30 PM" src="https://github.com/Uniswap/uniswapx-service/assets/16843454/10abcb1c-2342-4e8d-a0e9-aae32a7a7e0d">
