### PR TITLE
delete check for fill event on expired; this was fixed in the sdk

### DIFF
--- a/lib/handlers/check-order-status/service.ts
+++ b/lib/handlers/check-order-status/service.ts
@@ -76,41 +76,10 @@ export class CheckOrderStatusService {
     log.info('validated order', { validation: validation, curBlock: curBlockNumber, orderHash: order.orderHash })
     switch (validation) {
       case OrderValidation.Expired: {
-        // order could still be filled even when OrderQuoter.quote bubbled up 'expired' revert
-        const fillEvent = (await orderWatcher.getFillInfo(fromBlock, curBlockNumber)).find(
-          (e) => e.orderHash === orderHash
-        )
-        if (fillEvent) {
-          const settledAmounts = await this.fillEventProcessor.processFillEvent({
-            provider,
-            fillEvent,
-            parsedOrder,
-            quoteId,
-            chainId,
-            startingBlockNumber,
-            order,
-          })
-
-          extraUpdateInfo = {
-            orderStatus: ORDER_STATUS.FILLED,
-            txHash: fillEvent.txHash,
-            settledAmounts,
-          }
-          break
-        } else {
-          if (getFillLogAttempts == 0) {
-            log.info('failed to get fill log in expired case, retrying one more time', {
-              orderInfo: {
-                orderHash: orderHash,
-              },
-            })
-          }
-          extraUpdateInfo = {
-            orderStatus: getFillLogAttempts == 0 ? ORDER_STATUS.OPEN : ORDER_STATUS.EXPIRED,
-            getFillLogAttempts: getFillLogAttempts + 1,
-          }
-          break
+        extraUpdateInfo = {
+          orderStatus: ORDER_STATUS.EXPIRED,
         }
+        break
       }
       case OrderValidation.InsufficientFunds:
         extraUpdateInfo = {

--- a/test/unit/handlers/check-order-status-service.test.ts
+++ b/test/unit/handlers/check-order-status-service.test.ts
@@ -81,77 +81,18 @@ describe('checkOrderStatusService', () => {
         validatorMock.validate.mockResolvedValue(OrderValidation.Expired)
       })
 
-      it('should close order with filled if expired and filled', async () => {
-        getFillInfoMock.mockImplementation(() => {
-          return [
-            {
-              orderHash: MOCK_ORDER_HASH,
-              filler: '0x123',
-              nonce: BigNumber.from(1),
-              swapper: '0x123',
-              blockNumber: 12321312313,
-              txHash: '0x1244345323',
-              inputs: [{ token: 'USDC', amount: BigNumber.from(100) }],
-              outputs: [{ token: 'WETH', amount: BigNumber.from(1) }],
-            },
-          ]
-        })
-
-        let result = await checkOrderStatusService.handleRequest(openOrderRequest)
-
-        expect(ordersRepositoryMock.getByHash).toHaveBeenCalled()
-        expect(ordersRepositoryMock.updateOrderStatus).toHaveBeenCalled()
-        expect(watcherMock.getFillInfo).toHaveBeenCalled()
-        expect(providerMock.getTransaction).toHaveBeenCalled()
-        expect(validatorMock.validate).toHaveBeenCalled()
-        expect(result).toEqual(
-          expect.objectContaining({
-            orderStatus: 'filled',
-            settledAmounts: [
-              {
-                tokenIn: '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9',
-                amountIn: '1000000000000000000',
-                tokenOut: 'WETH',
-                amountOut: '1',
-              },
-            ],
-            txHash: '0x1244345323',
-          })
-        )
-      })
-
-      it('should retry if expired and getFillLogAttempts = 0', async () => {
-        getFillInfoMock.mockImplementation(() => {
-          return []
-        })
-
-        let result = await checkOrderStatusService.handleRequest(openOrderRequest)
-
-        expect(ordersRepositoryMock.getByHash).toHaveBeenCalled()
-        expect(ordersRepositoryMock.updateOrderStatus).not.toHaveBeenCalled()
-        expect(watcherMock.getFillInfo).toHaveBeenCalled()
-        expect(providerMock.getTransaction).not.toHaveBeenCalled()
-        expect(validatorMock.validate).toHaveBeenCalled()
-        expect(result).toEqual(
-          expect.objectContaining({
-            getFillLogAttempts: 1,
-          })
-        )
-      })
-
-      it('should should update with expired if getFillLogAttempts = 1', async () => {
+      it('should should update with expired', async () => {
         getFillInfoMock.mockImplementation(() => {
           return []
         })
 
         let result = await checkOrderStatusService.handleRequest({
           ...openOrderRequest,
-          getFillLogAttempts: 1,
         })
 
         expect(ordersRepositoryMock.getByHash).toHaveBeenCalled()
         expect(ordersRepositoryMock.updateOrderStatus).toHaveBeenCalled()
-        expect(watcherMock.getFillInfo).toHaveBeenCalled()
+        expect(watcherMock.getFillInfo).not.toHaveBeenCalled()
         expect(providerMock.getTransaction).not.toHaveBeenCalled()
         expect(validatorMock.validate).toHaveBeenCalled()
         expect(result).toEqual(

--- a/test/unit/handlers/check-order-status.test.ts
+++ b/test/unit/handlers/check-order-status.test.ts
@@ -122,35 +122,6 @@ describe('Testing check order status handler', () => {
       })
     })
 
-    it('should check fill events when order expired', async () => {
-      const checkorderStatusHandler = new CheckOrderStatusHandler('check-order-status', initialInjectorPromiseMock)
-      validateMock.mockReturnValue(OrderValidation.Expired)
-      getTransactionMock.mockReturnValueOnce({
-        wait: () =>
-          Promise.resolve({
-            effectiveGasPrice: BigNumber.from(1),
-            gasUsed: 100,
-          }),
-      })
-      getFillInfoMock.mockReturnValue([
-        {
-          orderHash: MOCK_ORDER_HASH,
-          filler: '0x123',
-          nonce: BigNumber.from(1),
-          swapper: '0x123',
-          blockNumber: 12321312313,
-          txHash: '0x1244345323',
-          inputs: [{ token: 'USDC', amount: BigNumber.from(100) }],
-          outputs: [{ token: 'WETH', amount: BigNumber.from(1) }],
-        },
-      ])
-
-      expect(await checkorderStatusHandler.handler(handlerEventMock)).toMatchObject({
-        orderStatus: ORDER_STATUS.FILLED,
-      })
-      expect(getFillInfoMock).toBeCalled()
-    })
-
     it('should check fill events when nonceUsed', async () => {
       const checkorderStatusHandler = new CheckOrderStatusHandler('check-order-status', initialInjectorPromiseMock)
       validateMock.mockReturnValue(OrderValidation.NonceUsed)


### PR DESCRIPTION
This check looks unnecessary given this comment in the sdk 
https://github.com/Uniswap/uniswapx-sdk/blob/7c5e5ade6a7ec77291d48f884c426666d8000a16/src/utils/OrderQuoter.ts#L185

Validation goes from Validator.validate -> Quoter.quote -> getValidations -> checkTerminalStates