### PR TITLE
feat, test: flag for only posting metadata; default value support

### DIFF
--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -7,11 +7,7 @@ import { Unit } from 'aws-embedded-metrics'
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
 import { metrics } from '../../util/metrics'
 import { UnimindQueryParams, unimindQueryParamsSchema } from './schema'
-
-const DEFAULT_UNIMIND_PARAMETERS = {
-  pi: 5,
-  tau: 5
-}
+import { DEFAULT_UNIMIND_PARAMETERS } from '../../util/constants'
 
 type UnimindResponse = {
   pi: number
@@ -26,13 +22,13 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
     const { quoteMetadataRepository, unimindParametersRepository } = containerInjected
     
     try {
-      const { expectParams, ...quoteMetadataFields } = requestQueryParams
+      const { logOnly, ...quoteMetadataFields } = requestQueryParams
       const quoteMetadata = {
         ...quoteMetadataFields,
         route: JSON.parse(requestQueryParams.route)
       }
       // For requests that don't expect params, we only save the quote metadata and return
-      if (!expectParams) { 
+      if (logOnly) { 
         await quoteMetadataRepository.put(quoteMetadata)
         return {
           statusCode: 200,

--- a/lib/handlers/get-unimind/schema/index.ts
+++ b/lib/handlers/get-unimind/schema/index.ts
@@ -38,10 +38,10 @@ export const unimindQueryParamsSchema = Joi.object({
       'string.invalidJson': 'route must be a valid JSON string',
       'string.routeInvalid': 'route structure is invalid after parsing'
     }),
-  expectParams: Joi.boolean().required()
+  logOnly: Joi.boolean().optional()
 })
 
 export type UnimindQueryParams = Omit<QuoteMetadata, 'route'> & {
   route: string, // route is now a JSON string to be used as a GET query param
-  expectParams: boolean
+  logOnly?: boolean
 }

--- a/lib/handlers/get-unimind/schema/index.ts
+++ b/lib/handlers/get-unimind/schema/index.ts
@@ -37,9 +37,11 @@ export const unimindQueryParamsSchema = Joi.object({
     .messages({
       'string.invalidJson': 'route must be a valid JSON string',
       'string.routeInvalid': 'route structure is invalid after parsing'
-    })
+    }),
+  expectParams: Joi.boolean().required()
 })
 
 export type UnimindQueryParams = Omit<QuoteMetadata, 'route'> & {
-  route: string // route is now a JSON string to be used as a GET query param
+  route: string, // route is now a JSON string to be used as a GET query param
+  expectParams: boolean
 }

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -23,3 +23,8 @@ export const BLOCK_RANGE = 10000
 export const CRON_MAX_ATTEMPTS = 10
 //Dynamo limits batch write to 25
 export const DYNAMO_BATCH_WRITE_MAX = 25
+
+export const DEFAULT_UNIMIND_PARAMETERS = {
+  pi: 5,
+  tau: 5
+}

--- a/test/unit/handlers/get-unimind/get-unimind.test.ts
+++ b/test/unit/handlers/get-unimind/get-unimind.test.ts
@@ -53,10 +53,6 @@ describe('Testing get unimind handler', () => {
       priceImpact: 0.01,
       route: STRINGIFIED_ROUTE,
     }
-    const quoteQueryParams = {
-      ...quoteMetadata,
-      expectParams: true
-    }
 
     mockUnimindParametersRepo.getByPair.mockResolvedValue({
       pair: 'ETH-USDC',
@@ -66,7 +62,7 @@ describe('Testing get unimind handler', () => {
 
     const response = await getUnimindHandler.handler(
       {
-        queryStringParameters: quoteQueryParams,
+        queryStringParameters: quoteMetadata,
         requestContext: {
           requestId: 'test-request-id'
         }
@@ -96,16 +92,11 @@ describe('Testing get unimind handler', () => {
       route: STRINGIFIED_ROUTE,
     }
 
-    const quoteQueryParams = {
-      ...quoteMetadata,
-      expectParams: true
-    }
-
     mockUnimindParametersRepo.getByPair.mockResolvedValue(undefined)
 
     const response = await getUnimindHandler.handler(
       {
-        queryStringParameters: quoteQueryParams,
+        queryStringParameters: quoteMetadata,
         requestContext: {
           requestId: 'test-request-id'
         }
@@ -137,7 +128,7 @@ describe('Testing get unimind handler', () => {
 
     const quoteQueryParams = {
       ...quoteMetadata,
-      expectParams: false
+      logOnly: true
     }
 
     const response = await getUnimindHandler.handler(
@@ -175,7 +166,7 @@ describe('Testing get unimind handler', () => {
 
     const quoteQueryParams = {
       ...quoteMetadata,
-      expectParams: false
+      logOnly: true
     }
 
     // This pair does not exist in unimindParametersRepository
@@ -257,16 +248,11 @@ describe('Testing get unimind handler', () => {
       route: STRINGIFIED_ROUTE,
     }
 
-    const quoteQueryParams = {
-      ...quoteMetadata,
-      expectParams: true
-    }
-
     mockQuoteMetadataRepo.put.mockRejectedValue(new Error('DB Error'))
 
     const response = await getUnimindHandler.handler(
       {
-        queryStringParameters: quoteQueryParams,
+        queryStringParameters: quoteMetadata,
         requestContext: {
           requestId: 'test-request-id-repo-error'
         }


### PR DESCRIPTION
- Add flag for orders that don't require parameters returned (only seeking to have quote metadata posted)
- Use default values when it's a newly seen pair & append to unimind table
- Tests