### PR TITLE
feat: add startingBaseFee to dynamoDB

### DIFF
--- a/lib/repositories/dutch-orders-repository.ts
+++ b/lib/repositories/dutch-orders-repository.ts
@@ -38,6 +38,7 @@ export class DutchOrdersRepository extends GenericOrdersRepository<string, strin
         cosignature: { type: DYNAMODB_TYPES.STRING },
         auctionStartBlock: { type: DYNAMODB_TYPES.NUMBER },
         baselinePriorityFeeWei: { type: DYNAMODB_TYPES.STRING },
+        startingBaseFee: { type: DYNAMODB_TYPES.STRING },
         cosigner: { type: DYNAMODB_TYPES.STRING },
 
         //on chain data


### PR DESCRIPTION
When inserting an order to the db, we get a `Field 'startingBaseFee' does not have a mapping or alias` error