### PR TITLE
feat, test: add pair as a GSI in Orders table

### DIFF
--- a/bin/config.ts
+++ b/bin/config.ts
@@ -13,6 +13,7 @@ export const PROD_INDEX_CAPACITY: IndexCapacityConfig = {
   chainIdFiller: { readCapacity: 2000, writeCapacity: 100 },
   chaindIdOrderStatus: { readCapacity: 2000, writeCapacity: 100 },
   chainIdFillerOrderStatus: { readCapacity: 2000, writeCapacity: 100 },
+  pair: { readCapacity: 2000, writeCapacity: 100 },
 }
 
 export const PROD_TABLE_CAPACITY: TableCapacityConfig = {

--- a/bin/stacks/dynamo-stack.ts
+++ b/bin/stacks/dynamo-stack.ts
@@ -29,6 +29,7 @@ export type IndexCapacityConfig = {
   chainIdFiller?: CapacityOptions
   chaindIdOrderStatus?: CapacityOptions
   chainIdFillerOrderStatus?: CapacityOptions
+  pair?: CapacityOptions
 }
 
 export type TableCapacityConfig = {
@@ -411,5 +412,19 @@ const createCommonIndices = (table: aws_dynamo.Table, indexCapacityConfig: Index
     },
     projectionType: aws_dynamo.ProjectionType.ALL,
     ...indexCapacityConfig?.chainIdFillerOrderStatus,
+  })
+
+  table.addGlobalSecondaryIndex({
+    indexName: `${TABLE_KEY.PAIR}-${TABLE_KEY.CREATED_AT}-all`,
+    partitionKey: {
+      name: TABLE_KEY.PAIR,
+      type: aws_dynamo.AttributeType.STRING,
+    },
+    sortKey: {
+      name: TABLE_KEY.CREATED_AT,
+      type: aws_dynamo.AttributeType.NUMBER,
+    },
+    projectionType: aws_dynamo.ProjectionType.ALL,
+    ...indexCapacityConfig?.pair,
   })
 }

