### PR TITLE
Stop Limit orders from triggering step function

### DIFF
--- a/lib/compute/on-chain-status-checker.ts
+++ b/lib/compute/on-chain-status-checker.ts
@@ -14,7 +14,6 @@ const LOOP_DELAY_MS = 30000 //30 seconds
 // arbitrary and capricious value
 // if increasing check memory utilization
 export const BATCH_READ_MAX = 100
-
 export class OnChainStatusChecker {
   private checkOrderStatusService: CheckOrderStatusService
   constructor(private dbInterface: BaseOrdersRepository, private _stop = false) {

--- a/lib/handlers/check-order-status/service.ts
+++ b/lib/handlers/check-order-status/service.ts
@@ -27,7 +27,7 @@ export class CheckOrderStatusService {
   private readonly fillEventProcessor
   constructor(
     private dbInterface: BaseOrdersRepository,
-    fillEventBlockLookback: (chainId: ChainId) => number = FILL_EVENT_LOOKBACK_BLOCKS_ON
+    private fillEventBlockLookback: (chainId: ChainId) => number = FILL_EVENT_LOOKBACK_BLOCKS_ON
   ) {
     this.fillEventProcessor = new FillEventProcessor(fillEventBlockLookback)
   }
@@ -52,9 +52,7 @@ export class CheckOrderStatusService {
     log.info('parsed order', { order: parsedOrder, signature: order.signature })
     const validation = await orderQuoter.validate({ order: parsedOrder, signature: order.signature })
     const curBlockNumber = await provider.getBlockNumber()
-    const fromBlock = !startingBlockNumber
-      ? curBlockNumber - FILL_EVENT_LOOKBACK_BLOCKS_ON(chainId)
-      : startingBlockNumber
+    const fromBlock = !startingBlockNumber ? curBlockNumber - this.fillEventBlockLookback(chainId) : startingBlockNumber
 
     const commonUpdateInfo = {
       orderHash,

--- a/lib/handlers/post-limit-order/injector.ts
+++ b/lib/handlers/post-limit-order/injector.ts
@@ -1,4 +1,4 @@
-import { OrderValidator as OnchainValidator } from '@uniswap/uniswapx-sdk'
+import { OrderType, OrderValidator as OnchainValidator } from '@uniswap/uniswapx-sdk'
 import { MetricsLogger } from 'aws-embedded-metrics'
 import { APIGatewayEvent, Context } from 'aws-lambda'
 import { DynamoDB } from 'aws-sdk'
@@ -35,6 +35,7 @@ export class PostLimitOrderInjector extends ApiInjector<ContainerInjected, ApiRI
         SkipDecayStartTimeValidation: true,
       }),
       onchainValidatorByChainId,
+      orderType: OrderType.Limit,
       getMaxOpenOrders: getMaxLimitOpenOrders,
     }
   }

--- a/lib/handlers/post-order/handler.ts
+++ b/lib/handlers/post-order/handler.ts
@@ -36,7 +36,7 @@ export class PostOrderHandler extends APIGLambdaHandler<
     const {
       requestBody: { encodedOrder, signature, chainId, quoteId },
       requestInjected: { log },
-      containerInjected: { dbInterface, orderValidator, onchainValidatorByChainId, getMaxOpenOrders },
+      containerInjected: { dbInterface, orderValidator, onchainValidatorByChainId, orderType, getMaxOpenOrders },
     } = params
 
     log.info('Handling POST order request', params)
@@ -145,11 +145,13 @@ export class PostOrderHandler extends APIGLambdaHandler<
       },
     })
 
-    await this.kickoffOrderTrackingSfn(
-      { orderHash: id, chainId: chainId, orderStatus: ORDER_STATUS.OPEN, quoteId: quoteId ?? '' },
-      stateMachineArn,
-      log
-    )
+    if (orderType === OrderType.Dutch) {
+      await this.kickoffOrderTrackingSfn(
+        { orderHash: id, chainId: chainId, orderStatus: ORDER_STATUS.OPEN, quoteId: quoteId ?? '' },
+        stateMachineArn,
+        log
+      )
+    }
     return {
       statusCode: 201,
       body: { hash: id },

--- a/lib/handlers/post-order/injector.ts
+++ b/lib/handlers/post-order/injector.ts
@@ -1,4 +1,4 @@
-import { OrderValidator as OnchainValidator } from '@uniswap/uniswapx-sdk'
+import { OrderType, OrderValidator as OnchainValidator } from '@uniswap/uniswapx-sdk'
 import { MetricsLogger } from 'aws-embedded-metrics'
 import { APIGatewayEvent, Context } from 'aws-lambda'
 import { DynamoDB } from 'aws-sdk'
@@ -19,6 +19,7 @@ export interface ContainerInjected {
   dbInterface: BaseOrdersRepository
   orderValidator: OrderValidator
   onchainValidatorByChainId: { [chainId: number]: OnchainValidator }
+  orderType: OrderType
   // return the number of open orders the given offerer is allowed to have at a time
   getMaxOpenOrders: (offerer: string) => number
 }
@@ -41,6 +42,7 @@ export class PostOrderInjector extends ApiInjector<ContainerInjected, ApiRInj, P
       dbInterface: DutchOrdersRepository.create(new DynamoDB.DocumentClient()),
       orderValidator: new OrderValidator(() => new Date().getTime() / 1000, ONE_DAY_IN_SECONDS),
       onchainValidatorByChainId,
+      orderType: OrderType.Dutch,
       getMaxOpenOrders,
     }
   }

--- a/test/unit/handlers/post-order.test.ts
+++ b/test/unit/handlers/post-order.test.ts
@@ -129,6 +129,7 @@ describe('Testing post order handler.', () => {
             validate: validationFailedValidatorMock,
           },
         },
+        orderType: OrderType.Dutch,
         getMaxOpenOrders,
       }
     },


### PR DESCRIPTION
Step functions were still being created for limit orders. They fail immediately due to being configured to check the dutch order table.

This disables the step function invocation for order types other than dutch orders.

Manual Tests:
Dutch order posts created a step function
Limit order posts did not create a step function