### PR TITLE
chore: bump x sdk to latest beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@swc/jest": "^0.2.29",
     "@types/sinon": "^10.0.13",
     "@uniswap/signer": "^0.0.4",
-    "@uniswap/uniswapx-sdk": "2.1.0-beta.11",
+    "@uniswap/uniswapx-sdk": "^2.1.0-beta.12",
     "aws-cdk-lib": "2.85.0",
     "aws-embedded-metrics": "^4.1.0",
     "aws-sdk": "^2.1238.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4309,10 +4309,10 @@
     asn1.js "^5.4.1"
     ethers "^6.8.1"
 
-"@uniswap/uniswapx-sdk@2.1.0-beta.11":
-  version "2.1.0-beta.11"
-  resolved "https://registry.npmjs.org/@uniswap/uniswapx-sdk/-/uniswapx-sdk-2.1.0-beta.11.tgz#4b551f9cacc9c948c19d10aa69e50430712755ca"
-  integrity sha512-TjQg3Wx9xpggRdyQLodU7HMWZgf+sB0zOwmjN2bWGayFFM+6un0k7KQNOE9zTDDYxdxpeLlNWT7r97C4OiNHoQ==
+"@uniswap/uniswapx-sdk@^2.1.0-beta.12":
+  version "2.1.0-beta.12"
+  resolved "https://registry.yarnpkg.com/@uniswap/uniswapx-sdk/-/uniswapx-sdk-2.1.0-beta.12.tgz#be9f10ee6443d24f42be9dd10b35fa630cfcfa1d"
+  integrity sha512-rM6fCiFQoVXuOW5X9NCv3eNeTST6jiT2EOMT4tO5Iw3/DDqrufcgJ2KXHxxsMDch675tS1OBlfgX3DjxOEtatA==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/providers" "^5.7.0"


### PR DESCRIPTION
latest version of x sdk adds priorityOrderReactor-specific errors