### PR TITLE
Limit reaper step function data size

### DIFF
--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -268,7 +268,7 @@ export class StepFunctionStack extends cdk.NestedStack {
 
     // Schedule the GS Reaper to run every day
     new aws_events.Rule(this, 'GSReaperSchedule', {
-      schedule: aws_events.Schedule.rate(Duration.days(1)),
+      schedule: aws_events.Schedule.rate(Duration.hours(1)),
       targets: [new aws_events_targets.SfnStateMachine(gsReaperStateMachine)],
     })
 

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -268,7 +268,7 @@ export class StepFunctionStack extends cdk.NestedStack {
 
     // Schedule the GS Reaper to run every day
     new aws_events.Rule(this, 'GSReaperSchedule', {
-      schedule: aws_events.Schedule.rate(Duration.hours(1)),
+      schedule: aws_events.Schedule.rate(Duration.hours(5)),
       targets: [new aws_events_targets.SfnStateMachine(gsReaperStateMachine)],
     })
 

--- a/test/unit/handlers/gs-reaper/gs-reaper.test.ts
+++ b/test/unit/handlers/gs-reaper/gs-reaper.test.ts
@@ -260,6 +260,8 @@ describe('gs-reaper handler', () => {
     expect(result.currentBlock).toBe(OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET])
     expect(result.orderUpdates[MOCK_ORDER_ENTITY.orderHash]).toBeDefined()
     expect(result.orderUpdates[MOCK_ORDER_ENTITY.orderHash].status).toBe(ORDER_STATUS.FILLED)
+    // Verify order was removed from parsedOrders
+    expect(result.parsedOrders[MOCK_ORDER_ENTITY.orderHash]).toBeUndefined()
   })
 
   it('processes CHECK_CANCELLED stage correctly', async () => {
@@ -290,6 +292,8 @@ describe('gs-reaper handler', () => {
     expect(result.stage).toBe('UPDATE_DB')
     expect(result.orderUpdates[MOCK_ORDER_ENTITY.orderHash]).toBeDefined()
     expect(result.orderUpdates[MOCK_ORDER_ENTITY.orderHash].status).toBe(ORDER_STATUS.CANCELLED)
+    // Verify order was removed from parsedOrders
+    expect(result.parsedOrders[MOCK_ORDER_ENTITY.orderHash]).toBeUndefined()
   })
 
   it('processes UPDATE_DB stage correctly and moves to next chain', async () => {


### PR DESCRIPTION
Only process up to 50 orders at once. Remove an order from `parsedOrders` list if it's added to the `orderUpdates` list.

Run the job every 5 hours.