### PR TITLE
feat: log priceImpact, referencePrice for BigQuery

### DIFF
--- a/lib/services/analytics-service.ts
+++ b/lib/services/analytics-service.ts
@@ -38,6 +38,8 @@ export class AnalyticsService implements AnalyticsServiceInterface {
       blockNumber: order?.blockNumber,
       route: JSON.stringify(order?.route),
       usedUnimind: order?.usedUnimind ?? false,
+      priceImpact: order?.priceImpact,
+      referencePrice: order?.referencePrice,
     }
 
     if (isPriorityOrderEntity(order)) {


### PR DESCRIPTION
Log `priceImpact` and `referencePrice` so we can pick it up in BigQuery to see this information among X orders