### PR TITLE
fix: deduplicate order notifications

### DIFF
--- a/lib/repositories/orders-repository.ts
+++ b/lib/repositories/orders-repository.ts
@@ -106,6 +106,9 @@ export class DynamoOrdersRepository implements BaseOrdersRepository {
         txHash: { type: DYNAMODB_TYPES.STRING },
         settledAmounts: { type: DYNAMODB_TYPES.LIST },
       },
+      // Timestamps are explicitly turned off to avoid re-triggering dynamo streams,
+      // which can happen when only the modified timestamp is updated (by a Put/Update).
+      timestamps: false,
       table: ordersTable,
     } as const)
 

--- a/test/repositories/dynamo-repository.test.ts
+++ b/test/repositories/dynamo-repository.test.ts
@@ -460,7 +460,6 @@ describe('OrdersRepository getOrders test with sorting', () => {
 describe('OrdersRepository getByHash test', () => {
   it('should successfully get an item from table', async () => {
     const order1 = await ordersRepository.getByHash(MOCK_ORDER_1.orderHash)
-    // dynamodb-toolbox auto-generates 'created' and 'modified' fields
     expect(order1).toEqual(expect.objectContaining(MOCK_ORDER_1))
 
     const order2 = await ordersRepository.getByHash(MOCK_ORDER_2.orderHash)


### PR DESCRIPTION
Disables timestamps from the `dynamodb-toolbox` ORM, which were causing nop modifications to entities to cause a MODIFY event in the DynamoDB Event Stream, and triggering the Order Notifications Lambda multiple times per order created.

Docs: https://www.dynamodbtoolbox.com/docs#conventions-and-motivations:~:text=Created%20and%20modified%20timestamps%20are%20enabled%20by%20default.

## Testing

To reproduce the error, stand up the server and send an order in. Observe in the logs that the Order Notifications Lambda is triggered multiple times, and that the difference in the record for each trigger is only the `_md` (modified timestamp) of the record.

Tested manually, and verified that order creation now only triggers the Order Notifications Lambda one time.