### PR TITLE
DAT-480 add createdAt to get response for Dutch_V2 objects

### DIFF
--- a/lib/handlers/get-orders/schema/GetDutchV2OrderResponse.ts
+++ b/lib/handlers/get-orders/schema/GetDutchV2OrderResponse.ts
@@ -38,6 +38,7 @@ export type GetDutchV2OrderResponse = {
   nonce: string
   quoteId: string | undefined
   requestId: string | undefined
+  createdAt: number | undefined
 }
 
 export const CosignerDataJoi = Joi.object({
@@ -85,4 +86,5 @@ export const GetDutchV2OrderResponseEntryJoi = Joi.object({
   nonce: FieldValidator.isValidNonce(),
   cosignerData: CosignerDataJoi,
   cosignature: Joi.string(),
+  createdAt: Joi.number(),
 })

--- a/lib/models/DutchV2Order.ts
+++ b/lib/models/DutchV2Order.ts
@@ -11,7 +11,8 @@ export class DutchV2Order extends Order {
     readonly orderStatus?: ORDER_STATUS,
     readonly txHash?: string,
     readonly quoteId?: string,
-    readonly requestId?: string
+    readonly requestId?: string,
+    readonly createdAt?: number
   ) {
     super()
   }
@@ -59,6 +60,7 @@ export class DutchV2Order extends Order {
       cosignature: decodedOrder.info.cosignature,
       quoteId: this.quoteId,
       requestId: this.requestId,
+      createdAt: this.createdAt,
     }
 
     return order
@@ -72,7 +74,8 @@ export class DutchV2Order extends Order {
       entity.orderStatus,
       entity.txHash,
       entity.quoteId,
-      entity.requestId
+      entity.requestId,
+      entity.createdAt
     )
   }
 
@@ -112,6 +115,7 @@ export class DutchV2Order extends Order {
       cosignature: this.inner.info.cosignature,
       quoteId: this.quoteId,
       requestId: this.requestId,
+      createdAt: this.createdAt,
     }
   }
 }

--- a/test/unit/models/DutchV2Order.test.ts
+++ b/test/unit/models/DutchV2Order.test.ts
@@ -23,12 +23,17 @@ describe('DutchV2 Model', () => {
       SDKDutchOrderV2Factory.buildDutchV2Order(),
       MOCK_SIGNATURE,
       ChainId.MAINNET,
-      ORDER_STATUS.OPEN
+      ORDER_STATUS.OPEN,
+      undefined,
+      undefined,
+      undefined,
+      100
     )
     const entity: UniswapXOrderEntity = order.toEntity(ORDER_STATUS.OPEN)
     const fromEntity = DutchV2Order.fromEntity(entity)
 
     expect(order).toEqual(fromEntity)
+    expect(order.createdAt).toEqual(100)
   })
 
   test('toGetResponse', () => {
@@ -36,7 +41,11 @@ describe('DutchV2 Model', () => {
       SDKDutchOrderV2Factory.buildDutchV2Order(),
       MOCK_SIGNATURE,
       ChainId.MAINNET,
-      ORDER_STATUS.OPEN
+      ORDER_STATUS.OPEN,
+      undefined,
+      undefined,
+      undefined,
+      100
     )
     const response: GetDutchV2OrderResponse = order.toGetResponse()
 
@@ -66,5 +75,6 @@ describe('DutchV2 Model', () => {
     response.cosignerData.outputOverrides.forEach((o, i) => {
       expect(o).toEqual(order.inner.info.cosignerData.outputOverrides[i].toString())
     })
+    expect(order.createdAt).toEqual(100)
   })
 })


### PR DESCRIPTION
there is a bug in graphql for Dutch_V2 orders caused by missing createdAt date