### PR TITLE
Add Arbitrum time for polling

### DIFF
--- a/lib/handlers/check-order-status/index.ts
+++ b/lib/handlers/check-order-status/index.ts
@@ -63,9 +63,12 @@ const checkOrderStatusHandler = new CheckOrderStatusHandler(
     LimitOrdersRepository.create(documentClient),
     FILL_EVENT_LOOKBACK_BLOCKS_ON,
     new FillEventLogger(FILL_EVENT_LOOKBACK_BLOCKS_ON, AnalyticsService.create()),
-    new CheckOrderStatusUtils(OrderType.Limit, AnalyticsService.create(), limitOrdersRepository, () => {
-      return 30
-    })
+    new CheckOrderStatusUtils(
+      OrderType.Limit,
+      AnalyticsService.create(),
+      limitOrdersRepository,
+      calculateDutchRetryWaitSeconds
+    )
   ),
   relayOrderService
 )

--- a/lib/handlers/check-order-status/util.ts
+++ b/lib/handlers/check-order-status/util.ts
@@ -178,6 +178,8 @@ export const AVERAGE_BLOCK_TIME = (chainId: ChainId): number => {
       return 12
     case ChainId.ARBITRUM_ONE:
       return 1
+    case ChainId.BASE:
+      return 2
     case ChainId.POLYGON:
       // Keep this at the default 12 for now since we would have to do more retries
       // if it was at 2 seconds

--- a/lib/handlers/check-order-status/util.ts
+++ b/lib/handlers/check-order-status/util.ts
@@ -176,6 +176,8 @@ export const AVERAGE_BLOCK_TIME = (chainId: ChainId): number => {
   switch (chainId) {
     case ChainId.MAINNET:
       return 12
+    case ChainId.ARBITRUM_ONE:
+      return 1
     case ChainId.POLYGON:
       // Keep this at the default 12 for now since we would have to do more retries
       // if it was at 2 seconds


### PR DESCRIPTION
It's used [here](https://github.com/Uniswap/uniswapx-service/blob/56b00d92d9d576055fe5723a86dfaaef8d00ff75/lib/handlers/check-order-status/index.ts#L58C7-L58C37) to determine retry wait secs.