### PR TITLE
Track record staleness

### DIFF
--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -506,6 +506,26 @@ export class DashboardStack extends cdk.NestedStack {
             },
           },
           {
+            height: 6,
+            width: 12,
+            y: 68,
+            x: 0,
+            type: 'metric',
+            properties: {
+              metrics: _.flatMap(SUPPORTED_CHAINS, (chainId) => [
+                ['Uniswap', `NotificationRecordStaleness-chain-${chainId}`, 'Service', `UniswapXService`],
+                ['.', '.', '.', `.`, { stat: 'p99' }],
+                ['.', '.', '.', `.`, { stat: 'p50' }],
+                ['.', '.', '.', `.`, { stat: 'Average' }],
+              ]),
+              view: 'timeSeries',
+              region,
+              title: 'DutchV2 Notification Record Staleness',
+              period: 300,
+              stat: 'p90',
+            },
+          },
+          {
             height: 1,
             width: 24,
             y: 25,

--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -53,7 +53,7 @@ export class LambdaStack extends cdk.NestedStack {
     const { provisionedConcurrency, kmsKey, tableCapacityConfig, indexCapacityConfig, chatbotSNSArn } = props
 
     const lambdaName = `${SERVICE_NAME}Lambda`
-    const orderNotificationProvisionedConcurrency = 10
+    const orderNotificationProvisionedConcurrency = 20
 
     const lambdaRole = new aws_iam.Role(this, `${lambdaName}-LambdaRole`, {
       assumedBy: new aws_iam.ServicePrincipal('lambda.amazonaws.com'),

--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -53,7 +53,7 @@ export class LambdaStack extends cdk.NestedStack {
     const { provisionedConcurrency, kmsKey, tableCapacityConfig, indexCapacityConfig, chatbotSNSArn } = props
 
     const lambdaName = `${SERVICE_NAME}Lambda`
-    const orderNotificationProvisionedConcurrency = 20
+    const orderNotificationProvisionedConcurrency = 50
 
     const lambdaRole = new aws_iam.Role(this, `${lambdaName}-LambdaRole`, {
       assumedBy: new aws_iam.ServicePrincipal('lambda.amazonaws.com'),

--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -165,7 +165,7 @@ export class LambdaStack extends cdk.NestedStack {
 
     const notificationConfig = {
       startingPosition: aws_lambda.StartingPosition.TRIM_HORIZON,
-      batchSize: 10,
+      batchSize: 1,
       retryAttempts: 0,
       bisectBatchOnError: true,
       reportBatchItemFailures: true,


### PR DESCRIPTION
The previous changes didn't improve the order notification staleness. The problem may be upstream so I'd like to see the time difference between the current time and the record's `ApproximateCreationDateTime` (when it's inserted into dynamo).

I also revert the `batchSize` to 1 since that increase didn't help us.