### PR TITLE
goerli is dead.

### DIFF
--- a/test/e2e/order.test.ts
+++ b/test/e2e/order.test.ts
@@ -406,7 +406,12 @@ describe('/dutch-auction/order', () => {
     })
   })
 
-  describe('+ attempt to fill', () => {
+  // TODO: Migrate to Sepolia/other test chain
+  // GOERLI chain is deprecated.
+  // 1. change RPC_5
+  // 2. Deploy contracts
+  // 3. fund wallets(alice,filler)
+  describe.skip('+ attempt to fill', () => {
     it('erc20 to eth', async () => {
       const { order, signature } = await buildAndSubmitOrder(
         aliceAddress,


### PR DESCRIPTION
remove e2e tests that rely on goerli testnet until we can migrate to a new testnet
  1. change RPC_5
  2. Deploy contracts--may include uni token/dependent contracts
  4. fund wallets(alice,filler)