### PR TITLE
Increase reaper timeout and memory

### DIFF
--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -44,12 +44,12 @@ export class StepFunctionStack extends cdk.NestedStack {
       role: props.lambdaRole,
       entry: path.join(__dirname, '../../lib/handlers/check-order-status/index.ts'),
       handler: 'checkOrderStatusHandler',
-      memorySize: 512,
+      memorySize: 1024,
       bundling: {
         minify: true,
         sourceMap: true,
       },
-      timeout: Duration.seconds(60),
+      timeout: Duration.minutes(5),
       environment: {
         VERSION: '3',
         NODE_OPTIONS: '--enable-source-maps',

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -228,7 +228,7 @@ export class StepFunctionStack extends cdk.NestedStack {
         minify: true,
         sourceMap: true,
       },
-      timeout: Duration.seconds(300),
+      timeout: Duration.minutes(15),
       environment: {
         VERSION: '1',
         NODE_OPTIONS: '--enable-source-maps',


### PR DESCRIPTION
The reaper currently dies after 15 to 25 minutes and I believe it's due to timeout. Also increasing memory capacity to see if it helps.