--- a/jest-dynamodb-config.js
+++ b/jest-dynamodb-config.js
@@ -16,6 +16,7 @@ module.exports = {
         { AttributeName: 'filler_offerer', AttributeType: 'S' },
         { AttributeName: 'filler_offerer_orderStatus', AttributeType: 'S' },
         { AttributeName: 'chainId_orderStatus_filler', AttributeType: 'S' },
+        { AttributeName: 'pair', AttributeType: 'S' },
         { AttributeName: 'createdAt', AttributeType: 'N' },
       ],
       GlobalSecondaryIndexes: [
@@ -138,6 +139,15 @@ module.exports = {
           Projection: {
             ProjectionType: 'ALL',
           },
+          ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
+        },
+        {
+          IndexName: 'pair-createdAt-all',
+          KeySchema: [
+            { AttributeName: 'pair', KeyType: 'HASH' },
+            { AttributeName: 'createdAt', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
           ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 },
         },
       ],

--- a/lib/config/dynamodb.ts
+++ b/lib/config/dynamodb.ts
@@ -23,6 +23,7 @@ export enum TABLE_KEY {
   TX_HASH = 'txHash',
   CHAIN_ID = 'chainId',
   TYPE = 'type',
+  PAIR = 'pair',
 
   // compound table keys
   CHAIN_ID_FILLER = 'chainId_filler',

--- a/lib/crons/unimind-algorithm.ts
+++ b/lib/crons/unimind-algorithm.ts
@@ -29,7 +29,7 @@ export async function updateParameters(
 ): Promise<void> {
   const beforeUpdateTime = Date.now()
 
-  const pair = 'ETH-USDC'
+  const pair = '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123'
   await repo.put({
     pair,
     pi: 3.14,

--- a/lib/entities/RelayOrderEntity.ts
+++ b/lib/entities/RelayOrderEntity.ts
@@ -12,6 +12,7 @@ export type RelayOrderEntity = {
   chainId: number
   offerer: string
   reactor: string
+  pair: string
 
   deadline: number
   input: {

--- a/lib/handlers/get-orders/schema/index.ts
+++ b/lib/handlers/get-orders/schema/index.ts
@@ -29,8 +29,9 @@ export const GetOrdersQueryParamsJoi = Joi.object({
   desc: Joi.boolean(),
   orderType: FieldValidator.isValidGetQueryParamOrderType(),
   executeAddress: FieldValidator.isValidEthAddress(),
+  pair: Joi.string(),
 })
-  .or('orderHash', 'orderHashes', 'chainId', 'orderStatus', 'swapper', 'filler')
+  .or('orderHash', 'orderHashes', 'chainId', 'orderStatus', 'swapper', 'filler', 'pair')
   .when('.chainId', {
     is: Joi.exist(),
     then: Joi.object({
@@ -58,6 +59,7 @@ export type SharedGetOrdersQueryParams = {
   desc?: boolean
   orderType?: GetOrderTypeQueryParamEnum
   executeAddress?: string
+  pair?: string
 }
 export type RawGetOrdersQueryParams = SharedGetOrdersQueryParams & {
   swapper?: string
@@ -81,4 +83,5 @@ export enum GET_QUERY_PARAMS {
   DESC = 'desc',
   ORDER_TYPE = 'orderType',
   EXECUTE_ADDRESS = 'executeAddress',
+  PAIR = 'pair',
 }

--- a/lib/handlers/shared/get.ts
+++ b/lib/handlers/shared/get.ts
@@ -79,6 +79,7 @@ export const parseGetQueryParams = (
       ? requestQueryParams?.orderType
       : undefined
   const executeAddress = requestQueryParams?.executeAddress
+  const pair = requestQueryParams?.pair
 
   return {
     limit: limit,
@@ -94,6 +95,7 @@ export const parseGetQueryParams = (
       ...(chainId && { chainId: chainId }),
       ...(desc !== undefined && { desc: desc }),
       ...(orderHashes && { orderHashes: [...new Set(orderHashes)] }),
+      ...(pair && { pair: pair }),
     },
     ...(cursor && { cursor: cursor }),
   }

--- a/lib/models/RelayOrder.ts
+++ b/lib/models/RelayOrder.ts
@@ -43,6 +43,7 @@ export class RelayOrder extends Order {
       },
       reactor: decodedOrder.info.reactor.toLowerCase(),
       deadline: decodedOrder.info.deadline,
+      pair: `${input.token}-${decodedOrder.info.fee.token}-${decodedOrder.chainId}`,
     }
     return order
   }

--- a/lib/repositories/IndexMappers/OffchainOrderIndexMapper.ts
+++ b/lib/repositories/IndexMappers/OffchainOrderIndexMapper.ts
@@ -88,6 +88,12 @@ export class OffchainOrderIndexMapper<T extends UniswapXOrderEntity | RelayOrder
           partitionKey: queryFilters['chainId'] as number,
           index: TABLE_KEY.CHAIN_ID,
         }
+
+      case this.areParamsRequested([GET_QUERY_PARAMS.PAIR], requestedParams):
+        return {
+          partitionKey: queryFilters['pair'] as string,
+          index: TABLE_KEY.PAIR,
+        }
     }
     return undefined
   }
@@ -101,6 +107,7 @@ export class OffchainOrderIndexMapper<T extends UniswapXOrderEntity | RelayOrder
       chainId_orderStatus: `${order.chainId}_${order.orderStatus}`,
       chainId_orderStatus_filler: `${order.chainId}_${order.orderStatus}_${order.filler}`,
       filler_offerer_orderStatus: `${order.filler}_${order.offerer}_${order.orderStatus}`,
+      pair: `${order.pair}`,
     }
   }
 
@@ -115,6 +122,7 @@ export class OffchainOrderIndexMapper<T extends UniswapXOrderEntity | RelayOrder
       filler_offerer_orderStatus: `${order.filler}_${order.offerer}_${newStatus}`,
       chainId_orderStatus: `${order.chainId}_${newStatus}`,
       chainId_orderStatus_filler: `${order.chainId}_${newStatus}_${order.filler}`,
+      pair: `${order.pair}`,
     }
   }
 }

--- a/lib/repositories/dutch-orders-repository.ts
+++ b/lib/repositories/dutch-orders-repository.ts
@@ -44,7 +44,6 @@ export class DutchOrdersRepository extends GenericOrdersRepository<string, strin
         priceImpact: { type: DYNAMODB_TYPES.NUMBER },
         blockNumber: { type: DYNAMODB_TYPES.NUMBER },
         route: { type: DYNAMODB_TYPES.MAP },
-        pair: { type: DYNAMODB_TYPES.STRING },
 
         //on chain data
         nonce: { type: DYNAMODB_TYPES.STRING, required: true },
@@ -71,6 +70,7 @@ export class DutchOrdersRepository extends GenericOrdersRepository<string, strin
         chainId_orderStatus: { type: DYNAMODB_TYPES.STRING },
         chainId_orderStatus_filler: { type: DYNAMODB_TYPES.STRING },
         filler_offerer_orderStatus: { type: DYNAMODB_TYPES.STRING },
+        pair: { type: DYNAMODB_TYPES.STRING },
       },
       table: ordersTable,
     } as const)

