### PR TITLE
fix: remove kmsClient at lambda initialization

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -335,6 +335,7 @@ envVars['PERMIT2_TENDERLY'] = process.env[`PERMIT2_TENDERLY`] || ''
 envVars['FILL_EVENT_DESTINATION_ARN'] = process.env['FILL_EVENT_DESTINATION_ARN'] || ''
 envVars['POSTED_ORDER_DESTINATION_ARN'] = process.env['POSTED_ORDER_DESTINATION'] || ''
 envVars['LABS_COSIGNER'] = process.env['LABS_COSIGNER'] || ''
+envVars['LABS_PRIORITY_COSIGNER'] = process.env['LABS_PRIORITY_COSIGNER'] || ''
 
 new APIStack(app, `${SERVICE_NAME}Stack`, {
   provisionedConcurrency: process.env.PROVISION_CONCURRENCY ? parseInt(process.env.PROVISION_CONCURRENCY) : 0,

--- a/lib/handlers/post-limit-order/injector.ts
+++ b/lib/handlers/post-limit-order/injector.ts
@@ -1,30 +1,19 @@
-import { KMSClient } from '@aws-sdk/client-kms'
-import { KmsSigner } from '@uniswap/signer'
 import { MetricsLogger } from 'aws-embedded-metrics'
 import { APIGatewayEvent, Context } from 'aws-lambda'
 import { default as Logger } from 'bunyan'
-import { checkDefined } from '../../preconditions/preconditions'
 import { setGlobalLogger } from '../../util/log'
 import { setGlobalMetrics } from '../../util/metrics'
 import { ApiInjector, ApiRInj } from '../base'
 import { DEFAULT_MAX_OPEN_LIMIT_ORDERS, HIGH_MAX_OPEN_ORDERS, HIGH_MAX_OPEN_ORDERS_SWAPPERS } from '../constants'
 import { PostOrderRequestBody } from '../post-order/schema'
-import { ContainerInjected as PostContainerInjected } from '../shared/post'
 
-export class PostLimitOrderInjector extends ApiInjector<PostContainerInjected, ApiRInj, PostOrderRequestBody, void> {
-  public async buildContainerInjected(): Promise<PostContainerInjected> {
-    const kmsKeyId = checkDefined(process.env.KMS_KEY_ID, 'KMS_KEY_ID is not defined')
-    const region = checkDefined(process.env.REGION, 'REGION is not defined')
-    const cosigner = new KmsSigner(new KMSClient({ region: region }), kmsKeyId)
-    const cosignerAddress = await cosigner.getAddress()
-
-    return {
-      cosignerAddress,
-    }
+export class PostLimitOrderInjector extends ApiInjector<unknown, ApiRInj, PostOrderRequestBody, void> {
+  public async buildContainerInjected(): Promise<unknown> {
+    return {}
   }
 
   public async getRequestInjected(
-    _containerInjected: PostContainerInjected,
+    _containerInjected: unknown,
     _requestBody: PostOrderRequestBody,
     _requestQueryParams: void,
     _event: APIGatewayEvent,

--- a/lib/handlers/post-order/handler.ts
+++ b/lib/handlers/post-order/handler.ts
@@ -19,12 +19,11 @@ import {
   ErrorResponse,
   Response,
 } from '../base'
-import { ContainerInjected as PostContainerInjected } from '../shared/post'
 import { PostOrderBodyParser } from './PostOrderBodyParser'
 import { PostOrderRequestBody, PostOrderRequestBodyJoi, PostOrderResponse, PostOrderResponseJoi } from './schema'
 
 export class PostOrderHandler extends APIGLambdaHandler<
-  PostContainerInjected,
+  unknown,
   ApiRInj,
   PostOrderRequestBody,
   void,
@@ -32,7 +31,7 @@ export class PostOrderHandler extends APIGLambdaHandler<
 > {
   constructor(
     handlerName: string,
-    injectorPromise: Promise<ApiInjector<PostContainerInjected, ApiRInj, PostOrderRequestBody, void>>,
+    injectorPromise: Promise<ApiInjector<unknown, ApiRInj, PostOrderRequestBody, void>>,
     private readonly orderDispatcher: OrderDispatcher,
     private readonly bodyParser: PostOrderBodyParser
   ) {
@@ -40,15 +39,14 @@ export class PostOrderHandler extends APIGLambdaHandler<
   }
 
   public async handleRequest(
-    params: APIHandleRequestParams<PostContainerInjected, ApiRInj, PostOrderRequestBody, void>
+    params: APIHandleRequestParams<unknown, ApiRInj, PostOrderRequestBody, void>
   ): Promise<Response<PostOrderResponse> | ErrorResponse> {
     const {
       requestBody,
       requestInjected: { log },
-      containerInjected: { cosignerAddress },
     } = params
 
-    log.info({ requestBody: requestBody, cosignerAddress: cosignerAddress }, 'Handling POST order request')
+    log.info({ requestBody: requestBody }, 'Handling POST order request')
 
     let order: Order
 

--- a/lib/handlers/post-order/injector.ts
+++ b/lib/handlers/post-order/injector.ts
@@ -1,30 +1,19 @@
-import { KMSClient } from '@aws-sdk/client-kms'
-import { KmsSigner } from '@uniswap/signer'
 import { MetricsLogger } from 'aws-embedded-metrics'
 import { APIGatewayEvent, Context } from 'aws-lambda'
 import { default as Logger } from 'bunyan'
-import { checkDefined } from '../../preconditions/preconditions'
 import { setGlobalLogger } from '../../util/log'
 import { setGlobalMetrics } from '../../util/metrics'
 import { ApiInjector, ApiRInj } from '../base'
 import { DEFAULT_MAX_OPEN_ORDERS, HIGH_MAX_OPEN_ORDERS, HIGH_MAX_OPEN_ORDERS_SWAPPERS } from '../constants'
-import { ContainerInjected as PostContainerInjected } from '../shared/post'
 import { PostOrderRequestBody } from './schema'
 
-export class PostOrderInjector extends ApiInjector<PostContainerInjected, ApiRInj, PostOrderRequestBody, void> {
-  public async buildContainerInjected(): Promise<PostContainerInjected> {
-    const kmsKeyId = checkDefined(process.env.KMS_KEY_ID, 'KMS_KEY_ID is not defined')
-    const region = checkDefined(process.env.REGION, 'REGION is not defined')
-    const cosigner = new KmsSigner(new KMSClient({ region: region }), kmsKeyId)
-    const cosignerAddress = await cosigner.getAddress()
-
-    return {
-      cosignerAddress,
-    }
+export class PostOrderInjector extends ApiInjector<unknown, ApiRInj, PostOrderRequestBody, void> {
+  public async buildContainerInjected(): Promise<unknown> {
+    return {}
   }
 
   public async getRequestInjected(
-    _containerInjected: PostContainerInjected,
+    _containerInjected: unknown,
     _requestBody: PostOrderRequestBody,
     _requestQueryParams: void,
     _event: APIGatewayEvent,

--- a/lib/handlers/shared/post.ts
+++ b/lib/handlers/shared/post.ts
@@ -1,3 +1,0 @@
-export interface ContainerInjected {
-  cosignerAddress: string
-}


### PR DESCRIPTION
We are stuck at `Resource handler returned message: "Provisioned Concurrency configuration failed to be applied. Reason: FAILED" (RequestToken: 9aea2c7d-1c2d-d851-2af7-264d24939869, HandlerErrorCode: NotStabilized)` error on deployments. One theory is that we are initializing too many things at lambda initialization and that somehow caused the `NotStabilized` error. This PR stops KmsClient initialization since we re-create it at every request anyways.