### PR TITLE
Fix charts and alerts

### DIFF
--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -403,6 +403,7 @@ export class DashboardStack extends cdk.NestedStack {
                 ['Uniswap', `OrderSfn-PercentDecayedUntilFill-chain-${chainId}`, 'Service', `UniswapXService`],
                 ['.', '.', '.', `.`, { stat: 'p99' }],
                 ['.', '.', '.', `.`, { stat: 'p50' }],
+                ['.', '.', '.', `.`, { stat: 'Average' }],
               ]),
               view: 'timeSeries',
               region,

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -167,13 +167,13 @@ export class StepFunctionStack extends cdk.NestedStack {
           m1: new Metric({
             namespace: 'Uniswap',
             metricName: `OrderSfn-expired-chain-${chainId}`,
-            dimensionsMap: METRIC_DIMENSION_MAP,
+            dimensionsMap: { Service: 'UniswapXService' },
             statistic: 'sum',
           }),
           m2: new Metric({
             namespace: 'Uniswap',
             metricName: `OrderSfn-filled-chain-${chainId}`,
-            dimensionsMap: METRIC_DIMENSION_MAP,
+            dimensionsMap: { Service: 'UniswapXService' },
             statistic: 'sum',
           }),
         },

--- a/lib/handlers/check-order-status/fill-event-logger.ts
+++ b/lib/handlers/check-order-status/fill-event-logger.ts
@@ -55,8 +55,10 @@ export class FillEventLogger {
     }
 
     // blocks until fill is the number of blocks between the fill event and the starting block number (need to add back the look back blocks)
-    const blocksUntilFill = fillEvent.blockNumber - (startingBlockNumber + this.fillEventBlockLookback(chainId))
-    metrics.putMetric(`OrderSfn-BlocksUntilFill-chain-${chainId}`, blocksUntilFill, Unit.Count)
+    if (startingBlockNumber != 0) {
+      const blocksUntilFill = fillEvent.blockNumber - (startingBlockNumber + this.fillEventBlockLookback(chainId))
+      metrics.putMetric(`OrderSfn-BlocksUntilFill-chain-${chainId}`, blocksUntilFill, Unit.Count)
+    }
     return settledAmounts
   }
 }


### PR DESCRIPTION
The following two charts in the Order Service dashboard are not useful:
<img width="1194" alt="image" src="https://github.com/Uniswap/uniswapx-service/assets/11261382/8882ae5e-ebd4-4669-8b7b-a8ea0b664569">
- **Order Percent Decay Until Fill by Chain**: I've found that aggregating using an `avg` will give us real-time data while the P99 and P50 are very delayed and sparse. To fix this, I'm keeping the P99 and P50 while also adding the `avg` to the graph.
- **Blocks Until Fill by Chain**: The spikes of 20M make the chart unreadable. The problem is that when the `startingBlockNumber` is not present, it defaults to 0, leading the `BlocksUntilFill` to just be the current block height. The fix is to remove any case where `startingBlockNumber` is 0.

Also fix the `dimensionsMap` of the new expiry alert.