--- a/lib/repositories/generic-orders-repository.ts
+++ b/lib/repositories/generic-orders-repository.ts
@@ -193,7 +193,7 @@ export abstract class GenericOrdersRepository<
 
       default: {
         throw new Error(
-          'Invalid query, must query with one of the following params: [orderHash, orderHashes, chainId, orderStatus, swapper, filler]'
+          'Invalid query, must query with one of the following params: [orderHash, orderHashes, chainId, orderStatus, swapper, filler, pair]'
         )
       }
     }

--- a/lib/repositories/limit-orders-repository.ts
+++ b/lib/repositories/limit-orders-repository.ts
@@ -53,6 +53,7 @@ export class LimitOrdersRepository extends GenericOrdersRepository<string, strin
         txHash: { type: DYNAMODB_TYPES.STRING },
         fillBlock: { type: DYNAMODB_TYPES.NUMBER },
         settledAmounts: { type: DYNAMODB_TYPES.LIST },
+        pair: { type: DYNAMODB_TYPES.STRING },
       },
       table: limitOrdersTable,
     } as const)

--- a/lib/repositories/util.ts
+++ b/lib/repositories/util.ts
@@ -60,6 +60,10 @@ export const getTableIndices = (tableName: TABLE_NAMES) => {
           partitionKey: `${TABLE_KEY.CHAIN_ID}_${TABLE_KEY.ORDER_STATUS}_${TABLE_KEY.FILLER}`,
           sortKey: TABLE_KEY.CREATED_AT,
         },
+        [`${TABLE_KEY.PAIR}-${TABLE_KEY.CREATED_AT}-all`]: {
+          partitionKey: TABLE_KEY.PAIR,
+          sortKey: TABLE_KEY.CREATED_AT,
+        },
         offererNonceIndex: { partitionKey: TABLE_KEY.OFFERER, sortKey: TABLE_KEY.NONCE },
       }
   }

