### PR TITLE
feat: add nonce to GET /orders response for both v1 and v2 orders

### DIFF
--- a/lib/handlers/get-orders/schema/GetDutchV2OrderResponse.ts
+++ b/lib/handlers/get-orders/schema/GetDutchV2OrderResponse.ts
@@ -35,6 +35,7 @@ export type GetDutchV2OrderResponse = {
     outputOverrides: string[]
   }
   cosignature: string
+  nonce: string
   quoteId: string | undefined
   requestId: string | undefined
 }
@@ -81,6 +82,7 @@ export const GetDutchV2OrderResponseEntryJoi = Joi.object({
   ),
   quoteId: FieldValidator.isValidQuoteId(),
   requestId: FieldValidator.isValidRequestId(),
+  nonce: FieldValidator.isValidNonce(),
   cosignerData: CosignerDataJoi,
   cosignature: Joi.string(),
 })

--- a/lib/handlers/get-orders/schema/GetOrdersResponse.ts
+++ b/lib/handlers/get-orders/schema/GetOrdersResponse.ts
@@ -52,6 +52,7 @@ export const OrderResponseEntryJoi = Joi.object({
   chainId: FieldValidator.isValidChainId(),
   quoteId: FieldValidator.isValidQuoteId(),
   requestId: FieldValidator.isValidRequestId(),
+  nonce: FieldValidator.isValidNonce(),
 }).keys({
   ...OrderRepsonseEntryJoiMigrations,
 })

--- a/lib/models/DutchV2Order.ts
+++ b/lib/models/DutchV2Order.ts
@@ -83,7 +83,7 @@ export class DutchV2Order extends Order {
       signature: this.signature,
       encodedOrder: this.inner.serialize(),
       chainId: this.chainId,
-
+      nonce: this.inner.info.nonce.toString(),
       txHash: this.txHash,
       orderHash: this.inner.hash(),
       swapper: this.inner.info.swapper,

--- a/lib/services/UniswapXOrderService.ts
+++ b/lib/services/UniswapXOrderService.ts
@@ -213,8 +213,6 @@ export class UniswapXOrderService {
 
     const dutchQueryResults = [...queryResults.orders]
 
-    this.logger.info(`queryRes: ${JSON.stringify(queryResults)}`)
-
     let retryCount = 0
     while (dutchQueryResults.length < limit && queryResults.cursor && retryCount < MAX_QUERY_RETRY) {
       queryResults = await this.repository.getOrdersFilteredByType(

--- a/lib/services/UniswapXOrderService.ts
+++ b/lib/services/UniswapXOrderService.ts
@@ -176,6 +176,7 @@ export class UniswapXOrderService {
   ): Promise<GetOrdersResponse<GetDutchV2OrderResponse>> {
     let queryResults = await this.repository.getOrdersFilteredByType(limit, params, [OrderType.Dutch_V2], cursor)
     const dutchV2QueryResults = [...queryResults.orders]
+    console.log(`queryRes: ${JSON.stringify(queryResults)}`)
 
     let retryCount = 0
     while (dutchV2QueryResults.length < limit && queryResults.cursor && retryCount < MAX_QUERY_RETRY) {
@@ -196,6 +197,7 @@ export class UniswapXOrderService {
       dutchV2OrderResponses.push(dutchV2Order.toGetResponse())
     }
 
+    console.log(`responses: ${JSON.stringify(dutchV2OrderResponses)}`)
     return { orders: dutchV2OrderResponses, cursor: queryResults.cursor }
   }
 
@@ -212,6 +214,8 @@ export class UniswapXOrderService {
     )
 
     const dutchQueryResults = [...queryResults.orders]
+
+    this.logger.info(`queryRes: ${JSON.stringify(queryResults)}`)
 
     let retryCount = 0
     while (dutchQueryResults.length < limit && queryResults.cursor && retryCount < MAX_QUERY_RETRY) {

--- a/lib/services/UniswapXOrderService.ts
+++ b/lib/services/UniswapXOrderService.ts
@@ -176,7 +176,6 @@ export class UniswapXOrderService {
   ): Promise<GetOrdersResponse<GetDutchV2OrderResponse>> {
     let queryResults = await this.repository.getOrdersFilteredByType(limit, params, [OrderType.Dutch_V2], cursor)
     const dutchV2QueryResults = [...queryResults.orders]
-    console.log(`queryRes: ${JSON.stringify(queryResults)}`)
 
     let retryCount = 0
     while (dutchV2QueryResults.length < limit && queryResults.cursor && retryCount < MAX_QUERY_RETRY) {
@@ -197,7 +196,6 @@ export class UniswapXOrderService {
       dutchV2OrderResponses.push(dutchV2Order.toGetResponse())
     }
 
-    console.log(`responses: ${JSON.stringify(dutchV2OrderResponses)}`)
     return { orders: dutchV2OrderResponses, cursor: queryResults.cursor }
   }
 


### PR DESCRIPTION
completes [PROTO-255](https://linear.app/uniswap/issue/PROTO-255/orderservice-nonce-not-part-of-get-orders-response)

verified working locally
<img width="910" alt="Screenshot 2024-05-31 at 4 19 14 PM" src="https://github.com/Uniswap/uniswapx-service/assets/11896690/4b2b7e44-2250-458b-b0d1-dbac3c5cd15f">
