### PR TITLE
add goerli back for e2e tests

### DIFF
--- a/lib/util/chain.ts
+++ b/lib/util/chain.ts
@@ -4,8 +4,9 @@ export enum ChainId {
   ARBITRUM_ONE = 42161,
   POLYGON = 137,
   SEPOLIA = 11155111,
+  GÖRLI = 5,
 }
 
 // If you update SUPPORTED_CHAINS, ensure you add a corresponding RPC_${chainId} enviroment variable.
 // lib/config.py will require it to be defined.
-export const SUPPORTED_CHAINS = [ChainId.MAINNET, ChainId.POLYGON, ChainId.SEPOLIA]
+export const SUPPORTED_CHAINS = [ChainId.MAINNET, ChainId.POLYGON, ChainId.SEPOLIA, ChainId.GÖRLI]

--- a/test/integ/handlers/check-order-status.test.ts
+++ b/test/integ/handlers/check-order-status.test.ts
@@ -103,7 +103,7 @@ describe('Testing check order status handler', () => {
           orderStatus: ORDER_STATUS.OPEN as string,
           chainId: 2022,
         } as any)
-      ).rejects.toThrowError(`"chainId" must be one of [1, 137, 11155111]`)
+      ).rejects.toThrowError(`"chainId" must be one of [1, 137, 11155111, 5]`)
     })
   })
 

