### PR TITLE
feat: usedUnimind flag and analytics

### DIFF
--- a/lib/entities/Order.ts
+++ b/lib/entities/Order.ts
@@ -91,6 +91,7 @@ export type SharedXOrderEntity = {
   blockNumber?: number
   route?: Route
   pair?: string
+  usedUnimind?: boolean
 }
 
 export type DutchV1OrderEntity = SharedXOrderEntity & {

--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -46,6 +46,9 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
         }
       }
 
+      // If we made it through these filters, then we are using Unimind to provide parameters
+      quoteMetadata.usedUnimind = true
+
       let [, unimindParameters] = await Promise.all([
         quoteMetadataRepository.put(quoteMetadata),
         unimindParametersRepository.getByPair(requestQueryParams.pair)
@@ -64,6 +67,7 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
 
       const beforeCalculateTime = Date.now()
       const parameters = this.calculateParameters(unimindParameters, quoteMetadata)
+      // TODO: Add condition for not using Unimind with bad parameters
       const afterCalculateTime = Date.now()
       const calculateTime = afterCalculateTime - beforeCalculateTime
       metrics.putMetric(`final-parameters-calculation-time`, calculateTime)

--- a/lib/models/DutchV3Order.ts
+++ b/lib/models/DutchV3Order.ts
@@ -84,7 +84,8 @@ export class DutchV3Order extends Order {
       referencePrice: quoteMetadata?.referencePrice,
       priceImpact: quoteMetadata?.priceImpact,
       route: quoteMetadata?.route,
-      pair: quoteMetadata?.pair
+      pair: quoteMetadata?.pair,
+      usedUnimind: quoteMetadata?.usedUnimind
     }
 
     return order

--- a/lib/repositories/dutch-orders-repository.ts
+++ b/lib/repositories/dutch-orders-repository.ts
@@ -44,7 +44,7 @@ export class DutchOrdersRepository extends GenericOrdersRepository<string, strin
         priceImpact: { type: DYNAMODB_TYPES.NUMBER },
         blockNumber: { type: DYNAMODB_TYPES.NUMBER },
         route: { type: DYNAMODB_TYPES.MAP },
-
+        usedUnimind: {type: DYNAMODB_TYPES.BOOLEAN},
         //on chain data
         nonce: { type: DYNAMODB_TYPES.STRING, required: true },
         offerer: { type: DYNAMODB_TYPES.STRING, required: true },

--- a/lib/repositories/quote-metadata-repository.ts
+++ b/lib/repositories/quote-metadata-repository.ts
@@ -26,6 +26,7 @@ export interface QuoteMetadata {
   blockNumber: number
   route: Route
   pair: string
+  usedUnimind: boolean
 }
 
 export interface QuoteMetadataRepository {
@@ -56,7 +57,8 @@ export class DynamoQuoteMetadataRepository implements QuoteMetadataRepository {
         priceImpact: { type: DYNAMODB_TYPES.NUMBER, required: true },
         pair: {type: DYNAMODB_TYPES.STRING, required: true},
         blockNumber: {type: DYNAMODB_TYPES.NUMBER, required: false},
-        route: {type: DYNAMODB_TYPES.MAP, required: false}
+        route: {type: DYNAMODB_TYPES.MAP, required: false},
+        usedUnimind: {type: DYNAMODB_TYPES.BOOLEAN, required: true}
       },
       table,
     } as const)

--- a/lib/services/analytics-service.ts
+++ b/lib/services/analytics-service.ts
@@ -37,6 +37,7 @@ export class AnalyticsService implements AnalyticsServiceInterface {
       orderType: orderType,
       blockNumber: order?.blockNumber,
       route: JSON.stringify(order?.route),
+      usedUnimind: order?.usedUnimind,
     }
 
     if (isPriorityOrderEntity(order)) {

--- a/lib/services/analytics-service.ts
+++ b/lib/services/analytics-service.ts
@@ -37,7 +37,7 @@ export class AnalyticsService implements AnalyticsServiceInterface {
       orderType: orderType,
       blockNumber: order?.blockNumber,
       route: JSON.stringify(order?.route),
-      usedUnimind: order?.usedUnimind,
+      usedUnimind: order?.usedUnimind ?? false,
     }
 
     if (isPriorityOrderEntity(order)) {

--- a/test/integ/crons/unimind-algorithm.test.ts
+++ b/test/integ/crons/unimind-algorithm.test.ts
@@ -79,7 +79,8 @@ const mockOrder: DutchV3OrderEntity = {
       to: "0xghjk"
     }
   },
-  pair: "0x1-0x2-21"
+  pair: "0x1-0x2-21",
+  usedUnimind: false
 }
 
 const mockOldPair = '0x4444444444444444444444444444444444444444-0x2222222222222222222222222222222222222222-42161'

--- a/test/unit/handlers/get-unimind/get-unimind.test.ts
+++ b/test/unit/handlers/get-unimind/get-unimind.test.ts
@@ -90,7 +90,8 @@ describe('Testing get unimind handler', () => {
     expect(response.statusCode).toBe(200)
     expect(mockQuoteMetadataRepo.put).toHaveBeenCalledWith({
       ...quoteMetadata,
-      route: SAMPLE_ROUTE // Should be parsed object when stored
+      route: SAMPLE_ROUTE, // Should be parsed object when stored
+      usedUnimind: true
     })
     expect(mockUnimindParametersRepo.getByPair).toHaveBeenCalledWith('0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123')
   })
@@ -122,7 +123,8 @@ describe('Testing get unimind handler', () => {
     //Handler should have saved the quote metadata since we expect params in response
     expect(mockQuoteMetadataRepo.put).toHaveBeenCalledWith({
       ...quoteMetadata,
-      route: JSON.parse(quoteMetadata.route)
+      route: JSON.parse(quoteMetadata.route),
+      usedUnimind: true
     })
 
     expect(response.statusCode).toBe(200)
@@ -296,7 +298,8 @@ describe('Testing get unimind handler', () => {
     expect(body.detail).toBe('DB Error')
     expect(mockQuoteMetadataRepo.put).toHaveBeenCalledWith({
       ...quoteMetadata,
-      route: SAMPLE_ROUTE // Should be parsed object when stored
+      route: SAMPLE_ROUTE, // Should be parsed object when stored
+      usedUnimind: true
     })
   })
 

--- a/test/unit/handlers/post-order/post-order.test.ts
+++ b/test/unit/handlers/post-order/post-order.test.ts
@@ -88,6 +88,7 @@ const SAMPLE_QUOTE_METADATA = {
       to: '0abcdef',
     },
   },
+  usedUnimind: true
 }
 
 const mockSfnClient = mockClient(SFNClient)

--- a/test/unit/repositories/quote-metadata-repository.test.ts
+++ b/test/unit/repositories/quote-metadata-repository.test.ts
@@ -23,6 +23,7 @@ describe('QuoteMetadataRepository', () => {
         }
     },
     pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
+    usedUnimind: false
   }
 
   beforeEach(() => {

--- a/test/unit/services/analytics-service.test.ts
+++ b/test/unit/services/analytics-service.test.ts
@@ -73,7 +73,8 @@ describe('Analytics Service', () => {
           tokenOut: '0xOutputToken',
           filler: '0xGetAddress',
           orderType: 'Limit',
-          route: JSON.stringify(mockedOrder.route)
+          route: JSON.stringify(mockedOrder.route),
+          usedUnimind: false,
         },
       })
     })
@@ -110,7 +111,8 @@ describe('Analytics Service', () => {
           tokenOut: '0xOutputToken',
           filler: '0xGetAddress',
           orderType: 'Limit',
-          route: JSON.stringify(mockedOrder.route)
+          route: JSON.stringify(mockedOrder.route),
+          usedUnimind: false,
         },
       })
     })


### PR DESCRIPTION
Add a `usedUnimind` flag for quotes that were given Unimind parameters
Orders ultimately submitted from those quotes will be recorded and logged with the boolean `usedUnimind`