### PR TITLE
fix: do not update orders with no status change

### DIFF
--- a/lib/handlers/check-order-status/handler.ts
+++ b/lib/handlers/check-order-status/handler.ts
@@ -331,7 +331,6 @@ export class CheckOrderStatusHandler extends SfnLambdaHandler<ContainerInjected,
         },
         'updating order status'
       )
-
       await dbInterface.updateOrderStatus(orderHash, orderStatus, txHash, settledAmounts)
 
       if (IS_TERMINAL_STATE(orderStatus)) {

--- a/lib/handlers/check-order-status/handler.ts
+++ b/lib/handlers/check-order-status/handler.ts
@@ -313,24 +313,25 @@ export class CheckOrderStatusHandler extends SfnLambdaHandler<ContainerInjected,
       validation,
     } = params
 
-    log.info(
-      {
-        orderHash,
-        quoteId,
-        retryCount,
-        startingBlockNumber,
-        chainId,
-        lastStatus,
-        orderStatus,
-        txHash,
-        settledAmounts,
-        getFillLogAttempts,
-      },
-      'updating order status'
-    )
     // Avoid updating the order if the status is unchanged.
     // This also avoids unnecessarily triggering downstream events from dynamodb changes.
     if (orderStatus !== lastStatus) {
+      log.info(
+        {
+          orderHash,
+          quoteId,
+          retryCount,
+          startingBlockNumber,
+          chainId,
+          lastStatus,
+          orderStatus,
+          txHash,
+          settledAmounts,
+          getFillLogAttempts,
+        },
+        'updating order status'
+      )
+
       await dbInterface.updateOrderStatus(orderHash, orderStatus, txHash, settledAmounts)
 
       if (IS_TERMINAL_STATE(orderStatus)) {

--- a/lib/handlers/check-order-status/handler.ts
+++ b/lib/handlers/check-order-status/handler.ts
@@ -332,27 +332,27 @@ export class CheckOrderStatusHandler extends SfnLambdaHandler<ContainerInjected,
     // This also avoids unnecessarily triggering downstream events from dynamodb changes.
     if (orderStatus !== lastStatus) {
       await dbInterface.updateOrderStatus(orderHash, orderStatus, txHash, settledAmounts)
-    }
 
-    if (IS_TERMINAL_STATE(orderStatus)) {
-      metrics.putMetric(`OrderSfn-${orderStatus}`, 1)
-      metrics.putMetric(`OrderSfn-${orderStatus}-chain-${chainId}`, 1)
-      log.info({
-        terminalOrderInfo: {
-          orderStatus,
-          orderHash,
-          quoteId: quoteId,
-          getFillLogAttempts,
-          startingBlockNumber,
-          chainId: chainId,
-          settledAmounts: settledAmounts
-            ?.map((s) => JSON.stringify(s))
-            .join(',')
-            .toString(),
-          retryCount,
-          validation,
-        },
-      })
+      if (IS_TERMINAL_STATE(orderStatus)) {
+        metrics.putMetric(`OrderSfn-${orderStatus}`, 1)
+        metrics.putMetric(`OrderSfn-${orderStatus}-chain-${chainId}`, 1)
+        log.info({
+          terminalOrderInfo: {
+            orderStatus,
+            orderHash,
+            quoteId: quoteId,
+            getFillLogAttempts,
+            startingBlockNumber,
+            chainId: chainId,
+            settledAmounts: settledAmounts
+              ?.map((s) => JSON.stringify(s))
+              .join(',')
+              .toString(),
+            retryCount,
+            validation,
+          },
+        })
+      }
     }
 
     return {

--- a/lib/handlers/check-order-status/injector.ts
+++ b/lib/handlers/check-order-status/injector.ts
@@ -3,18 +3,19 @@ import { MetricsLogger } from 'aws-embedded-metrics'
 import { DynamoDB } from 'aws-sdk'
 import { default as bunyan, default as Logger } from 'bunyan'
 import { ethers } from 'ethers'
+import { ORDER_STATUS } from '../../entities'
+import { checkDefined } from '../../preconditions/preconditions'
 import { BaseOrdersRepository } from '../../repositories/base'
 import { DynamoOrdersRepository } from '../../repositories/orders-repository'
 import { setGlobalMetrics } from '../../util/metrics'
 import { BaseRInj, SfnInjector, SfnStateInputOutput } from '../base/index'
-import { checkDefined } from '../../preconditions/preconditions';
 
 export interface RequestInjected extends BaseRInj {
   chainId: number
   quoteId: string
   orderHash: string
   startingBlockNumber: number
-  orderStatus: string
+  orderStatus: ORDER_STATUS
   getFillLogAttempts: number
   retryCount: number
   provider: ethers.providers.StaticJsonRpcProvider
@@ -59,7 +60,7 @@ export class CheckOrderStatusInjector extends SfnInjector<ContainerInjected, Req
       orderHash: event.orderHash as string,
       quoteId: event.quoteId as string,
       startingBlockNumber: event.startingBlockNumber ? (event.startingBlockNumber as number) : 0,
-      orderStatus: event.orderStatus as string,
+      orderStatus: event.orderStatus as ORDER_STATUS,
       getFillLogAttempts: event.getFillLogAttempts ? (event.getFillLogAttempts as number) : 0,
       retryCount: event.retryCount ? (event.retryCount as number) : 0,
       provider: provider,

--- a/test/handlers/check-order-status.test.ts
+++ b/test/handlers/check-order-status.test.ts
@@ -84,9 +84,10 @@ describe('Testing check order status handler', () => {
           provider: {
             getBlockNumber: providerMock,
             getTransaction: getTransactionMock,
-            getBlock: () => Promise.resolve({
-              timestamp: 123456
-            })
+            getBlock: () =>
+              Promise.resolve({
+                timestamp: 123456,
+              }),
           },
         }
       },
@@ -163,22 +164,25 @@ describe('Testing check order status handler', () => {
       const checkorderStatusHandler = new CheckOrderStatusHandler('check-order-status', initialInjectorPromiseMock)
       validateMock.mockReturnValue(OrderValidation.Expired)
       getTransactionMock.mockReturnValueOnce({
-        wait: () => Promise.resolve({
-          effectiveGasPrice: BigNumber.from(1),
-          gasUsed: 100
-        })
+        wait: () =>
+          Promise.resolve({
+            effectiveGasPrice: BigNumber.from(1),
+            gasUsed: 100,
+          }),
       })
-      getFillInfoMock.mockReturnValue([{
-        orderHash: MOCK_ORDER_HASH,
-        filler: '0x123',
-        nonce: BigNumber.from(1),
-        swapper: '0x123',
-        blockNumber: 12321312313,
-        txHash: '0x1244345323',
-        inputs: [{token: 'USDC', amount: BigNumber.from(100)}],
-        outputs: [{token: 'WETH', amount: BigNumber.from(1)}],
-      }])
-      
+      getFillInfoMock.mockReturnValue([
+        {
+          orderHash: MOCK_ORDER_HASH,
+          filler: '0x123',
+          nonce: BigNumber.from(1),
+          swapper: '0x123',
+          blockNumber: 12321312313,
+          txHash: '0x1244345323',
+          inputs: [{ token: 'USDC', amount: BigNumber.from(100) }],
+          outputs: [{ token: 'WETH', amount: BigNumber.from(1) }],
+        },
+      ])
+
       expect(await checkorderStatusHandler.handler(handlerEventMock)).toMatchObject({
         orderStatus: ORDER_STATUS.FILLED,
       })
@@ -189,22 +193,25 @@ describe('Testing check order status handler', () => {
       const checkorderStatusHandler = new CheckOrderStatusHandler('check-order-status', initialInjectorPromiseMock)
       validateMock.mockReturnValue(OrderValidation.NonceUsed)
       getTransactionMock.mockReturnValueOnce({
-        wait: () => Promise.resolve({
-          effectiveGasPrice: BigNumber.from(1),
-          gasUsed: 100
-        })
+        wait: () =>
+          Promise.resolve({
+            effectiveGasPrice: BigNumber.from(1),
+            gasUsed: 100,
+          }),
       })
-      getFillInfoMock.mockReturnValue([{
-        orderHash: MOCK_ORDER_HASH,
-        filler: '0x123',
-        nonce: BigNumber.from(1),
-        swapper: '0x123',
-        blockNumber: 12321312313,
-        txHash: '0x1244345323',
-        inputs: [{token: 'USDC', amount: BigNumber.from(100)}],
-        outputs: [{token: 'WETH', amount: BigNumber.from(1)}],
-      }])
-      
+      getFillInfoMock.mockReturnValue([
+        {
+          orderHash: MOCK_ORDER_HASH,
+          filler: '0x123',
+          nonce: BigNumber.from(1),
+          swapper: '0x123',
+          blockNumber: 12321312313,
+          txHash: '0x1244345323',
+          inputs: [{ token: 'USDC', amount: BigNumber.from(100) }],
+          outputs: [{ token: 'WETH', amount: BigNumber.from(1) }],
+        },
+      ])
+
       expect(await checkorderStatusHandler.handler(handlerEventMock)).toMatchObject({
         orderStatus: ORDER_STATUS.FILLED,
       })
@@ -239,7 +246,7 @@ describe('Testing check order status handler', () => {
       const response = await checkOrderStatusHandler.handler(handlerEventMock)
       expect(getByHashMock).toBeCalledWith(MOCK_ORDER_HASH)
       expect(validateMock).toBeCalled()
-      expect(updateOrderStatusMock).toBeCalledWith(MOCK_ORDER_HASH, ORDER_STATUS.OPEN, undefined, undefined)
+      expect(updateOrderStatusMock).not.toBeCalled() // there is no update
       expect(response).toEqual({
         orderHash: MOCK_ORDER_HASH,
         orderStatus: 'open',
@@ -257,7 +264,7 @@ describe('Testing check order status handler', () => {
       const response = await checkOrderStatusHandler.handler(handlerEventMock)
       expect(getByHashMock).toBeCalledWith(MOCK_ORDER_HASH)
       expect(validateMock).toBeCalled()
-      expect(updateOrderStatusMock).toBeCalledWith(MOCK_ORDER_HASH, ORDER_STATUS.OPEN, undefined, undefined)
+      expect(updateOrderStatusMock).not.toBeCalled() // there is no update
       expect(response).toEqual({
         orderHash: MOCK_ORDER_HASH,
         orderStatus: 'open',
@@ -275,7 +282,7 @@ describe('Testing check order status handler', () => {
       const response = await checkOrderStatusHandler.handler(handlerEventMock)
       expect(getByHashMock).toBeCalledWith(MOCK_ORDER_HASH)
       expect(validateMock).toBeCalled()
-      expect(updateOrderStatusMock).toBeCalledWith(MOCK_ORDER_HASH, ORDER_STATUS.OPEN, undefined, undefined)
+      expect(updateOrderStatusMock).not.toBeCalled() // there is no update
       expect(response).toEqual({
         orderHash: MOCK_ORDER_HASH,
         orderStatus: 'open',


### PR DESCRIPTION
Avoids updating orders that have had no status updates.

These updates - which were occurring with every check on the order status - only served to re-trigger downstream dynamodb stream events, which was causing multiple webhooks to be sent for the same open orders.