### PR TITLE
feat, test: allow route in metadata to be optional

### DIFF
--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -25,7 +25,7 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
       const { logOnly, ...quoteMetadataFields } = requestQueryParams
       const quoteMetadata = {
         ...quoteMetadataFields,
-        route: JSON.parse(requestQueryParams.route)
+        route: requestQueryParams.route ? JSON.parse(requestQueryParams.route) : undefined
       }
       // For requests that don't expect params, we only save the quote metadata and return
       if (logOnly) { 

--- a/lib/handlers/get-unimind/schema/index.ts
+++ b/lib/handlers/get-unimind/schema/index.ts
@@ -21,7 +21,7 @@ export const unimindQueryParamsSchema = Joi.object({
   referencePrice: Joi.string().required(),
   priceImpact: Joi.number().required(),
   route: Joi.string()
-    .required()
+    .optional()
     .custom((value, helpers) => {
       try {
         const parsed = JSON.parse(value)

--- a/lib/repositories/quote-metadata-repository.ts
+++ b/lib/repositories/quote-metadata-repository.ts
@@ -53,8 +53,8 @@ export class DynamoQuoteMetadataRepository implements QuoteMetadataRepository {
         quoteId: { partitionKey: true, type: DYNAMODB_TYPES.STRING },
         referencePrice: { type: DYNAMODB_TYPES.STRING, required: true },
         priceImpact: { type: DYNAMODB_TYPES.NUMBER, required: true },
-        route: {type: DYNAMODB_TYPES.MAP, required: true},
-        pair: {type: DYNAMODB_TYPES.STRING, required: true}
+        pair: {type: DYNAMODB_TYPES.STRING, required: true},
+        route: {type: DYNAMODB_TYPES.MAP, required: false}
       },
       table,
     } as const)

--- a/test/unit/handlers/get-unimind/get-unimind.test.ts
+++ b/test/unit/handlers/get-unimind/get-unimind.test.ts
@@ -409,5 +409,27 @@ describe('Testing get unimind handler', () => {
     expect(response.statusCode).toBe(200)
     expect(mockQuoteMetadataRepo.put).toHaveBeenCalledTimes(1)
     expect(mockUnimindParametersRepo.getByPair).toHaveBeenCalledTimes(1)
-  }) 
+  })
+
+  it('Allow route to be optional', async () => {
+    const quoteMetadata = {
+      quoteId: 'test-quote-id',
+      referencePrice: '4221.21',
+      priceImpact: 0.01,
+      pair: 'ETH-USDC',
+      // missing route
+    }
+
+    const response = await getUnimindHandler.handler(
+      {
+        queryStringParameters: quoteMetadata,
+        requestContext: { requestId: 'test-request-id' }
+      } as any,
+      EVENT_CONTEXT
+    )
+
+    expect(response.statusCode).toBe(200)
+    expect(mockQuoteMetadataRepo.put).toHaveBeenCalledTimes(1)
+    expect(mockUnimindParametersRepo.getByPair).toHaveBeenCalledTimes(1)
+  })
 }) 


### PR DESCRIPTION
- When hitting Unimind endpoint with quote metadata, the route field will be optional