### PR TITLE
feat, test: unimind address filter function; filter on cron

### DIFF
--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -7,7 +7,8 @@ import { Unit } from 'aws-embedded-metrics'
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
 import { metrics } from '../../util/metrics'
 import { UnimindQueryParams, unimindQueryParamsSchema } from './schema'
-import { DEFAULT_UNIMIND_PARAMETERS, PUBLIC_UNIMIND_PARAMETERS, UNIMIND_DEV_SWAPPER_ADDRESS } from '../../util/constants'
+import { DEFAULT_UNIMIND_PARAMETERS, PUBLIC_UNIMIND_PARAMETERS } from '../../util/constants'
+import { unimindAddressFilter } from '../../util/unimind'
 
 type UnimindResponse = {
   pi: number
@@ -38,7 +39,7 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
         }
       }
 
-      if (!swapper || swapper != UNIMIND_DEV_SWAPPER_ADDRESS) {
+      if (!swapper || !unimindAddressFilter(swapper)) {
         return {
             statusCode: 200,
             body: PUBLIC_UNIMIND_PARAMETERS

--- a/lib/util/unimind.ts
+++ b/lib/util/unimind.ts
@@ -1,0 +1,5 @@
+import { UNIMIND_DEV_SWAPPER_ADDRESS } from "./constants";
+
+export function unimindAddressFilter(address: string) {
+  return address.toLowerCase() === UNIMIND_DEV_SWAPPER_ADDRESS.toLowerCase()
+}


### PR DESCRIPTION
- Turn the address filter into a function so further updates apply to all cases the filter is used
- Enable the Unimind cron to use the address filter