### PR TITLE
feat: add fillBlock to table & V3 queries

### DIFF
--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -179,7 +179,7 @@ export class DashboardStack extends cdk.NestedStack {
             x: 0,
             type: 'log',
             properties: {
-              query: `SOURCE '/aws/lambda/${orderStatusLambdaName}' | fields orderInfo.orderHash as orderHash, orderInfo.tokenInChainId as chainId, orderInfo.offerer as offerer,orderInfo.exclusiveFiller as exclusiveFiller, orderInfo.filler as filler, orderInfo.tokenOut as tokenOut, orderInfo.amountOut as amountOut, orderInfo.blockNumber as blockNumber, orderInfo.txHash as txHash, orderInfo.gasUsed as gasUsed, orderInfo.gasCostInETH as gasCostInEth\n| filter ispresent(orderInfo.orderStatus) and orderInfo.orderStatus = 'filled'\n| sort @timestamp desc`,
+              query: `SOURCE '/aws/lambda/${orderStatusLambdaName}' | fields orderInfo.orderHash as orderHash, orderInfo.tokenInChainId as chainId, orderInfo.offerer as offerer,orderInfo.exclusiveFiller as exclusiveFiller, orderInfo.filler as filler, orderInfo.tokenOut as tokenOut, orderInfo.amountOut as amountOut, orderInfo.blockNumber as blockNumber, orderInfo.txHash as txHash, orderInfo.fillBlock as fillBlock, orderInfo.gasUsed as gasUsed, orderInfo.gasCostInETH as gasCostInEth\n| filter ispresent(orderInfo.orderStatus) and orderInfo.orderStatus = 'filled'\n| sort @timestamp desc`,
               region,
               stacked: false,
               view: 'table',

--- a/lib/entities/Order.ts
+++ b/lib/entities/Order.ts
@@ -82,6 +82,7 @@ export type SharedXOrderEntity = {
   requestId?: string
   // TxHash field is defined when the order has been filled and there is a txHash associated with the fill.
   txHash?: string
+  fillBlock?: number
   // SettledAmount field is defined when the order has been filled and the fill amounts have been recorded.
   settledAmounts?: SettledAmount[]
 }

--- a/lib/handlers/get-orders/schema/GetDutchV3OrderResponse.ts
+++ b/lib/handlers/get-orders/schema/GetDutchV3OrderResponse.ts
@@ -15,6 +15,7 @@ export type GetDutchV3OrderResponse = {
   reactor: string
 
   txHash: string | undefined
+  fillBlock: number | undefined
   deadline: number
   input: {
     token: string
@@ -69,6 +70,7 @@ export const GetDutchV3OrderResponseEntryJoi = Joi.object({
   chainId: FieldValidator.isValidChainId().required(),
   startingBaseFee: FieldValidator.isValidAmount(),
   txHash: FieldValidator.isValidTxHash(),
+  fillBlock: FieldValidator.isValidNumber(),
   input: Joi.object({
     token: FieldValidator.isValidEthAddress().required(),
     startAmount: FieldValidator.isValidAmount().required(),

--- a/lib/handlers/post-order/PostOrderBodyParser.ts
+++ b/lib/handlers/post-order/PostOrderBodyParser.ts
@@ -138,7 +138,7 @@ export class PostOrderBodyParser {
   ): DutchV3Order {
     try {
       const order = CosignedV3DutchOrder.parse(encodedOrder, chainId)
-      return new DutchV3Order(order as SDKV3DutchOrder, signature, chainId, undefined, undefined, quoteId, requestId)
+      return new DutchV3Order(order as SDKV3DutchOrder, signature, chainId, undefined, undefined, undefined, quoteId, requestId)
     } catch (err) {
       this.logger.error('Unable to parse DutchV3 order', {
         err,

--- a/lib/models/DutchV3Order.ts
+++ b/lib/models/DutchV3Order.ts
@@ -10,6 +10,7 @@ export class DutchV3Order extends Order {
     readonly chainId: number,
     readonly orderStatus?: ORDER_STATUS,
     readonly txHash?: string,
+    readonly fillBlock?: number,
     readonly quoteId?: string,
     readonly requestId?: string,
     readonly createdAt?: number
@@ -65,6 +66,7 @@ export class DutchV3Order extends Order {
         outputOverrides: decodedOrder.info.cosignerData.outputOverrides.map((o) => o.toString()),
       },
       txHash: this.txHash,
+      fillBlock: this.fillBlock,
       cosignature: decodedOrder.info.cosignature,
       quoteId: this.quoteId,
       requestId: this.requestId,
@@ -81,6 +83,7 @@ export class DutchV3Order extends Order {
       entity.chainId,
       entity.orderStatus,
       entity.txHash,
+      entity.fillBlock,
       entity.quoteId,
       entity.requestId,
       entity.createdAt
@@ -96,6 +99,7 @@ export class DutchV3Order extends Order {
       chainId: this.chainId,
       nonce: this.inner.info.nonce.toString(),
       txHash: this.txHash,
+      fillBlock: this.fillBlock,
       orderHash: this.inner.hash(),
       swapper: this.inner.info.swapper,
       reactor: this.inner.info.reactor,

--- a/lib/repositories/RelayOrderRepository.ts
+++ b/lib/repositories/RelayOrderRepository.ts
@@ -42,6 +42,7 @@ export class RelayOrderRepository extends GenericOrdersRepository<string, string
         relayFee: { type: DYNAMODB_TYPES.MAP },
         quoteId: { type: DYNAMODB_TYPES.STRING },
         txHash: { type: DYNAMODB_TYPES.STRING },
+        fillBlock: { type: DYNAMODB_TYPES.NUMBER },
         settledAmounts: { type: DYNAMODB_TYPES.LIST },
 
         offerer_orderStatus: { type: DYNAMODB_TYPES.STRING },

--- a/lib/repositories/base.ts
+++ b/lib/repositories/base.ts
@@ -39,6 +39,7 @@ export interface BaseOrdersRepository<T extends OrderEntityType> {
     orderHash: string,
     status: ORDER_STATUS,
     txHash?: string,
+    fillBlock?: number,
     settledAmounts?: SettledAmount[]
   ) => Promise<void>
   deleteOrders: (orderHashes: string[]) => Promise<void>

--- a/lib/repositories/dutch-orders-repository.ts
+++ b/lib/repositories/dutch-orders-repository.ts
@@ -55,6 +55,7 @@ export class DutchOrdersRepository extends GenericOrdersRepository<string, strin
         quoteId: { type: DYNAMODB_TYPES.STRING },
         requestId: { type: DYNAMODB_TYPES.STRING },
         txHash: { type: DYNAMODB_TYPES.STRING },
+        fillBlock: { type: DYNAMODB_TYPES.NUMBER },
         settledAmounts: { type: DYNAMODB_TYPES.LIST },
 
         //indexes

--- a/lib/repositories/generic-orders-repository.ts
+++ b/lib/repositories/generic-orders-repository.ts
@@ -105,6 +105,7 @@ export abstract class GenericOrdersRepository<
     orderHash: string,
     status: ORDER_STATUS,
     txHash?: string,
+    fillBlock?: number,
     settledAmounts?: SettledAmount[]
   ): Promise<void> {
     try {
@@ -117,6 +118,7 @@ export abstract class GenericOrdersRepository<
         [TABLE_KEY.ORDER_HASH]: orderHash,
         ...this.indexMapper.getIndexFieldsForStatusUpdate(order, status),
         ...(txHash && { txHash }),
+        ...(fillBlock && { fillBlock }),
         ...(settledAmounts && { settledAmounts }),
       })
     } catch (e) {

--- a/lib/repositories/generic-orders-repository.ts
+++ b/lib/repositories/generic-orders-repository.ts
@@ -119,7 +119,7 @@ export abstract class GenericOrdersRepository<
         ...this.indexMapper.getIndexFieldsForStatusUpdate(order, status),
         ...(txHash && { txHash }),
         ...(fillBlock && { fillBlock }),
-        ...(settledAmounts && { settledAmounts }),
+        ...(settledAmounts && { settledAmounts })
       })
     } catch (e) {
       log.error('updateOrderStatus error', { error: e })

--- a/lib/repositories/limit-orders-repository.ts
+++ b/lib/repositories/limit-orders-repository.ts
@@ -51,6 +51,7 @@ export class LimitOrdersRepository extends GenericOrdersRepository<string, strin
         filler_offerer_orderStatus: { type: DYNAMODB_TYPES.STRING },
         quoteId: { type: DYNAMODB_TYPES.STRING },
         txHash: { type: DYNAMODB_TYPES.STRING },
+        fillBlock: { type: DYNAMODB_TYPES.NUMBER },
         settledAmounts: { type: DYNAMODB_TYPES.LIST },
       },
       table: limitOrdersTable,

--- a/swagger.json
+++ b/swagger.json
@@ -397,6 +397,10 @@
             "description": "TxHash field is defined when the order has been filled and there is a txHash associated with the fill.",
             "type": "string"
           },
+          "fillBlock": {
+            "description": "Fill block field is defined when the order has been filled and the fill block has been recorded.",
+            "type": "number"
+          },
           "settledAmounts": {
             "description": "SettledAmount field is defined when the order has been filled and the fill amounts have been recorded.",
             "type": "array",

--- a/test/integ/repositories/dynamo-repository.test.ts
+++ b/test/integ/repositories/dynamo-repository.test.ts
@@ -635,7 +635,7 @@ describe('OrdersRepository get order count by offerer test', () => {
 
 describe('OrdersRepository update status test', () => {
   it('should successfully update orderStatus of an order identified by orderHash', async () => {
-    await ordersRepository.updateOrderStatus('0x1', ORDER_STATUS.FILLED, 'txHash', [
+    await ordersRepository.updateOrderStatus('0x1', ORDER_STATUS.FILLED, 'txHash', 1, [
       { tokenOut: '0x1', amountOut: '1' } as SettledAmount,
     ])
     await expect(ordersRepository.getByHash('0x1')).resolves.toMatchObject({
@@ -644,6 +644,7 @@ describe('OrdersRepository update status test', () => {
       chainId_orderStatus: `${MOCK_ORDER_1.chainId}_${ORDER_STATUS.FILLED}`,
       chainId_orderStatus_filler: `${MOCK_ORDER_1.chainId}_${ORDER_STATUS.FILLED}_undefined`,
       txHash: 'txHash',
+      fillBlock: 1,
       settledAmounts: [{ tokenOut: '0x1', amountOut: '1' }],
     })
   })

--- a/test/integ/repositories/limit-orders-repository.test.ts
+++ b/test/integ/repositories/limit-orders-repository.test.ts
@@ -536,7 +536,7 @@ describe('OrdersRepository get order count by offerer test', () => {
 
 describe('OrdersRepository update status test', () => {
   it('should successfully update orderStatus of an order identified by orderHash', async () => {
-    await ordersRepository.updateOrderStatus('0x1', ORDER_STATUS.FILLED, 'txHash', [
+    await ordersRepository.updateOrderStatus('0x1', ORDER_STATUS.FILLED, 'txHash', 1, [
       { tokenOut: '0x1', amountOut: '1' } as any,
     ])
     await expect(ordersRepository.getByHash('0x1')).resolves.toMatchObject({
@@ -545,6 +545,7 @@ describe('OrdersRepository update status test', () => {
       chainId_orderStatus: `${MOCK_ORDER_1.chainId}_${ORDER_STATUS.FILLED}`,
       chainId_orderStatus_filler: `${MOCK_ORDER_1.chainId}_${ORDER_STATUS.FILLED}_${(MOCK_ORDER_1 as any).filler}`,
       txHash: 'txHash',
+      fillBlock: 1,
       settledAmounts: [{ tokenOut: '0x1', amountOut: '1' }],
     })
   })

--- a/test/integ/repositories/limit-orders-repository.test.ts
+++ b/test/integ/repositories/limit-orders-repository.test.ts
@@ -545,7 +545,6 @@ describe('OrdersRepository update status test', () => {
       chainId_orderStatus: `${MOCK_ORDER_1.chainId}_${ORDER_STATUS.FILLED}`,
       chainId_orderStatus_filler: `${MOCK_ORDER_1.chainId}_${ORDER_STATUS.FILLED}_${(MOCK_ORDER_1 as any).filler}`,
       txHash: 'txHash',
-      fillBlock: 1,
       settledAmounts: [{ tokenOut: '0x1', amountOut: '1' }],
     })
   })

--- a/test/unit/models/DutchV3Order.test.ts
+++ b/test/unit/models/DutchV3Order.test.ts
@@ -27,6 +27,7 @@ describe('DutchV3 Model', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       100
     )
     const entity: UniswapXOrderEntity = order.toEntity(ORDER_STATUS.OPEN)
@@ -42,6 +43,7 @@ describe('DutchV3 Model', () => {
       MOCK_SIGNATURE,
       ChainId.ARBITRUM_ONE,
       ORDER_STATUS.OPEN,
+      undefined,
       undefined,
       undefined,
       undefined,


### PR DESCRIPTION
- Add `fillBlock` as one of the fields in an order's status
- Make this field show up in queries for DutchV3 orders