### PR TITLE
feat, test: enforce strict logOnly parameters

### DIFF
--- a/lib/handlers/get-unimind/schema/index.ts
+++ b/lib/handlers/get-unimind/schema/index.ts
@@ -39,6 +39,10 @@ export const unimindQueryParamsSchema = Joi.object({
       'string.routeInvalid': 'route structure is invalid after parsing'
     }),
   logOnly: Joi.boolean().optional()
+    .truthy('true')
+    .falsy('false')
+    .sensitive()
+    // All other values are rejected for a 400 error
 })
 
 export type UnimindQueryParams = Omit<QuoteMetadata, 'route'> & {


### PR DESCRIPTION
- Case-sensitive acceptance of logOnly
- Non-booleans are not accepted
- Tests