### PR TITLE
feat: update order limits

### DIFF
--- a/lib/handlers/post-order/handler.ts
+++ b/lib/handlers/post-order/handler.ts
@@ -218,7 +218,7 @@ const HIGH_MAX_OPEN_ORDERS_SWAPPERS: string[] = [
   '0xe001e6f6879c07b9ac24291a490f2795106d348c',
   '0x8943ea25bbfe135450315ab8678f2f79559f4630',
 ]
-export const DEFAULT_MAX_OPEN_ORDERS = 5
+export const DEFAULT_MAX_OPEN_ORDERS = 50
 export const HIGH_MAX_OPEN_ORDERS = 200
 
 // return the number of open orders the given offerer is allowed to have at a time

--- a/lib/util/order-validator.ts
+++ b/lib/util/order-validator.ts
@@ -7,7 +7,7 @@ export type OrderValidationResponse = {
   errorString?: string
 }
 
-const ONE_DAY_IN_SECONDS = 60 * 60 * 24
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 364
 
 export class OrderValidator {
   constructor(private readonly getCurrentTime: () => number) {}
@@ -109,7 +109,7 @@ export class OrderValidator {
         errorString: 'Deadline must be in the future',
       }
     }
-    if (deadline > this.getCurrentTime() + ONE_DAY_IN_SECONDS) {
+    if (deadline > this.getCurrentTime() + ONE_YEAR_IN_SECONDS) {
       return {
         valid: false,
         errorString: `Deadline field invalid: Order expiry cannot be larger than thirty minutes`,

--- a/test/util/order-validator.test.ts
+++ b/test/util/order-validator.test.ts
@@ -7,7 +7,7 @@ const validationProvider = new OrderValidator(() => CURRENT_TIME)
 const INPUT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000022'
 const OUTPUT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000033'
 const EXCLUSIVE_FILLER = '0x0000000000000000000000000000000000000044'
-const ONE_DAY = 60 * 60 * 24
+const ONE_YEAR = 60 * 60 * 24 * 364
 const SWAPPER = '0x0000000000000000000000000000000000032100'
 const RECIPIENT = '0x0000000000000000000000000000000000045600'
 const INPUT = { token: INPUT_TOKEN_ADDRESS, startAmount: BigNumber.from('1'), endAmount: BigNumber.from('2') }
@@ -62,7 +62,7 @@ describe('Testing off chain validation', () => {
       expect(validationResp).toEqual({ errorString: 'Deadline must be in the future', valid: false })
     })
     it('Testing deadline longer than one day', async () => {
-      const order = newOrder({ deadline: CURRENT_TIME + ONE_DAY + 1 })
+      const order = newOrder({ deadline: CURRENT_TIME + ONE_YEAR + 1 })
       const validationResp = validationProvider.validate(order)
       expect(validationResp).toEqual({
         errorString: 'Deadline field invalid: Order expiry cannot be larger than thirty minutes',
@@ -70,7 +70,7 @@ describe('Testing off chain validation', () => {
       })
     })
     it('Testing valid deadline.', async () => {
-      const order = newOrder({ deadline: CURRENT_TIME + ONE_DAY })
+      const order = newOrder({ deadline: CURRENT_TIME + ONE_YEAR })
       const validationResp = validationProvider.validate(order)
       expect(validationResp).toEqual({ valid: true })
     })


### PR DESCRIPTION
- max expiry of one year
- max open orders of 50 per swapper
