### PR TITLE
Bump up encoded order length limit to 4k for DutchV3

### DIFF
--- a/lib/util/field-validator.ts
+++ b/lib/util/field-validator.ts
@@ -17,7 +17,7 @@ const COSIGNER = checkDefined(process.env.LABS_COSIGNER, 'LABS_COSIGNER is not d
 const PRIORITY_COSIGNER = checkDefined(process.env.LABS_PRIORITY_COSIGNER, 'LABS_PRIORITY_COSIGNER is not defined')
 
 export default class FieldValidator {
-  private static readonly ENCODED_ORDER_JOI = Joi.string().regex(this.getHexiDecimalRegex(3000, true))
+  private static readonly ENCODED_ORDER_JOI = Joi.string().regex(this.getHexiDecimalRegex(4000, true))
   private static readonly SIGNATURE_JOI = Joi.string().regex(this.getHexiDecimalRegex(130))
   private static readonly ORDER_HASH_JOI = Joi.string().regex(this.getHexiDecimalRegex(64))
   private static readonly ORDER_HASHES_JOI = Joi.string()

--- a/test/unit/handlers/post-order/post-limit-order.test.ts
+++ b/test/unit/handlers/post-order/post-limit-order.test.ts
@@ -307,7 +307,7 @@ describe('Testing post limit order handler.', () => {
     it.each([
       [
         { encodedOrder: '0xbad_order' },
-        '{"detail":"\\"encodedOrder\\" with value \\"0xbad_order\\" fails to match the required pattern: /^0x[0-9,a-z,A-Z]{0,3000}$/","errorCode":"VALIDATION_ERROR"}',
+        '{"detail":"\\"encodedOrder\\" with value \\"0xbad_order\\" fails to match the required pattern: /^0x[0-9,a-z,A-Z]{0,4000}$/","errorCode":"VALIDATION_ERROR"}',
       ],
       [
         { signature: '0xbad_signature' },

--- a/test/unit/handlers/post-order/post-order.test.ts
+++ b/test/unit/handlers/post-order/post-order.test.ts
@@ -558,7 +558,7 @@ describe('Testing post order handler.', () => {
     it.each([
       [
         { encodedOrder: '0xbad_order' },
-        '{"detail":"\\"encodedOrder\\" with value \\"0xbad_order\\" fails to match the required pattern: /^0x[0-9,a-z,A-Z]{0,3000}$/","errorCode":"VALIDATION_ERROR"}',
+        '{"detail":"\\"encodedOrder\\" with value \\"0xbad_order\\" fails to match the required pattern: /^0x[0-9,a-z,A-Z]{0,4000}$/","errorCode":"VALIDATION_ERROR"}',
       ],
       [
         { signature: '0xbad_signature' },

--- a/test/unit/util/field-validator.test.ts
+++ b/test/unit/util/field-validator.test.ts
@@ -103,7 +103,7 @@ describe('Testing each field on the FieldValidator class.', () => {
       const validatedField = FieldValidator.isValidEncodedOrder().validate(invalidOrder)
       expect(validatedField.error).toBeTruthy()
       expect(validatedField.error?.details[0].message).toEqual(
-        `"value" with value "${invalidOrder}" fails to match the required pattern: /^0x[0-9,a-z,A-Z]{0,3000}$/`
+        `"value" with value "${invalidOrder}" fails to match the required pattern: /^0x[0-9,a-z,A-Z]{0,4000}$/`
       )
     })
   })


### PR DESCRIPTION
DutchV3 orders are a bit larger and are hitting the 3k char limit.