### PR TITLE
bump time to check expiration in e2e tests

### DIFF
--- a/test/e2e/order.test.ts
+++ b/test/e2e/order.test.ts
@@ -376,7 +376,7 @@ describe('/dutch-auction/order', () => {
       )
       expect(await expectOrdersToBeOpen([order.hash()])).toBeTruthy()
 
-      expect(await waitAndGetOrderStatus(order.hash(), DEFAULT_DEADLINE_SECONDS + 1)).toBe('expired')
+      expect(await waitAndGetOrderStatus(order.hash(), DEFAULT_DEADLINE_SECONDS + 20)).toBe('expired')
     })
 
     it('erc20 to eth', async () => {
@@ -388,7 +388,7 @@ describe('/dutch-auction/order', () => {
         ZERO_ADDRESS
       )
       expect(await expectOrdersToBeOpen([order.hash()])).toBeTruthy()
-      expect(await waitAndGetOrderStatus(order.hash(), DEFAULT_DEADLINE_SECONDS + 1)).toBe('expired')
+      expect(await waitAndGetOrderStatus(order.hash(), DEFAULT_DEADLINE_SECONDS + 20)).toBe('expired')
     })
 
     it('does not expire order before deadline', async () => {


### PR DESCRIPTION
due to how we update the expiration, it might not be updated to expired within 1 second, so bumping the wait time by 20 seconds