### PR TITLE
Migrate Reaper to a step function

### DIFF
--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -14,45 +14,11 @@ export interface CronStackProps extends cdk.NestedStackProps {
 }
 
 export class CronStack extends cdk.NestedStack {
-  public readonly gsReaperCronLambda?: aws_lambda_nodejs.NodejsFunction
   public readonly unimindAlgorithmCronLambda?: aws_lambda_nodejs.NodejsFunction
 
   constructor(scope: Construct, name: string, props: CronStackProps) {
     super(scope, name, props)
-    const { lambdaRole, envVars } = props
-
-    this.gsReaperCronLambda = new aws_lambda_nodejs.NodejsFunction(this, 'gsReaperCronLambda', {
-      role: lambdaRole,
-      runtime: cdk.aws_lambda.Runtime.NODEJS_18_X,
-      entry: path.join(__dirname, '../../lib/crons/gs-reaper.ts'),
-      handler: 'handler',
-      timeout: cdk.Duration.minutes(15),
-      memorySize: 512,
-      bundling: {
-        minify: true,
-        sourceMap: true,
-      },
-      environment: {
-        NODE_OPTIONS: '--enable-source-maps',
-        ...envVars,
-      },
-    })
-    new aws_events.Rule(this, `${SERVICE_NAME}GSReaperCron`, {
-      schedule: aws_events.Schedule.rate(cdk.Duration.days(1)),
-      targets: [new cdk.aws_events_targets.LambdaFunction(this.gsReaperCronLambda)],
-    })
-
-    new cdk.aws_cloudwatch.Alarm(this, `ReaperErrorAlarmSev3`, {
-      alarmName: `${SERVICE_NAME}-SEV3-ReaperError`,
-      metric: new cdk.aws_cloudwatch.Metric({
-        period: cdk.Duration.days(1),
-        metricName: 'DeleteStaleOrdersError',
-        namespace: 'Uniswap',
-        statistic: 'sum',
-      }),
-      threshold: 1,
-      evaluationPeriods: 1,
-    })
+    const { lambdaRole } = props
 
     this.unimindAlgorithmCronLambda = new aws_lambda_nodejs.NodejsFunction(this, 'unimindAlgorithmCronLambda', {
       role: lambdaRole,

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -10,6 +10,9 @@ import { SUPPORTED_CHAINS } from '../../lib/util/chain'
 import { STAGE } from '../../lib/util/stage'
 import { SERVICE_NAME } from '../constants'
 import orderStatusTrackingStateMachine from '../definitions/order-tracking-sfn.json'
+import { aws_stepfunctions, aws_events } from 'aws-cdk-lib'
+import * as aws_events_targets from 'aws-cdk-lib/aws-events-targets'
+import * as aws_stepfunctions_tasks from 'aws-cdk-lib/aws-stepfunctions-tasks'
 
 export class StepFunctionStack extends cdk.NestedStack {
   public chainIdToStatusTrackingStateMachineArn: { [key: string]: string } = {}
@@ -213,5 +216,72 @@ export class StepFunctionStack extends cdk.NestedStack {
         sev3ExpiredRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
       }
     }
+
+    // Add GS Reaper Step Function
+    const gsReaperFunction = new NodejsFunction(this, `${SERVICE_NAME}-${stage}-GSReaperLambda`, {
+      runtime: aws_lambda.Runtime.NODEJS_18_X,
+      role: props.lambdaRole,
+      entry: path.join(__dirname, '../../lib/crons/gs-reaper.ts'),
+      handler: 'handler',
+      memorySize: 1024,
+      bundling: {
+        minify: true,
+        sourceMap: true,
+      },
+      timeout: Duration.seconds(300),
+      environment: {
+        VERSION: '1',
+        NODE_OPTIONS: '--enable-source-maps',
+        ...props.envVars,
+        stage: stage,
+      },
+    })
+
+    const gsReaperTask = new aws_stepfunctions_tasks.LambdaInvoke(this, 'InvokeGSReaper', {
+      lambdaFunction: gsReaperFunction,
+      resultPath: '$.result',
+      retryOnServiceExceptions: true,
+    })
+
+    const gsReaperDefinition = aws_stepfunctions.Chain.start(
+      gsReaperTask.next(
+        new aws_stepfunctions.Choice(this, 'CheckContinue')
+          .when(
+            aws_stepfunctions.Condition.isNotNull('$.result.Payload'),
+            new aws_stepfunctions.Wait(this, 'Wait5Seconds', {
+              time: aws_stepfunctions.WaitTime.duration(Duration.seconds(5)),
+            }).next(
+              new aws_stepfunctions.Pass(this, 'ContinueExecution', {
+                inputPath: '$.result.Payload',
+              }).next(gsReaperTask)
+            )
+          )
+          .otherwise(new aws_stepfunctions.Succeed(this, 'Done'))
+      )
+    )
+
+    const gsReaperStateMachine = new aws_stepfunctions.StateMachine(this, `${SERVICE_NAME}-${stage}-GSReaper`, {
+      definition: gsReaperDefinition,
+      timeout: Duration.days(1),
+      role: stateMachineRole,
+    })
+
+    // Schedule the GS Reaper to run every day
+    new aws_events.Rule(this, 'GSReaperSchedule', {
+      schedule: aws_events.Schedule.rate(Duration.days(1)),
+      targets: [new aws_events_targets.SfnStateMachine(gsReaperStateMachine)],
+    })
+
+    new cdk.aws_cloudwatch.Alarm(this, `ReaperErrorAlarmSev3`, {
+      alarmName: `${SERVICE_NAME}-SEV3-${stage}-ReaperError`,
+      metric: new cdk.aws_cloudwatch.Metric({
+        period: Duration.days(1),
+        metricName: 'DeleteStaleOrdersError',
+        namespace: 'Uniswap',
+        statistic: 'sum',
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+    })
   }
 }

--- a/lib/crons/gs-reaper.ts
+++ b/lib/crons/gs-reaper.ts
@@ -1,44 +1,16 @@
-import { EventBridgeEvent, ScheduledHandler } from 'aws-lambda'
+import { EventBridgeEvent } from 'aws-lambda'
 import { DynamoDB } from 'aws-sdk'
 import { default as bunyan, default as Logger } from 'bunyan'
 import { metricScope, MetricsLogger, Unit } from 'aws-embedded-metrics'
 import { ORDER_STATUS, SettledAmount, UniswapXOrderEntity } from '../entities'
 import { BaseOrdersRepository, QueryResult } from '../repositories/base'
 import { DutchOrdersRepository } from '../repositories/dutch-orders-repository'
-import { BLOCK_RANGE, CRON_MAX_ATTEMPTS, DYNAMO_BATCH_WRITE_MAX, OLDEST_BLOCK_BY_CHAIN } from '../util/constants'
+import { BLOCK_RANGE, REAPER_MAX_ATTEMPTS, DYNAMO_BATCH_WRITE_MAX, OLDEST_BLOCK_BY_CHAIN, REAPER_RANGES_PER_RUN } from '../util/constants'
 import { ethers } from 'ethers'
 import { CosignedPriorityOrder, CosignedV2DutchOrder, CosignedV3DutchOrder, DutchOrder, OrderType, OrderValidation, OrderValidator, REACTOR_ADDRESS_MAPPING, UniswapXEventWatcher, UniswapXOrder } from '@uniswap/uniswapx-sdk'
 import { parseOrder } from '../handlers/OrderParser'
 import { getSettledAmounts } from '../handlers/check-order-status/util'
 import { ChainId } from '../util/chain'
-
-export const handler: ScheduledHandler = metricScope((metrics) => async (_event: EventBridgeEvent<string, void>) => {
-  await main(metrics)
-})
-
-/**
- * The Reaper is a cron job that runs daily and checks for any orphaned orders
- * that have been filled, cancelled or expired
- * @param metrics - The metrics logger
- */
-async function main(metrics: MetricsLogger) {
-  metrics.setNamespace('Uniswap')
-  metrics.setDimensions({ Service: 'UniswapXServiceCron' })
-  const log: Logger = bunyan.createLogger({
-    name: 'DynamoReaperCron',
-    serializers: bunyan.stdSerializers,
-    level: 'info',
-  })
-  const repo = DutchOrdersRepository.create(new DynamoDB.DocumentClient())
-  const providers = new Map<ChainId, ethers.providers.StaticJsonRpcProvider>()
-  for (const chainIdKey of Object.keys(OLDEST_BLOCK_BY_CHAIN)) {
-    const chainId = Number(chainIdKey) as keyof typeof OLDEST_BLOCK_BY_CHAIN
-    const rpcURL = process.env[`RPC_${chainId}`]
-    const provider = new ethers.providers.StaticJsonRpcProvider(rpcURL, chainId)
-    providers.set(chainId, provider)
-  }
-  await cleanupOrphanedOrders(repo, providers, log, metrics)
-}
 
 type OrderUpdate = {
   status: ORDER_STATUS,
@@ -47,136 +19,274 @@ type OrderUpdate = {
   settledAmounts?: SettledAmount[]
 }
 
-export async function cleanupOrphanedOrders(
-  repo: BaseOrdersRepository<UniswapXOrderEntity>,
-  providers: Map<ChainId, ethers.providers.StaticJsonRpcProvider>,
-  log: Logger,
-  metrics?: MetricsLogger
-): Promise<void> {
+type StepFunctionState = {
+  chainId: number
+  currentBlock: number
+  earliestBlock: number
+  orderUpdates: Record<string, OrderUpdate>
+  parsedOrders: Record<string, { order: UniswapXOrder; signature: string; deadline: number }>
+  stage: 'INIT' | 'PROCESS_BLOCKS' | 'CHECK_CANCELLED' | 'UPDATE_DB'
+}
+
+export const handler = metricScope((metrics) => async (event: StepFunctionState | EventBridgeEvent<string, void>): Promise<StepFunctionState | void> => {
+  metrics.setNamespace('Uniswap')
+  metrics.setDimensions({ Service: 'UniswapXServiceCron' })
   
+  const log: Logger = bunyan.createLogger({
+    name: 'DynamoReaperCron',
+    serializers: bunyan.stdSerializers,
+    level: 'info',
+  })
+  
+  const repo = DutchOrdersRepository.create(new DynamoDB.DocumentClient())
+  const providers = new Map<ChainId, ethers.providers.StaticJsonRpcProvider>()
   for (const chainIdKey of Object.keys(OLDEST_BLOCK_BY_CHAIN)) {
     const chainId = Number(chainIdKey) as keyof typeof OLDEST_BLOCK_BY_CHAIN
-    const provider = providers.get(chainId)
+    const rpcURL = process.env[`RPC_${chainId}`]
+    const provider = new ethers.providers.StaticJsonRpcProvider(rpcURL, chainId)
+    providers.set(chainId, provider)
+  }
+
+  // Initialize if this is the first run (is EventBridgeEvent)
+  if ('time' in event) {
+    const firstChainId = Number(Object.keys(OLDEST_BLOCK_BY_CHAIN)[0])
+    const provider = providers.get(firstChainId)
     if (!provider) {
-      log.error(`No provider found for chainId ${chainId}`)
-      continue
+      throw new Error(`No provider found for chainId ${firstChainId}`)
+    }
+    const currentBlock = await provider.getBlockNumber()
+    return {
+      chainId: firstChainId,
+      currentBlock,
+      earliestBlock: OLDEST_BLOCK_BY_CHAIN[firstChainId as keyof typeof OLDEST_BLOCK_BY_CHAIN],
+      orderUpdates: {},
+      parsedOrders: {},
+      stage: 'INIT'
+    }
+  }
+
+  const state = event as StepFunctionState
+  const provider = providers.get(state.chainId)
+  if (!provider) {
+    throw new Error(`No provider found for chainId ${state.chainId}`)
+  }
+
+  switch (state.stage) {
+    case 'INIT': {
+      const parsedOrdersMap = await getParsedOrders(repo, state.chainId)
+      return {
+        ...state,
+        parsedOrders: Object.fromEntries(parsedOrdersMap),
+        stage: 'PROCESS_BLOCKS'
+      }
     }
 
-    // get a map of all open orders from the database
-    const parsedOrders = await getParsedOrders(repo, chainId)
-    const orderUpdates = new Map<string, OrderUpdate>()
+    case 'PROCESS_BLOCKS': {
+      // Process multiple block ranges before returning
+      for (let i = 0; i < REAPER_RANGES_PER_RUN; i++) {
+        const nextBlock = state.currentBlock - BLOCK_RANGE
+        const orderUpdates = await processBlockRange(
+          state.currentBlock,
+          nextBlock,
+          state.chainId,
+          state.parsedOrders,
+          provider,
+          state.orderUpdates,
+          log,
+          metrics
+        )
 
-    // Look through events to find if any of the orders have been filled
-    for (const orderType of Object.keys(REACTOR_ADDRESS_MAPPING[chainId])){
-      const reactorAddress = REACTOR_ADDRESS_MAPPING[chainId][orderType as OrderType]
-      if (!reactorAddress) continue
-      const watcher = new UniswapXEventWatcher(provider, reactorAddress)
-      const lastProcessedBlock = await provider.getBlockNumber()
-      let recentErrors = 0
-      const earliestBlock = OLDEST_BLOCK_BY_CHAIN[chainId]
-      // TODO: Lookback 1.2 days
-      // const msPerDay = 1000 * 60 * 60 * 24 * 1.2
-      // const blocksPerDay = msPerDay / BLOCK_TIME_MS_BY_CHAIN[chainId]
-      // const earliestBlock = lastProcessedBlock - blocksPerDay
+        state.currentBlock = nextBlock
+        state.orderUpdates = orderUpdates
 
-      for (let i = lastProcessedBlock; i > earliestBlock; i -= BLOCK_RANGE) {
-        let attempts = 0
-        while (attempts < CRON_MAX_ATTEMPTS) {
-          try {
-            log.info(`Getting fill events for blocks ${i - BLOCK_RANGE} to ${i}`)
-            const fillEvents = await watcher.getFillEvents(i - BLOCK_RANGE, i)
-            recentErrors = Math.max(0, recentErrors - 1)
-            await Promise.all(fillEvents.map(async (e) => {
-              if (parsedOrders.has(e.orderHash)) {
-                log.info(`Fill event found for order ${e.orderHash}`)
-                // Only get fill info when we know there's a matching event in this
-                // range due to additional RPC calls that are required for fill info
-                const fillInfo = await watcher.getFillInfo(i - BLOCK_RANGE, i)
-                const fillEvent = fillInfo.find((f) => f.orderHash === e.orderHash)
-                if (fillEvent) {
-                const [tx, block] = await Promise.all([
-                  provider.getTransaction(fillEvent.txHash),
-                  provider.getBlock(fillEvent.blockNumber),
-                ])
-                const settledAmounts = getSettledAmounts(
-                  fillEvent,
-                  {
-                    timestamp: block.timestamp,
-                    gasPrice: tx.gasPrice,
-                    maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
-                    maxFeePerGas: tx.maxFeePerGas,
-                  },
-                    parsedOrders.get(e.orderHash)?.order as DutchOrder | CosignedV2DutchOrder | CosignedV3DutchOrder | CosignedPriorityOrder
-                  )
-                  orderUpdates.set(e.orderHash, {
-                    status: ORDER_STATUS.FILLED,
-                    txHash: fillEvent.txHash,
-                    fillBlock: fillEvent.blockNumber,
-                    settledAmounts: settledAmounts,
-                  })
-                }
-                else {
-                  orderUpdates.set(e.orderHash, {
-                    status: ORDER_STATUS.FILLED,
-                  })
-                }
-              }
-            }))
-
-            break // Success - exit the retry loop
-          } catch (error) {
-            attempts++
-            recentErrors++
-            console.log(`Failed to get fill events for blocks ${i - BLOCK_RANGE} to ${i}, error: ${error}`)
-            log.error({ error }, `Failed to get fill events for blocks ${i - BLOCK_RANGE} to ${i}`)
-            if (attempts === CRON_MAX_ATTEMPTS) {
-              log.error({ error }, `Failed to get fill events after ${attempts} attempts for blocks ${i - BLOCK_RANGE} to ${i}`)
-              metrics?.putMetric(`GetFillEventsError`, 1, Unit.Count)
-              break // Skip this range and continue with the next one
-            }
-            // Wait time is determined by the number of recent errors
-            await new Promise(resolve => setTimeout(resolve, 1000 * recentErrors))
+        if (nextBlock <= state.earliestBlock) {
+          return {
+            ...state,
+            stage: 'CHECK_CANCELLED'
           }
         }
       }
-    }
 
-    // Loop through unfilled orders and see if they were cancelled
-    const quoter = new OrderValidator(provider, chainId)
-      for (const orderHash of parsedOrders.keys()) {
-        if (!orderUpdates.has(orderHash)) {
-        const validation = await quoter.validate({
-          order: parsedOrders.get(orderHash)!.order,
-          signature: parsedOrders.get(orderHash)!.signature,
-        })
-        if (validation === OrderValidation.NonceUsed) {
-          orderUpdates.set(orderHash, {
-            status: ORDER_STATUS.CANCELLED,
-          })
-        }
-        if (validation === OrderValidation.Expired) {
-          orderUpdates.set(orderHash, {
-            status: ORDER_STATUS.EXPIRED,
-          })
-        }
+      return {
+        ...state,
+        stage: 'PROCESS_BLOCKS'
       }
     }
 
-    // Update the orders in the database
-    log.info(`Updating ${orderUpdates.size} incorrect orders`)
-    for (const [orderHash, orderUpdate] of orderUpdates) {
-      await repo.updateOrderStatus(
-        orderHash,
-        orderUpdate.status,
-        orderUpdate.txHash,
-        orderUpdate.fillBlock,
-        orderUpdate.settledAmounts
+    case 'CHECK_CANCELLED': {
+      const orderUpdates = await checkCancelledOrders(
+        state.parsedOrders,
+        state.orderUpdates,
+        provider,
+        state.chainId
       )
-
-      metrics?.putMetric(`UpdateOrderStatus_${orderUpdate.status}`, 1, Unit.Count)
+      
+      return {
+        ...state,
+        orderUpdates,
+        stage: 'UPDATE_DB'
+      }
     }
-    log.info(`Update complete`)
+
+    case 'UPDATE_DB': {
+      await updateOrders(repo, state.orderUpdates, log, metrics)
+      
+      const chainIds = Object.keys(OLDEST_BLOCK_BY_CHAIN).map(Number)
+      const currentChainIndex = chainIds.indexOf(state.chainId)
+      
+      // We're done
+      if (currentChainIndex === chainIds.length - 1) {
+        return
+      }
+
+      const nextChainId = chainIds[currentChainIndex + 1]
+      const nextProvider = providers.get(nextChainId)
+      if (!nextProvider) {
+        throw new Error(`No provider found for chainId ${nextChainId}`)
+      }
+      const currentBlock = await nextProvider.getBlockNumber()
+      return {
+        chainId: nextChainId,
+        currentBlock,
+        earliestBlock: OLDEST_BLOCK_BY_CHAIN[nextChainId as keyof typeof OLDEST_BLOCK_BY_CHAIN],
+        orderUpdates: {},
+        parsedOrders: {},
+        stage: 'INIT'
+      }
+    }
   }
+})
+
+async function processBlockRange(
+  fromBlock: number,
+  toBlock: number,
+  chainId: number,
+  parsedOrders: Record<string, { order: UniswapXOrder; signature: string; deadline: number }>,
+  provider: ethers.providers.StaticJsonRpcProvider,
+  existingUpdates: Record<string, OrderUpdate>,
+  log: Logger,
+  metrics?: MetricsLogger
+): Promise<Record<string, OrderUpdate>> {
+  const orderUpdates = { ...existingUpdates }
+  const parsedOrdersMap = new Map(Object.entries(parsedOrders))
+  
+  for (const orderType of Object.keys(REACTOR_ADDRESS_MAPPING[chainId])) {
+    const reactorAddress = REACTOR_ADDRESS_MAPPING[chainId][orderType as OrderType]
+    if (!reactorAddress) continue
+    
+    const watcher = new UniswapXEventWatcher(provider, reactorAddress)
+    let attempts = 0
+    let recentErrors = 0
+
+    while (attempts < REAPER_MAX_ATTEMPTS) {
+      try {
+        log.info(`Getting fill events for blocks ${toBlock} to ${fromBlock}`)
+        const fillEvents = await watcher.getFillEvents(toBlock, fromBlock)
+        recentErrors = Math.max(0, recentErrors - 1)
+        
+        await Promise.all(fillEvents.map(async (e) => {
+          if (parsedOrdersMap.has(e.orderHash)) {
+            log.info(`Fill event found for order ${e.orderHash}`)
+            const fillInfo = await watcher.getFillInfo(toBlock, fromBlock)
+            const fillEvent = fillInfo.find((f) => f.orderHash === e.orderHash)
+            if (fillEvent) {
+              const [tx, block] = await Promise.all([
+                provider.getTransaction(fillEvent.txHash),
+                provider.getBlock(fillEvent.blockNumber),
+              ])
+              const settledAmounts = getSettledAmounts(
+                fillEvent,
+                {
+                  timestamp: block.timestamp,
+                  gasPrice: tx.gasPrice,
+                  maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+                  maxFeePerGas: tx.maxFeePerGas,
+                },
+                parsedOrdersMap.get(e.orderHash)?.order as DutchOrder | CosignedV2DutchOrder | CosignedV3DutchOrder | CosignedPriorityOrder
+              )
+              orderUpdates[e.orderHash] = {
+                status: ORDER_STATUS.FILLED,
+                txHash: fillEvent.txHash,
+                fillBlock: fillEvent.blockNumber,
+                settledAmounts: settledAmounts,
+              }
+            } else {
+              orderUpdates[e.orderHash] = {
+                status: ORDER_STATUS.FILLED,
+              }
+            }
+          }
+        }))
+        break
+      } catch (error) {
+        attempts++
+        recentErrors++
+        log.error({ error }, `Failed to get fill events for blocks ${toBlock} to ${fromBlock}`)
+        if (attempts === REAPER_MAX_ATTEMPTS) {
+          log.error({ error }, `Failed to get fill events after ${attempts} attempts for blocks ${toBlock} to ${fromBlock}`)
+          metrics?.putMetric(`GetFillEventsError`, 1, Unit.Count)
+          break
+        }
+        await new Promise(resolve => setTimeout(resolve, 1000 * recentErrors))
+      }
+    }
+  }
+
+  return orderUpdates
+}
+
+async function checkCancelledOrders(
+  parsedOrders: Record<string, { order: UniswapXOrder; signature: string; deadline: number }>,
+  existingUpdates: Record<string, OrderUpdate>,
+  provider: ethers.providers.StaticJsonRpcProvider,
+  chainId: number
+): Promise<Record<string, OrderUpdate>> {
+  const orderUpdates = { ...existingUpdates }
+  const quoter = new OrderValidator(provider, chainId)
+  
+  for (const [orderHash, orderData] of Object.entries(parsedOrders)) {
+    if (!orderUpdates[orderHash]) {
+      const validation = await quoter.validate({
+        order: orderData.order,
+        signature: orderData.signature,
+      })
+      if (validation === OrderValidation.NonceUsed) {
+        orderUpdates[orderHash] = {
+          status: ORDER_STATUS.CANCELLED,
+        }
+      }
+      if (validation === OrderValidation.Expired) {
+        orderUpdates[orderHash] = {
+          status: ORDER_STATUS.EXPIRED,
+        }
+      }
+    }
+  }
+  
+  return orderUpdates
+}
+
+async function updateOrders(
+  repo: BaseOrdersRepository<UniswapXOrderEntity>,
+  orderUpdates: Record<string, OrderUpdate>,
+  log: Logger,
+  metrics?: MetricsLogger
+): Promise<void> {
+  log.info(`Updating ${Object.keys(orderUpdates).length} incorrect orders`)
+  
+  for (const [orderHash, orderUpdate] of Object.entries(orderUpdates)) {
+    await repo.updateOrderStatus(
+      orderHash,
+      orderUpdate.status,
+      orderUpdate.txHash,
+      orderUpdate.fillBlock,
+      orderUpdate.settledAmounts
+    )
+
+    metrics?.putMetric(`UpdateOrderStatus_${orderUpdate.status}`, 1, Unit.Count)
+  }
+  
+  log.info(`Update complete`)
 }
 
 /**

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -20,7 +20,8 @@ export const BLOCK_TIME_MS_BY_CHAIN = {
   [ChainId.UNICHAIN]: 1000,
 }
 export const BLOCK_RANGE = 10000
-export const CRON_MAX_ATTEMPTS = 10
+export const REAPER_MAX_ATTEMPTS = 10
+export const REAPER_RANGES_PER_RUN = 10
 //Dynamo limits batch write to 25
 export const DYNAMO_BATCH_WRITE_MAX = 25
 

--- a/test/unit/handlers/gs-reaper/gs-reaper.test.ts
+++ b/test/unit/handlers/gs-reaper/gs-reaper.test.ts
@@ -5,10 +5,12 @@ import { default as bunyan, default as Logger } from 'bunyan'
 import { deleteStaleOrders } from '../../../../lib/crons/gs-reaper'
 import { ORDER_STATUS } from '../../../../lib/entities'
 import { DutchOrdersRepository } from '../../../../lib/repositories/dutch-orders-repository'
-import { BLOCK_RANGE, OLDEST_BLOCK_BY_CHAIN } from '../../../../lib/util/constants'
+import { BLOCK_RANGE, REAPER_RANGES_PER_RUN, OLDEST_BLOCK_BY_CHAIN } from '../../../../lib/util/constants'
 import { ChainId } from '../../../../lib/util/chain'
 import { cleanupOrphanedOrders } from '../../../../lib/crons/gs-reaper'
 import { MOCK_ORDER_ENTITY, MOCK_V2_ORDER_ENTITY } from '../../../test-data'
+import { handler } from '../../../../lib/crons/gs-reaper'
+import { parseOrder } from '../../../../lib/handlers/OrderParser'
 
 const dynamoConfig = {
   convertEmptyValues: true,
@@ -71,18 +73,31 @@ const mockProviders = new Map<ChainId, ethers.providers.StaticJsonRpcProvider>()
 for (const chainIdKey of Object.keys(OLDEST_BLOCK_BY_CHAIN)) {
   const chainId = Number(chainIdKey)
   const mockProvider = {
-    getBlockNumber: jest.fn().mockResolvedValue(OLDEST_BLOCK_BY_CHAIN[chainId] + BLOCK_RANGE),
+    getBlockNumber: jest.fn().mockResolvedValue(OLDEST_BLOCK_BY_CHAIN[chainId] + BLOCK_RANGE * REAPER_RANGES_PER_RUN),
     getTransaction: jest.fn().mockResolvedValue({
       gasPrice: '1000000000',
       maxPriorityFeePerGas: null,
       maxFeePerGas: null,
     }),
-  getBlock: jest.fn().mockResolvedValue({
-    timestamp: Date.now() / 1000,
-  }),
+    getBlock: jest.fn().mockResolvedValue({
+      timestamp: Date.now() / 1000,
+    }),
   }
-  mockProviders.set(chainId, mockProvider);
+  mockProviders.set(chainId, mockProvider as unknown as ethers.providers.StaticJsonRpcProvider);
 }
+
+// Mock ethers
+jest.mock('ethers', () => ({
+  ...jest.requireActual('ethers'),
+  ethers: {
+    ...jest.requireActual('ethers').ethers,
+    providers: {
+      StaticJsonRpcProvider: jest.fn().mockImplementation((url, chainId) => {
+        return mockProviders.get(chainId)
+      })
+    }
+  }
+}))
 
 // Setup mock watcher
 const mockFillBlockNumber = OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET] + BLOCK_RANGE/2
@@ -139,11 +154,62 @@ jest.mock('../../../../lib/handlers/check-order-status/util', () => {
   }
 })
 
-describe('cleanupOrphanedOrders', () => {
+const mockMetrics = {
+  setNamespace: jest.fn(),
+  setDimensions: jest.fn(),
+  putMetric: jest.fn(),
+}
+
+// Mock the aws-embedded-metrics module
+jest.mock('aws-embedded-metrics', () => ({
+  metricScope: (handler: Function) => {
+    return (event: any) => handler(mockMetrics)(event)
+  },
+  Unit: {
+    Count: 'Count'
+  }
+}))
+
+// Add AWS SDK mock before other mocks
+jest.mock('aws-sdk', () => {
+  return {
+    config: {
+      update: jest.fn()
+    },
+    DynamoDB: {
+      DocumentClient: jest.fn().mockImplementation(() => ({
+      }))
+    }
+  }
+})
+
+// Add mock for DutchOrdersRepository.create before the describe block
+jest.mock('../../../../lib/repositories/dutch-orders-repository', () => ({
+  DutchOrdersRepository: {
+    create: jest.fn().mockImplementation(() => mockOrdersRepository)
+  }
+}))
+
+describe('gs-reaper handler', () => {
   beforeEach(async () => {
+    // Configure AWS
+    const AWS = require('aws-sdk')
+    AWS.config.update({
+      region: 'local-env',
+      credentials: {
+        accessKeyId: 'fakeMyKeyId',
+        secretAccessKey: 'fakeSecretAccessKey'
+      }
+    })
+
     // Add test order to repository
     await mockOrdersRepository.addOrder(MOCK_ORDER_ENTITY)
     mockWatcher.getFillEvents.mockResolvedValue([{ orderHash: MOCK_V2_ORDER_ENTITY.orderHash }, { orderHash: MOCK_ORDER_ENTITY.orderHash }])
+    
+    // Clear metrics mocks
+    mockMetrics.setNamespace.mockClear()
+    mockMetrics.setDimensions.mockClear()
+    mockMetrics.putMetric.mockClear()
   })
 
   afterEach(async () => {
@@ -151,138 +217,136 @@ describe('cleanupOrphanedOrders', () => {
     jest.clearAllMocks()
   })
 
-  it('updates order status to FILLED when matching fill event is found', async () => {
-    await cleanupOrphanedOrders(mockOrdersRepository, mockProviders, log)
+  it('initializes state correctly from EventBridge event', async () => {
+    const eventBridgeEvent = { time: new Date().toISOString() }
+    const result = await handler(eventBridgeEvent)
 
-    // Verify order was updated
-    const updatedOrder = await mockOrdersRepository.getOrder(MOCK_ORDER_ENTITY.orderHash)
-    expect(updatedOrder?.orderStatus).toBe(ORDER_STATUS.FILLED)
-    expect(updatedOrder?.txHash).toBe('0xmocktxhash')
-    expect(updatedOrder?.fillBlock).toBe(mockFillBlockNumber)
-    expect(updatedOrder?.settledAmounts).toBeDefined()
-    expect(updatedOrder?.settledAmounts[0].tokenOut).toBe(MOCK_ORDER_ENTITY.outputs[0].token)
-    expect(updatedOrder?.settledAmounts[0].amountOut).toBe(MOCK_ORDER_ENTITY.outputs[0].startAmount)
-    expect(updatedOrder?.settledAmounts[0].tokenIn).toBe(MOCK_ORDER_ENTITY.input.token)
-    expect(updatedOrder?.settledAmounts[0].amountIn).toBe(MOCK_ORDER_ENTITY.input.startAmount)
+    expect(result).toEqual({
+      chainId: ChainId.MAINNET, // Mainnet is the first chain in the list
+      currentBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET] + BLOCK_RANGE * REAPER_RANGES_PER_RUN,
+      earliestBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET],
+      orderUpdates: {},
+      parsedOrders: {},
+      stage: 'INIT'
+    })
   })
 
-  it('updates order status to CANCELLED when nonce is used', async () => {
-    // Remove fill event from mock watcher
-    mockWatcher.getFillEvents.mockResolvedValue([])
-    
-    // Update the OrderValidator mock implementation for this test
+  it('processes INIT stage correctly', async () => {
+    const initialState = {
+      chainId: ChainId.MAINNET,
+      currentBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET] + BLOCK_RANGE * REAPER_RANGES_PER_RUN,
+      earliestBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET],
+      orderUpdates: {},
+      parsedOrders: {},
+      stage: 'INIT' as const
+    }
+
+    const result = await handler(initialState)
+
+    expect(result.stage).toBe('PROCESS_BLOCKS')
+    expect(result.parsedOrders).toBeDefined()
+    // parsedOrders should contain our mock order
+    expect(Object.keys(result.parsedOrders)).toContain(MOCK_ORDER_ENTITY.orderHash)
+  })
+
+  it('processes PROCESS_BLOCKS stage correctly', async () => {
+    const state = {
+      chainId: ChainId.MAINNET,
+      currentBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET] + BLOCK_RANGE * REAPER_RANGES_PER_RUN,
+      earliestBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET],
+      orderUpdates: {},
+      parsedOrders: {
+        [MOCK_ORDER_ENTITY.orderHash]: {
+          order: parseOrder(MOCK_ORDER_ENTITY, ChainId.MAINNET),
+          signature: MOCK_ORDER_ENTITY.signature,
+          deadline: MOCK_ORDER_ENTITY.deadline
+        }
+      },
+      stage: 'PROCESS_BLOCKS' as const
+    }
+
+    const result = await handler(state)
+
+    expect(result.stage).toBe('CHECK_CANCELLED')
+    expect(result.currentBlock).toBe(OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET])
+    expect(result.orderUpdates[MOCK_ORDER_ENTITY.orderHash]).toBeDefined()
+    expect(result.orderUpdates[MOCK_ORDER_ENTITY.orderHash].status).toBe(ORDER_STATUS.FILLED)
+  })
+
+  it('processes CHECK_CANCELLED stage correctly', async () => {
+    const state = {
+      chainId: ChainId.MAINNET,
+      currentBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET],
+      earliestBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET],
+      orderUpdates: {},
+      parsedOrders: {
+        [MOCK_ORDER_ENTITY.orderHash]: {
+          order: parseOrder(MOCK_ORDER_ENTITY, ChainId.MAINNET),
+          signature: MOCK_ORDER_ENTITY.signature,
+          deadline: MOCK_ORDER_ENTITY.deadline
+        }
+      },
+      stage: 'CHECK_CANCELLED' as const
+    }
+
+    // Update the OrderValidator mock to return NonceUsed
     const { OrderValidation } = jest.requireActual('@uniswap/uniswapx-sdk')
     const mockOrderValidator = jest.requireMock('@uniswap/uniswapx-sdk').OrderValidator
     mockOrderValidator.mockImplementation(() => ({
       validate: jest.fn().mockResolvedValue(OrderValidation.NonceUsed)
     }))
 
-    await cleanupOrphanedOrders(mockOrdersRepository, mockProviders, log)
+    const result = await handler(state)
 
-    // Verify order was updated
-    const updatedOrder = await mockOrdersRepository.getOrder(MOCK_ORDER_ENTITY.orderHash)
-    expect(updatedOrder?.orderStatus).toBe(ORDER_STATUS.CANCELLED)
-    expect(updatedOrder?.txHash).not.toBeDefined()
-    expect(updatedOrder?.fillBlock).not.toBeDefined()
-    expect(updatedOrder?.settledAmounts).not.toBeDefined()
+    expect(result.stage).toBe('UPDATE_DB')
+    expect(result.orderUpdates[MOCK_ORDER_ENTITY.orderHash]).toBeDefined()
+    expect(result.orderUpdates[MOCK_ORDER_ENTITY.orderHash].status).toBe(ORDER_STATUS.CANCELLED)
   })
 
-  it('updates order status to EXPIRED when deadline has passed', async () => {
-    // Remove fill event from mock watcher
-    mockWatcher.getFillEvents.mockResolvedValue([])
-    
-    // Update the OrderValidator mock implementation for this test
-    const { OrderValidation } = jest.requireActual('@uniswap/uniswapx-sdk')
-    const mockOrderValidator = jest.requireMock('@uniswap/uniswapx-sdk').OrderValidator
-    mockOrderValidator.mockImplementation(() => ({
-      validate: jest.fn().mockResolvedValue(OrderValidation.Expired)
-    }))
-
-    await cleanupOrphanedOrders(mockOrdersRepository, mockProviders, log)
-
-    // Verify order was updated
-    const updatedOrder = await mockOrdersRepository.getOrder(MOCK_ORDER_ENTITY.orderHash)
-    expect(updatedOrder?.orderStatus).toBe(ORDER_STATUS.EXPIRED)
-    expect(updatedOrder?.txHash).not.toBeDefined()
-    expect(updatedOrder?.fillBlock).not.toBeDefined()
-    expect(updatedOrder?.settledAmounts).not.toBeDefined()
-  })
-
-  it('updates order status remains OPEN when not filled, cancelled, or expired', async () => {
-    mockOrdersRepository.orders.clear()
-    const unexpiredOrder = { ...MOCK_ORDER_ENTITY, deadline: Date.now() / 1000 + 10000 }
-    await mockOrdersRepository.addOrder(unexpiredOrder)
-    // Remove fill event from mock watcher
-    mockWatcher.getFillEvents.mockResolvedValue([])
-    
-    // Update the OrderValidator mock implementation for this test
-    const { OrderValidation } = jest.requireActual('@uniswap/uniswapx-sdk')
-    const mockOrderValidator = jest.requireMock('@uniswap/uniswapx-sdk').OrderValidator
-    mockOrderValidator.mockImplementation(() => ({
-      validate: jest.fn().mockResolvedValue(OrderValidation.OK)
-    }))
-
-    await cleanupOrphanedOrders(mockOrdersRepository, mockProviders, log)
-
-    // Verify order remains OPEN
-    const updatedOrder = await mockOrdersRepository.getOrder(unexpiredOrder.orderHash)
-    expect(updatedOrder?.orderStatus).toBe(ORDER_STATUS.OPEN)
-    expect(updatedOrder?.txHash).not.toBeDefined()
-    expect(updatedOrder?.fillBlock).not.toBeDefined()
-    expect(updatedOrder?.settledAmounts).not.toBeDefined()
-  })
-
-  it('updates multiple order types on a single chain', async () => {
-    await mockOrdersRepository.addOrder(MOCK_V2_ORDER_ENTITY)
-    await cleanupOrphanedOrders(mockOrdersRepository, mockProviders, log)
-
-    // Verify order was updated
-    const updatedOrder = await mockOrdersRepository.getOrder(MOCK_ORDER_ENTITY.orderHash)
-    expect(updatedOrder?.orderStatus).toBe(ORDER_STATUS.FILLED)
-    expect(updatedOrder?.txHash).toBe('0xmocktxhash')
-    expect(updatedOrder?.fillBlock).toBe(mockFillBlockNumber)
-    expect(updatedOrder?.settledAmounts).toBeDefined()
-    expect(updatedOrder?.settledAmounts[0].tokenOut).toBe(MOCK_ORDER_ENTITY.outputs[0].token)
-    expect(updatedOrder?.settledAmounts[0].amountOut).toBe(MOCK_ORDER_ENTITY.outputs[0].startAmount)
-    expect(updatedOrder?.settledAmounts[0].tokenIn).toBe(MOCK_ORDER_ENTITY.input.token)
-    expect(updatedOrder?.settledAmounts[0].amountIn).toBe(MOCK_ORDER_ENTITY.input.startAmount)
-
-    const updatedV2Order = await mockOrdersRepository.getOrder(MOCK_V2_ORDER_ENTITY.orderHash)
-    expect(updatedV2Order?.orderStatus).toBe(ORDER_STATUS.FILLED)
-    expect(updatedV2Order?.txHash).toBe('0xmocktxhash2')
-    expect(updatedV2Order?.fillBlock).toBe(mockFillBlockNumber)
-    expect(updatedV2Order?.settledAmounts).toBeDefined()
-    expect(updatedV2Order?.settledAmounts[0].tokenOut).toBe(MOCK_V2_ORDER_ENTITY.outputs[0].token)
-    expect(updatedV2Order?.settledAmounts[0].amountOut).toBe(MOCK_V2_ORDER_ENTITY.outputs[0].startAmount)
-    expect(updatedV2Order?.settledAmounts[0].tokenIn).toBe(MOCK_V2_ORDER_ENTITY.input.token)
-    expect(updatedV2Order?.settledAmounts[0].amountIn).toBe(MOCK_V2_ORDER_ENTITY.input.startAmount)
-  })
-
-  it('iterates through multiple blocks batches', async () => {
-    // Start 10 blocks ahead of the oldest block
-    const mockProvider = {
-      getBlockNumber: jest.fn().mockResolvedValue(OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET] + BLOCK_RANGE * 10),
-      getTransaction: jest.fn().mockResolvedValue({
-        gasPrice: '1000000000',
-        maxPriorityFeePerGas: null,
-        maxFeePerGas: null,
-      }),
-      getBlock: jest.fn().mockResolvedValue({
-        timestamp: Date.now() / 1000,
-      }),
+  it('processes UPDATE_DB stage correctly and moves to next chain', async () => {
+    const state = {
+      chainId: ChainId.MAINNET,
+      currentBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET],
+      earliestBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET],
+      orderUpdates: {
+        [MOCK_ORDER_ENTITY.orderHash]: {
+          status: ORDER_STATUS.FILLED,
+          txHash: '0xmocktxhash',
+          fillBlock: mockFillBlockNumber
+        }
+      },
+      parsedOrders: {},
+      stage: 'UPDATE_DB' as const
     }
-    mockProviders.set(ChainId.MAINNET, mockProvider)
-    await cleanupOrphanedOrders(mockOrdersRepository, mockProviders, log)
 
-    // Verify order was updated
+    const result = await handler(state)
+
+    // Verify the order was updated in the repository
     const updatedOrder = await mockOrdersRepository.getOrder(MOCK_ORDER_ENTITY.orderHash)
     expect(updatedOrder?.orderStatus).toBe(ORDER_STATUS.FILLED)
     expect(updatedOrder?.txHash).toBe('0xmocktxhash')
     expect(updatedOrder?.fillBlock).toBe(mockFillBlockNumber)
-    expect(updatedOrder?.settledAmounts).toBeDefined()
-    expect(updatedOrder?.settledAmounts[0].tokenOut).toBe(MOCK_ORDER_ENTITY.outputs[0].token)
-    expect(updatedOrder?.settledAmounts[0].amountOut).toBe(MOCK_ORDER_ENTITY.outputs[0].startAmount)
-    expect(updatedOrder?.settledAmounts[0].tokenIn).toBe(MOCK_ORDER_ENTITY.input.token)
-    expect(updatedOrder?.settledAmounts[0].amountIn).toBe(MOCK_ORDER_ENTITY.input.startAmount)
+
+    // Verify we're moving to the next chain
+    const chainIds = Object.keys(OLDEST_BLOCK_BY_CHAIN).map(Number)
+    expect(result.chainId).toBe(chainIds[chainIds.indexOf(ChainId.MAINNET) + 1])
+    expect(result.stage).toBe('INIT')
+  })
+
+  it('returns undefined when processing UPDATE_DB stage for the last chain', async () => {
+    const chainIds = Object.keys(OLDEST_BLOCK_BY_CHAIN).map(Number)
+    const lastChainId = chainIds[chainIds.length - 1]
+
+    const state = {
+      chainId: lastChainId,
+      currentBlock: OLDEST_BLOCK_BY_CHAIN[lastChainId],
+      earliestBlock: OLDEST_BLOCK_BY_CHAIN[lastChainId],
+      orderUpdates: {},
+      parsedOrders: {},
+      stage: 'UPDATE_DB' as const
+    }
+
+    const result = await handler(state)
+    expect(result).toBeUndefined()
   })
 })


### PR DESCRIPTION
The cron job approach was too slow and hit AWS' 15 min limit. Migrating to the feature to a step function so it can run much longer.

# Step Function Stages

1. **GET_OPEN_ORDERS**: Retrieves and parses open orders from the database
2. **PROCESS_BLOCKS**: Scans blocks for order fill events across configured block ranges for each supported order type
3. **CHECK_CANCELLED**: Validates unfilled orders for cancellations and expirations
4. **UPDATE_DB**: Persists status changes and handles chain transitions

This is the step function state machine:
<img width="605" alt="image" src="https://github.com/user-attachments/assets/c41ae9d0-37ab-4585-81d6-392ffbd9b30e" />
Each `ContinueExecution` it will pick up on the stage that it left off, passing the result from the previous call.
