### PR TITLE
feat: add glob to webhook definition

### DIFF
--- a/lib/providers/json-webhook-provider.ts
+++ b/lib/providers/json-webhook-provider.ts
@@ -15,7 +15,7 @@ export class JsonWebhookProvider implements WebhookProvider {
 }
 
 export function findEndpointsMatchingFilter(filter: OrderFilter, definition: WebhookDefinition): Webhook[] {
-  let endpoints: Webhook[] = []
+  let endpoints: Webhook[] = definition['*'] ?? []
 
   const filterKeys = Object.keys(filter) as FILTER_FIELD[]
   const filterMapping = definition.filter

--- a/lib/providers/types.ts
+++ b/lib/providers/types.ts
@@ -6,7 +6,7 @@ export enum FILTER_FIELD {
 
 export type WebhookDefinition = {
   filter: WebhookFilterMapping
-  registeredWebhook: { [key: string]: string }
+  '*'?: Webhook[]
 }
 
 export type Webhook = {

--- a/test/providers/s3-webhook-provider.test.ts
+++ b/test/providers/s3-webhook-provider.test.ts
@@ -1,10 +1,10 @@
-import { S3Client } from '@aws-sdk/client-s3';
-import { WebhookDefinition } from '../../lib/providers/types'
+import { S3Client } from '@aws-sdk/client-s3'
 import { S3WebhookConfigurationProvider } from '../../lib/providers/s3-webhook-provider'
+import { WebhookDefinition } from '../../lib/providers/types'
 
 describe('S3WebhookProvider test', () => {
-  const bucket = 'test-bucket';
-  const key = 'test-key';
+  const bucket = 'test-bucket'
+  const key = 'test-key'
 
   function applyMock(endpoints: WebhookDefinition) {
     jest.spyOn(S3Client.prototype, 'send').mockImplementationOnce(() =>
@@ -13,9 +13,8 @@ describe('S3WebhookProvider test', () => {
           transformToString: () => Promise.resolve(JSON.stringify(endpoints)),
         },
       })
-    );
+    )
   }
-
 
   const mockEndpoints = {
     filter: {
@@ -25,7 +24,8 @@ describe('S3WebhookProvider test', () => {
       orderStatus: { open: [{ url: 'webhook.com/2' }, { url: 'webhook.com/1' }] },
       offerer: { '0x2': [{ url: 'webhook.com/4' }] },
     },
-    registeredWebhook: {}
+    ['*']: [{ url: 'webhook.com/0' }],
+    registeredWebhook: {},
   }
 
   const mockEndpoints2 = {
@@ -36,62 +36,88 @@ describe('S3WebhookProvider test', () => {
       orderStatus: { open: [{ url: 'webhook2.com/2' }, { url: 'webhook2.com/1' }] },
       offerer: { '0x2': [{ url: 'webhook2.com/4' }] },
     },
-    registeredWebhook: {}
+    ['*']: [{ url: 'webhook.com/0' }],
+    registeredWebhook: {},
   }
 
   it('Fetches endpoints', async () => {
-    applyMock(mockEndpoints);
-    const provider = new S3WebhookConfigurationProvider(bucket, key);
+    applyMock(mockEndpoints)
+    const provider = new S3WebhookConfigurationProvider(bucket, key)
     const endpoints = await provider.getEndpoints({
       filler: '0x1',
       orderStatus: 'open',
       offerer: '0x2',
-    } as any)
-    expect(endpoints).toEqual([{ url: 'webhook.com/1' }, { url: 'webhook.com/2' }, { url: 'webhook.com/4' }])
-  });
+    })
+    expect(endpoints).toEqual([
+      { url: 'webhook.com/0' },
+      { url: 'webhook.com/1' },
+      { url: 'webhook.com/2' },
+      { url: 'webhook.com/4' },
+    ])
+  })
 
   it('Caches fetched endpoints', async () => {
-    applyMock(mockEndpoints);
-    const provider = new S3WebhookConfigurationProvider(bucket, key);
-    let endpoints = await provider.getEndpoints({
+    applyMock(mockEndpoints)
+    const provider = new S3WebhookConfigurationProvider(bucket, key)
+    const endpoints = await provider.getEndpoints({
       filler: '0x1',
       orderStatus: 'open',
       offerer: '0x2',
-    } as any)
-    expect(endpoints).toEqual([{ url: 'webhook.com/1' }, { url: 'webhook.com/2' }, { url: 'webhook.com/4' }])
-  });
+    })
+    expect(endpoints).toEqual([
+      { url: 'webhook.com/0' },
+      { url: 'webhook.com/1' },
+      { url: 'webhook.com/2' },
+      { url: 'webhook.com/4' },
+    ])
+  })
 
   it('Refetches after cache expires', async () => {
-    applyMock(mockEndpoints);
-    const provider = new S3WebhookConfigurationProvider(bucket, key);
+    applyMock(mockEndpoints)
+    const provider = new S3WebhookConfigurationProvider(bucket, key)
     let endpoints = await provider.getEndpoints({
       filler: '0x1',
       orderStatus: 'open',
       offerer: '0x2',
-    } as any)
-    expect(endpoints).toEqual([{ url: 'webhook.com/1' }, { url: 'webhook.com/2' }, { url: 'webhook.com/4' }])
+    })
+    expect(endpoints).toEqual([
+      { url: 'webhook.com/0' },
+      { url: 'webhook.com/1' },
+      { url: 'webhook.com/2' },
+      { url: 'webhook.com/4' },
+    ])
 
     // update mock endpoints and skip a small bit of time forward
     // should still use the old ones
-    applyMock(mockEndpoints2);
-    jest.useFakeTimers().setSystemTime(Date.now() + 100);
+    applyMock(mockEndpoints2)
+    jest.useFakeTimers().setSystemTime(Date.now() + 100)
     endpoints = await provider.getEndpoints({
       filler: '0x1',
       orderStatus: 'open',
       offerer: '0x2',
-    } as any)
+    })
     // should still equal old ones
-    expect(endpoints).toEqual([{ url: 'webhook.com/1' }, { url: 'webhook.com/2' }, { url: 'webhook.com/4' }])
+    expect(endpoints).toEqual([
+      { url: 'webhook.com/0' },
+      { url: 'webhook.com/1' },
+      { url: 'webhook.com/2' },
+      { url: 'webhook.com/4' },
+    ])
 
     // skip farther forward
-    applyMock(mockEndpoints2);
-    jest.useFakeTimers().setSystemTime(Date.now() + 1000000);
+    applyMock(mockEndpoints2)
+    jest.useFakeTimers().setSystemTime(Date.now() + 1000000)
     endpoints = await provider.getEndpoints({
       filler: '0x1',
       orderStatus: 'open',
       offerer: '0x2',
-    } as any)
+    })
     // should still equal old ones
-    expect(endpoints).toEqual([{ url: 'webhook2.com/1' }, { url: 'webhook2.com/2' }, { url: 'webhook2.com/4' }])
-  });
+    expect(endpoints).toEqual([
+      { url: 'webhook.com/0' },
+      { url: 'webhook2.com/1' },
+      { url: 'webhook2.com/2' },
+      { url: 'webhook2.com/4' },
+    ])
+  })
 })


### PR DESCRIPTION
Adds a glob to the webhook definition, to allow the JSON WebhookDefinition to include a catch-all that is sent every order and order update.