--- a/test/unit/handlers/get-nonce.test.ts
+++ b/test/unit/handlers/get-nonce.test.ts
@@ -60,7 +60,7 @@ describe('Testing get nonce handler.', () => {
       [{ address: '' }, '"address\\" is not allowed to be empty"'],
       [{ address: '0xF53bDa7e0337BD456cDcDab0Ab24Db43E738065' }, 'VALIDATION ERROR: Invalid address'],
       [{}, '"address\\" is required'],
-      [{ address: MOCK_ADDRESS, chainId: 'foo' }, '\\"chainId\\" must be one of [1, 137, 11155111]'],
+      [{ address: MOCK_ADDRESS, chainId: 'foo' }, '\\"chainId\\" must be one of [1, 137, 11155111, 5]'],
     ])('Throws 400 with invalid query param %p', async (invalidQueryParam, bodyMsg) => {
       const invalidEvent = {
         ...event,

--- a/test/unit/handlers/get-orders.test.ts
+++ b/test/unit/handlers/get-orders.test.ts
@@ -215,7 +215,10 @@ describe('Testing get orders handler.', () => {
       [{ sort: 'foo(bar)' }, '"foo(bar)\\" fails to match the required pattern'],
       [{ cursor: 1 }, 'must be a string'],
       [{ sort: 'gt(4)' }, '{"detail":"\\"sortKey\\" is required","errorCode":"VALIDATION_ERROR"}'],
-      [{ chainId: 420 }, '{"detail":"\\"chainId\\" must be one of [1, 137, 11155111]","errorCode":"VALIDATION_ERROR"}'],
+      [
+        { chainId: 420 },
+        '{"detail":"\\"chainId\\" must be one of [1, 137, 11155111, 5]","errorCode":"VALIDATION_ERROR"}',
+      ],
       [{ desc: true }, '{"detail":"\\"sortKey\\" is required","errorCode":"VALIDATION_ERROR"}'],
       [
         { desc: 'yes', sortKey: 'createdAt', orderStatus: 'expired' },

--- a/test/unit/handlers/post-order/post-limit-order.test.ts
+++ b/test/unit/handlers/post-order/post-limit-order.test.ts
@@ -163,7 +163,7 @@ describe('Testing post limit order handler.', () => {
       })
     })
 
-    it.only('Testing valid request and response on another chain', async () => {
+    it('Testing valid request and response on another chain', async () => {
       validatorMock.mockReturnValue({ valid: true })
 
       const order = SDKDutchOrderFactory.buildLimitOrder(ChainId.SEPOLIA)

--- a/test/unit/handlers/post-order/post-order.test.ts
+++ b/test/unit/handlers/post-order/post-order.test.ts
@@ -389,7 +389,10 @@ describe('Testing post order handler.', () => {
         { signature: '0xbad_signature' },
         '{"detail":"\\"signature\\" with value \\"0xbad_signature\\" fails to match the required pattern: /^0x[0-9,a-z,A-Z]{130}$/","errorCode":"VALIDATION_ERROR"}',
       ],
-      [{ chainId: 0 }, `{"detail":"\\"chainId\\" must be one of [1, 137, 11155111]","errorCode":"VALIDATION_ERROR"}`],
+      [
+        { chainId: 0 },
+        `{"detail":"\\"chainId\\" must be one of [1, 137, 11155111, 5]","errorCode":"VALIDATION_ERROR"}`,
+      ],
       [{ quoteId: 'not_UUIDV4' }, '{"detail":"\\"quoteId\\" must be a valid GUID","errorCode":"VALIDATION_ERROR"}'],
     ])('Throws 400 with invalid field %p', async (invalidBodyField, bodyMsg) => {
       const invalidEvent = PostOrderRequestFactory.request({

--- a/test/unit/util/field-validator.test.ts
+++ b/test/unit/util/field-validator.test.ts
@@ -114,13 +114,13 @@ describe('Testing each field on the FieldValidator class.', () => {
       const chainId = 'MAINNET'
       const validatedField = FieldValidator.isValidChainId().validate(chainId)
       expect(validatedField.error).toBeTruthy()
-      expect(validatedField.error?.details[0].message).toEqual(`"value" must be one of [1, 137, 11155111]`)
+      expect(validatedField.error?.details[0].message).toEqual(`"value" must be one of [1, 137, 11155111, 5]`)
     })
     it('should invalidate unsupported chain.', async () => {
       const chainId = ChainId.ARBITRUM_ONE
       const validatedField = FieldValidator.isValidChainId().validate(chainId)
       expect(validatedField.error).toBeTruthy()
-      expect(validatedField.error?.details[0].message).toEqual(`"value" must be one of [1, 137, 11155111]`)
+      expect(validatedField.error?.details[0].message).toEqual(`"value" must be one of [1, 137, 11155111, 5]`)
     })
   })
   describe('Testing nonce field.', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3459,7 +3459,7 @@
 
 "@uniswap/uniswapx-sdk@2.0.1-alpha.7":
   version "2.0.1-alpha.7"
-  resolved "https://registry.npmjs.org/@uniswap/uniswapx-sdk/-/uniswapx-sdk-2.0.1-alpha.7.tgz#64c3283f78c6a8814d44d8cbe6c1b3ac400f34eb"
+  resolved "https://registry.npmjs.org/@uniswap/uniswapx-sdk/-/uniswapx-sdk-2.0.1-alpha.7.tgz"
   integrity sha512-i4ie/NGK42AFDsoCbDYfvKKrJHy7UzWulCPj26USVbDq1goq9s0bIfxniMHEDL2nph47zSDLUzAYEtYbvqRKvw==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"


### PR DESCRIPTION
add this back so the e2e tests give some coverage.

need to either fund
/// Addresses on goerli:
///   alice address: 0xE001E6F6879c07b9Ac24291A490F2795106D348C
///   filler address: 0x8943EA25bBfe135450315ab8678f2F79559F4630 (also needs to have at least 0.1 ETH)
on sepolia or create new alice/filler addresses and fund them on sepolia

also need to update
export const WETH_GOERLI = '0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6'
export const UNI_GOERLI = '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984'
for sepolia

Test Suites: 1 skipped, 1 passed, 1 of 2 total
Tests:       5 skipped, 18 passed, 23 total
Snapshots:   0 total
Time:        232.093 s
Ran all test suites matching /test\/e2e\//i.