### PR TITLE
fix: lowercase getNonce address

### DIFF
--- a/lib/handlers/get-nonce/handler.ts
+++ b/lib/handlers/get-nonce/handler.ts
@@ -23,7 +23,7 @@ export class GetNonceHandler extends APIGLambdaHandler<
 
     try {
       log.info({ address: address }, 'Getting nonce for address')
-      const nonce = await dbInterface.getNonceByAddressAndChain(address, chainId)
+      const nonce = await dbInterface.getNonceByAddressAndChain(address.toLowerCase(), chainId)
       return {
         statusCode: 200,
         body: {

--- a/test/handlers/get-nonce.test.ts
+++ b/test/handlers/get-nonce.test.ts
@@ -43,7 +43,7 @@ describe('Testing get nonce handler.', () => {
 
   it('Testing valid request and response.', async () => {
     const getNonceResponse = await getNonceHandler.handler(event as any, {} as any)
-    expect(getNonceByAddressMock).toBeCalledWith(requestInjectedMock.address, 1)
+    expect(getNonceByAddressMock).toBeCalledWith(requestInjectedMock.address.toLowerCase(), 1)
     expect(getNonceResponse).toMatchObject({
       body: JSON.stringify({ nonce: MOCK_NONCE }),
       statusCode: 200,
@@ -80,7 +80,7 @@ describe('Testing get nonce handler.', () => {
       async (invalidResponseField) => {
         getNonceByAddressMock.mockReturnValue(invalidResponseField)
         const getNonceResponse = await getNonceHandler.handler(event as any, {} as any)
-        expect(getNonceByAddressMock).toBeCalledWith(requestInjectedMock.address, 1)
+        expect(getNonceByAddressMock).toBeCalledWith(requestInjectedMock.address.toLowerCase(), 1)
         expect(getNonceResponse.statusCode).toEqual(500)
         expect(getNonceResponse.body).toEqual(expect.stringContaining('INTERNAL_ERROR'))
       }
@@ -92,7 +92,7 @@ describe('Testing get nonce handler.', () => {
         throw error
       })
       const getNonceResponse = await getNonceHandler.handler(event as any, {} as any)
-      expect(getNonceByAddressMock).toBeCalledWith(requestInjectedMock.address, 1)
+      expect(getNonceByAddressMock).toBeCalledWith(requestInjectedMock.address.toLowerCase(), 1)
       expect(getNonceResponse).toMatchObject({
         body: JSON.stringify({ detail: error.message, errorCode: 'INTERNAL_ERROR' }),
         statusCode: 500,


### PR DESCRIPTION
Orders are sanitized to have lowercased addresses before pumping into
the DB. This means all `offerers` in the nonce db also have lowercased
addresses. However, the getNonce query does not do sanitization, so if
any integrator requests eip-55 cased nonces, it will not find results in
the db. This commit sanitizes

However, we should hold out for the frontend to make a fix incrementing
the nonce. It's currently relying on nonce randomness to get new nonces