--- a/test/integ/crons/unimind-algorithm.test.ts
+++ b/test/integ/crons/unimind-algorithm.test.ts
@@ -31,9 +31,9 @@ describe('updateParameters Test', () => {
   it('should update unimind parameters', async () => {
     await updateParameters(unimindParametersRepository, log)
     
-    const updatedValues = await unimindParametersRepository.getByPair('ETH-USDC')
+    const updatedValues = await unimindParametersRepository.getByPair('0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123')
     expect(updatedValues).toBeDefined()
-    expect(updatedValues?.pair).toBe('ETH-USDC')
+    expect(updatedValues?.pair).toBe('0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123')
     expect(updatedValues?.pi).toBe(3.14)
     expect(typeof updatedValues?.tau).toBe('number')
   })

--- a/test/integ/repositories/dynamo-repository.test.ts
+++ b/test/integ/repositories/dynamo-repository.test.ts
@@ -410,7 +410,7 @@ describe('OrdersRepository getOrders test', () => {
 
   it('should return orders for limit', async () => {
     await expect(ordersRepository.getOrders(2, {})).rejects.toThrow(
-      'Invalid query, must query with one of the following params: [orderHash, orderHashes, chainId, orderStatus, swapper, filler]'
+      'Invalid query, must query with one of the following params: [orderHash, orderHashes, chainId, orderStatus, swapper, filler, pair]'
     )
   })
 

--- a/test/integ/repositories/limit-orders-repository.test.ts
+++ b/test/integ/repositories/limit-orders-repository.test.ts
@@ -328,7 +328,7 @@ describe('OrdersRepository getOrders test', () => {
 
   it('should return orders for limit', async () => {
     await expect(ordersRepository.getOrders(2, {})).rejects.toThrow(
-      'Invalid query, must query with one of the following params: [orderHash, orderHashes, chainId, orderStatus, swapper, filler]'
+      'Invalid query, must query with one of the following params: [orderHash, orderHashes, chainId, orderStatus, swapper, filler, pair]'
     )
   })
 })

--- a/test/unit/builders/QueryParamsBuilder.ts
+++ b/test/unit/builders/QueryParamsBuilder.ts
@@ -24,6 +24,11 @@ export class QueryParamsBuilder {
     return this
   }
 
+  withPair(value?: string) {
+    this.params.pair = value || 'ETH-USDC-1'
+    return this
+  }
+
   withDesc(value?: boolean) {
     if (value === undefined) {
       this.params.desc = true

--- a/test/unit/builders/QueryParamsBuilder.ts
+++ b/test/unit/builders/QueryParamsBuilder.ts
@@ -25,7 +25,7 @@ export class QueryParamsBuilder {
   }
 
   withPair(value?: string) {
-    this.params.pair = value || 'ETH-USDC-1'
+    this.params.pair = value || '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123'
     return this
   }
 

--- a/test/unit/handlers/get-orders.test.ts
+++ b/test/unit/handlers/get-orders.test.ts
@@ -261,7 +261,7 @@ describe('Testing get orders handler.', () => {
       [{ sortKey: 'createdBy' }, 'must be [createdAt]'],
       [
         { sortKey: 'createdAt' },
-        '{"detail":"\\"value\\" must contain at least one of [orderHash, orderHashes, chainId, orderStatus, swapper, filler]","errorCode":"VALIDATION_ERROR"}',
+        '{"detail":"\\"value\\" must contain at least one of [orderHash, orderHashes, chainId, orderStatus, swapper, filler, pair]","errorCode":"VALIDATION_ERROR"}',
       ],
       [{ sort: 'foo(bar)' }, '"foo(bar)\\" fails to match the required pattern'],
       [{ cursor: 1 }, 'must be a string'],

--- a/test/unit/handlers/get-unimind/get-unimind.test.ts
+++ b/test/unit/handlers/get-unimind/get-unimind.test.ts
@@ -55,7 +55,7 @@ describe('Testing get unimind handler', () => {
   it('Testing valid request and response', async () => {
     const quoteMetadata = {
       quoteId: 'test-quote-id',
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       referencePrice: '4221.21',
       priceImpact: 0.01,
       route: STRINGIFIED_ROUTE,
@@ -66,7 +66,7 @@ describe('Testing get unimind handler', () => {
     }
 
     mockUnimindParametersRepo.getByPair.mockResolvedValue({
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       pi: 3.14,
       tau: 4.2
     })
@@ -91,7 +91,7 @@ describe('Testing get unimind handler', () => {
       ...quoteMetadata,
       route: SAMPLE_ROUTE // Should be parsed object when stored
     })
-    expect(mockUnimindParametersRepo.getByPair).toHaveBeenCalledWith('ETH-USDC')
+    expect(mockUnimindParametersRepo.getByPair).toHaveBeenCalledWith('0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123')
   })
 
   it('Returns default parameters when unimind parameters not found', async () => {
@@ -180,7 +180,7 @@ describe('Testing get unimind handler', () => {
       quoteId: 'this-should-work',
       referencePrice: '100',
       priceImpact: 0.1,
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       route: STRINGIFIED_ROUTE,
     }
 
@@ -227,7 +227,7 @@ describe('Testing get unimind handler', () => {
           quoteId: 'this-should-work', 
           referencePrice: '100', 
           priceImpact: 0.1,
-          pair: 'ETH-USDC',
+          pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
           route: STRINGIFIED_ROUTE
         },
         requestContext: { requestId: 'test-request-id-cors' }
@@ -267,7 +267,7 @@ describe('Testing get unimind handler', () => {
   it('fails when repository throws error', async () => {
     const quoteMetadata = {
       quoteId: 'this-should-fail',
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       referencePrice: '666.56',
       priceImpact: 0.01,
       route: STRINGIFIED_ROUTE,
@@ -302,7 +302,7 @@ describe('Testing get unimind handler', () => {
   it('fails when route is invalid JSON', async () => {
     const getRequestParams = {
       quoteId: 'test-quote-id',
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       referencePrice: '4221.21',
       priceImpact: 0.01,
       route: '{invalid json'
@@ -328,7 +328,7 @@ describe('Testing get unimind handler', () => {
       quoteId: 'test-quote-id',
       referencePrice: '4221.21',
       priceImpact: 0.01,
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       route: STRINGIFIED_ROUTE,
     }
 
@@ -359,7 +359,7 @@ describe('Testing get unimind handler', () => {
       quoteId: 'test-quote-id',
       referencePrice: '4221.21',
       priceImpact: 0.01,
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       route: STRINGIFIED_ROUTE,
     }
 
@@ -390,7 +390,7 @@ describe('Testing get unimind handler', () => {
       quoteId: 'test-quote-id',
       referencePrice: '4221.21',
       priceImpact: 0.01,
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       route: STRINGIFIED_ROUTE,
     }
     //mock the put as successful
@@ -421,7 +421,7 @@ describe('Testing get unimind handler', () => {
       quoteId: 'test-quote-id',
       referencePrice: '4221.21',
       priceImpact: 0.01,
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       route: STRINGIFIED_ROUTE,
       swapper: UNIMIND_DEV_SWAPPER_ADDRESS
     }
@@ -446,7 +446,7 @@ describe('Testing get unimind handler', () => {
       quoteId: 'test-quote-id',
       referencePrice: '4221.21',
       priceImpact: 0.01,
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       swapper: UNIMIND_DEV_SWAPPER_ADDRESS,
       blockNumber: 1234,
       // missing route
@@ -470,7 +470,7 @@ describe('Testing get unimind handler', () => {
       quoteId: 'test-quote-id',
       referencePrice: '4221.21',
       priceImpact: 0.01,
-      pair: 'ETH-USDC',
+      pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       swapper: UNIMIND_DEV_SWAPPER_ADDRESS,
       // missing blockNumber
       route: STRINGIFIED_ROUTE,

--- a/test/unit/handlers/post-order/post-order.test.ts
+++ b/test/unit/handlers/post-order/post-order.test.ts
@@ -74,7 +74,7 @@ const SAMPLE_QUOTE_METADATA = {
   quoteId: '55e2cfca-5521-4a0a-b597-7bfb569032d7',
   referencePrice: '4221.21',
   priceImpact: 0.01,
-  pair: 'ETH-USDC',
+  pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
   blockNumber: 123456,
   route: {
     quote: '1234',

--- a/test/unit/repositories/OffchainOrderIndexMapper.test.ts
+++ b/test/unit/repositories/OffchainOrderIndexMapper.test.ts
@@ -105,7 +105,7 @@ describe('OffchainOrderIndexMapper', () => {
     it('should give pair index', async () => {
       const queryParams = queryParamsBuilder.withPair().build()
       expect(indexMapper.getIndexFromParams(queryParams)).toEqual({
-        partitionKey: 'ETH-USDC-1',
+        partitionKey: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
         index: `${TABLE_KEY.PAIR}`,
       })
     })
@@ -119,7 +119,7 @@ describe('OffchainOrderIndexMapper', () => {
         offerer: '0xOfferer',
         filler: '0xFiller',
         chainId: 5,
-        pair: 'ETH-USDC-1',
+        pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       }
       expect(indexMapper.getIndexFieldsForUpdate(order)).toEqual({
         chainId_filler: '5_0xFiller',
@@ -129,7 +129,7 @@ describe('OffchainOrderIndexMapper', () => {
         filler_offerer_orderStatus: '0xFiller_0xOfferer_filled',
         filler_orderStatus: '0xFiller_filled',
         offerer_orderStatus: '0xOfferer_filled',
-        pair: 'ETH-USDC-1',
+        pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       })
     })
   })
@@ -142,7 +142,7 @@ describe('OffchainOrderIndexMapper', () => {
         offerer: '0xOfferer',
         filler: '0xFiller',
         chainId: 5,
-        pair: 'ETH-USDC-1',
+        pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       }
       expect(indexMapper.getIndexFieldsForStatusUpdate(order, ORDER_STATUS.INSUFFICIENT_FUNDS)).toEqual({
         chainId_orderStatus: '5_insufficient-funds',
@@ -151,7 +151,7 @@ describe('OffchainOrderIndexMapper', () => {
         filler_orderStatus: '0xFiller_insufficient-funds',
         offerer_orderStatus: '0xOfferer_insufficient-funds',
         orderStatus: 'insufficient-funds',
-        pair: 'ETH-USDC-1',
+        pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       })
     })
   })

--- a/test/unit/repositories/OffchainOrderIndexMapper.test.ts
+++ b/test/unit/repositories/OffchainOrderIndexMapper.test.ts
@@ -101,6 +101,14 @@ describe('OffchainOrderIndexMapper', () => {
       const queryParams = queryParamsBuilder.build()
       expect(indexMapper.getIndexFromParams(queryParams)).toBeUndefined()
     })
+
+    it('should give pair index', async () => {
+      const queryParams = queryParamsBuilder.withPair().build()
+      expect(indexMapper.getIndexFromParams(queryParams)).toEqual({
+        partitionKey: 'ETH-USDC-1',
+        index: `${TABLE_KEY.PAIR}`,
+      })
+    })
   })
 
   describe('getIndexFieldsForUpdate', () => {
@@ -111,6 +119,7 @@ describe('OffchainOrderIndexMapper', () => {
         offerer: '0xOfferer',
         filler: '0xFiller',
         chainId: 5,
+        pair: 'ETH-USDC-1',
       }
       expect(indexMapper.getIndexFieldsForUpdate(order)).toEqual({
         chainId_filler: '5_0xFiller',
@@ -120,6 +129,7 @@ describe('OffchainOrderIndexMapper', () => {
         filler_offerer_orderStatus: '0xFiller_0xOfferer_filled',
         filler_orderStatus: '0xFiller_filled',
         offerer_orderStatus: '0xOfferer_filled',
+        pair: 'ETH-USDC-1',
       })
     })
   })
@@ -132,6 +142,7 @@ describe('OffchainOrderIndexMapper', () => {
         offerer: '0xOfferer',
         filler: '0xFiller',
         chainId: 5,
+        pair: 'ETH-USDC-1',
       }
       expect(indexMapper.getIndexFieldsForStatusUpdate(order, ORDER_STATUS.INSUFFICIENT_FUNDS)).toEqual({
         chainId_orderStatus: '5_insufficient-funds',
@@ -140,6 +151,7 @@ describe('OffchainOrderIndexMapper', () => {
         filler_orderStatus: '0xFiller_insufficient-funds',
         offerer_orderStatus: '0xOfferer_insufficient-funds',
         orderStatus: 'insufficient-funds',
+        pair: 'ETH-USDC-1',
       })
     })
   })

--- a/test/unit/repositories/quote-metadata-repository.test.ts
+++ b/test/unit/repositories/quote-metadata-repository.test.ts
@@ -22,7 +22,7 @@ describe('QuoteMetadataRepository', () => {
             to: "0abcdef"
         }
     },
-    pair: 'ETH-USDC',
+    pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
   }
 
   beforeEach(() => {

--- a/test/unit/repositories/unimind-parameters-repository.test.ts
+++ b/test/unit/repositories/unimind-parameters-repository.test.ts
@@ -6,7 +6,7 @@ describe('UnimindParametersRepository', () => {
   const mockDocumentClient = mock<DocumentClient>()
 
   const mockUnimindParameters: UnimindParameters = {
-    pair: 'ETH-USDC',
+    pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
     pi: 3.14,
     tau: 4.2,
   }
@@ -41,7 +41,7 @@ describe('UnimindParametersRepository', () => {
       const repository = DynamoUnimindParametersRepository.create(mockDocumentClient)
       
       const incompleteValues = {
-        pair: 'ETH-USDC',
+        pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
         // missing pi
         tau: 4.2,
       }
@@ -60,7 +60,7 @@ describe('UnimindParametersRepository', () => {
         promise: () => Promise.resolve({ Item: mockUnimindParameters }),
       } as any)
 
-      const result = await repository.getByPair('ETH-USDC')
+      const result = await repository.getByPair('0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123')
 
       expect(result).toEqual(mockUnimindParameters)
       expect(mockDocumentClient.get).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Unimind update algorithm needs to perform queries on `pair` in the `Orders` table
1. Adds `pair` as a GSI to enable queries on the `pair` attribute
2. Updates the `get-orders` endpoint to utilize this GSI to allow API users to also query for orders based on `pair`