### PR TITLE
Rev uniswapx-sdk to 2.0.0

### DIFF
--- a/lib/handlers/check-order-status/service.ts
+++ b/lib/handlers/check-order-status/service.ts
@@ -1,5 +1,12 @@
 import { MetricUnits } from '@aws-lambda-powertools/metrics'
-import { DutchOrder, EventWatcher, FillInfo, OrderValidation, OrderValidator, SignedOrder } from '@uniswap/uniswapx-sdk'
+import {
+  DutchOrder,
+  EventWatcher,
+  FillInfo,
+  OrderValidation,
+  OrderValidator,
+  SignedUniswapXOrder,
+} from '@uniswap/uniswapx-sdk'
 import { ethers } from 'ethers'
 import { OrderEntity, ORDER_STATUS, SettledAmount } from '../../entities'
 import { log } from '../../Logging'
@@ -144,7 +151,7 @@ export class CheckOrderStatusService {
     const validator = getValidator(provider, chainId)
     const orderWatcher = getWatcher(provider, chainId)
 
-    const validationsRequestList: SignedOrder[] = []
+    const validationsRequestList: SignedUniswapXOrder[] = []
     for (let i = 0; i < batch.length; i++) {
       const order = batch[i]
       const parsedOrder = DutchOrder.parse(order.encodedOrder, chainId)

--- a/lib/util/order.ts
+++ b/lib/util/order.ts
@@ -1,4 +1,4 @@
-import { DutchOrder, getOrderTypeFromEncoded, OrderType } from '@uniswap/uniswapx-sdk'
+import { DutchOrder, OrderType, UniswapXOrderParser } from '@uniswap/uniswapx-sdk'
 import { DynamoDBRecord } from 'aws-lambda'
 import { OrderEntity, ORDER_STATUS } from '../entities'
 
@@ -26,7 +26,7 @@ export const eventRecordToOrder = (record: DynamoDBRecord): ParsedOrder => {
   try {
     const chainId = parseInt(newOrder.chainId.N as string)
     const encodedOrder = newOrder.encodedOrder.S as string
-    const orderType = getOrderTypeFromEncoded(encodedOrder, chainId)
+    const orderType = new UniswapXOrderParser().getOrderTypeFromEncoded(encodedOrder, chainId)
 
     return {
       swapper: newOrder.offerer.S as string,

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@swc/core": "^1.3.101",
     "@swc/jest": "^0.2.29",
     "@types/sinon": "^10.0.13",
-    "@uniswap/uniswapx-sdk": "1.5.0",
+    "@uniswap/uniswapx-sdk": "2.0.0",
     "aws-cdk-lib": "2.85.0",
     "aws-embedded-metrics": "^4.1.0",
     "aws-sdk": "^2.1238.0",

--- a/test/e2e/order.test.ts
+++ b/test/e2e/order.test.ts
@@ -1,4 +1,4 @@
-import { DutchOrder, DutchOrderBuilder, REACTOR_ADDRESS_MAPPING, SignedOrder } from '@uniswap/uniswapx-sdk'
+import { DutchOrder, DutchOrderBuilder, REACTOR_ADDRESS_MAPPING, SignedUniswapXOrder } from '@uniswap/uniswapx-sdk'
 import { factories } from '@uniswap/uniswapx-sdk/dist/src/contracts/index'
 import axios from 'axios'
 import dotenv from 'dotenv'
@@ -16,7 +16,7 @@ const { abi } = ERC20_ABI
 dotenv.config()
 
 type OrderExecution = {
-  orders: SignedOrder[]
+  orders: SignedUniswapXOrder[]
   reactor: string
   fillContract: string
   fillData: string

--- a/test/integ/handlers/on-chain-status-checker.integration.test.ts
+++ b/test/integ/handlers/on-chain-status-checker.integration.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import { MetricUnits } from '@aws-lambda-powertools/metrics'
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
-import { EventWatcher, OrderValidation, OrderValidator, SignedOrder } from '@uniswap/uniswapx-sdk'
+import { EventWatcher, OrderValidation, OrderValidator, SignedUniswapXOrder } from '@uniswap/uniswapx-sdk'
 import { DocumentClient } from 'aws-sdk/clients/dynamodb'
 import { BigNumber } from 'ethers'
 import { BATCH_READ_MAX, OnChainStatusChecker } from '../../../lib/compute/on-chain-status-checker'
@@ -140,8 +140,8 @@ describe('OnChainStatusChecker', () => {
         validate: () => {
           return OrderValidation.NonceUsed
         },
-        validateBatch: (arr: SignedOrder[]) => {
-          return arr.map((o: SignedOrder) => {
+        validateBatch: (arr: SignedUniswapXOrder[]) => {
+          return arr.map((o: SignedUniswapXOrder) => {
             switch (o.signature) {
               case MOCK_SIGNATURE:
                 return OrderValidation.NonceUsed

--- a/yarn.lock
+++ b/yarn.lock
@@ -3274,10 +3274,10 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
-"@uniswap/uniswapx-sdk@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-1.5.0.tgz#61680cff849bc1d4c1b124be3a7bb345d38e8cad"
-  integrity sha512-nH0XbJcnZhbIImTkXfxTAxutHmlFSbUc7nKXXFA8IN6oFqLKL/81DlbTxR8juRyb48AhXpOLziEb6AyVFYeGHw==
+"@uniswap/uniswapx-sdk@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-2.0.0.tgz#fc544feeadf1ea2816ccbae0ca8e86d9c7415f9e"
+  integrity sha512-3kQNUf1uqfmhbR4Ue8Ua1VA3WnNxrWZc0lU73S3Bbx0L4iXYWUfQvDHte+Ok/fLs4xmb/Eat0I6i6AF3oO79oQ==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/providers" "^5.7.0"


### PR DESCRIPTION
Rev uniswapx-sdk to 2.0.0 in preparation for the new order types.

Unit, integration, end-to-end tests passing locally. 