### PR TITLE
feat, test: adjust model parameters; fix bps unit bug; tau safety ceiling

### DIFF
--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -7,7 +7,7 @@ import { Unit } from 'aws-embedded-metrics'
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
 import { metrics } from '../../util/metrics'
 import { UnimindQueryParams, unimindQueryParamsSchema } from './schema'
-import { DEFAULT_UNIMIND_PARAMETERS, PUBLIC_UNIMIND_PARAMETERS, UNIMIND_DEV_SWAPPER_ADDRESS } from '../../util/constants'
+import { DEFAULT_UNIMIND_PARAMETERS, PUBLIC_UNIMIND_PARAMETERS, UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_MAX_TAU_BPS } from '../../util/constants'
 import { IUnimindAlgorithm, supportedUnimindTokens, unimindAddressFilter } from '../../util/unimind'
 import { PriceImpactIntrinsicParameters, PriceImpactStrategy } from '../../unimind/priceImpactStrategy'
 
@@ -150,7 +150,8 @@ export function calculateParameters(strategy: IUnimindAlgorithm<PriceImpactIntri
   const intrinsicValues = JSON.parse(unimindParameters.intrinsicValues)
   // Keeping intrinsic extrinsic naming for consistency with algorithm
   const pi = strategy.computePi(intrinsicValues, extrinsicValues)
-  const tau = strategy.computeTau(intrinsicValues, extrinsicValues)
+  // Ceiling tau at UNIMIND_MAX_TAU_BPS for safety
+  const tau = Math.min(strategy.computeTau(intrinsicValues, extrinsicValues), UNIMIND_MAX_TAU_BPS)
   return {
     pi,
     tau

--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -83,7 +83,7 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
 
       const beforeCalculateTime = Date.now()
       const strategy = new PriceImpactStrategy()
-      const parameters = this.calculateParameters(strategy, unimindParameters, quoteMetadata)
+      const parameters = calculateParameters(strategy, unimindParameters, quoteMetadata)
       // TODO: Add condition for not using Unimind with bad parameters
       const afterCalculateTime = Date.now()
       const calculateTime = afterCalculateTime - beforeCalculateTime
@@ -100,17 +100,6 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
         errorCode: ErrorCode.InternalError,
         detail: (e as Error)?.message ?? 'Unknown error occurred'
       }
-    }
-  }
-
-  calculateParameters(strategy: IUnimindAlgorithm<PriceImpactIntrinsicParameters>, unimindParameters: UnimindParameters, extrinsicValues: QuoteMetadata): UnimindResponse {
-    const intrinsicValues = JSON.parse(unimindParameters.intrinsicValues)
-    // Keeping intrinsic extrinsic naming for consistency with algorithm
-    const pi = strategy.computePi(intrinsicValues, extrinsicValues)
-    const tau = strategy.computeTau(intrinsicValues, extrinsicValues)
-    return {
-      pi,
-      tau
     }
   }
 
@@ -154,5 +143,16 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
 
     const getUnimindRequestByPairMetricName = `GetUnimindRequestPair${pair}`
     metrics.putMetric(getUnimindRequestByPairMetricName, 1, Unit.Count)
+  }
+}
+
+export function calculateParameters(strategy: IUnimindAlgorithm<PriceImpactIntrinsicParameters>, unimindParameters: UnimindParameters, extrinsicValues: QuoteMetadata): UnimindResponse {
+  const intrinsicValues = JSON.parse(unimindParameters.intrinsicValues)
+  // Keeping intrinsic extrinsic naming for consistency with algorithm
+  const pi = strategy.computePi(intrinsicValues, extrinsicValues)
+  const tau = strategy.computeTau(intrinsicValues, extrinsicValues)
+  return {
+    pi,
+    tau
   }
 }

--- a/lib/unimind/priceImpactStrategy.ts
+++ b/lib/unimind/priceImpactStrategy.ts
@@ -3,6 +3,7 @@ import { UnimindStatistics } from "../crons/unimind-algorithm";
 import { UnimindParameters } from "../repositories/unimind-parameters-repository";
 import { IUnimindAlgorithm } from "../util/unimind";
 import { QuoteMetadata } from '../repositories/quote-metadata-repository';
+import { BPS } from '@uniswap/uniswapx-sdk';
 
 export type PriceImpactIntrinsicParameters = {
     lambda1: number;
@@ -343,7 +344,7 @@ export class PriceImpactStrategy implements IUnimindAlgorithm<PriceImpactIntrins
         try {
             const priceImpactFiller = this.computePriceImpactFiller(priceImpactOfAmm, intrinsicValues);
             const pi = (priceImpactOfAmm - priceImpactFiller) / (1 - priceImpactOfAmm);
-            return pi * 10000; // Convert from pure to bps
+            return pi * BPS; // Convert from pure to bps
         } catch (error) {
             return 0;
         }
@@ -352,7 +353,7 @@ export class PriceImpactStrategy implements IUnimindAlgorithm<PriceImpactIntrins
     public computeTau(intrinsicValues: PriceImpactIntrinsicParameters, extrinsicValues: QuoteMetadata): number {
         const expSigma = Math.exp(intrinsicValues.Sigma);
         const auctionDecayAmount = this.LENGTH_OF_AUCTION_IN_BLOCKS * expSigma;
-        const auctionDecayAmountBps = auctionDecayAmount * 10000;
+        const auctionDecayAmountBps = auctionDecayAmount * BPS;
         const tau = auctionDecayAmountBps - this.computePi(intrinsicValues, extrinsicValues);
         return tau; // In units of bps
     }

--- a/lib/unimind/priceImpactStrategy.ts
+++ b/lib/unimind/priceImpactStrategy.ts
@@ -13,11 +13,11 @@ export type PriceImpactIntrinsicParameters = {
 export class PriceImpactStrategy implements IUnimindAlgorithm<PriceImpactIntrinsicParameters> {
     // Algorithm constants
     private TARGET_FILL_RATE = 0.96;
-    private TARGET_WAIT_TIME_IN_BLOCKS = 4;
+    private TARGET_WAIT_TIME_IN_BLOCKS = 8;
     private BETA = 1;
-    private LAMBDA1_LEARNING_RATE = 1e-10;
-    private LAMBDA2_LEARNING_RATE = 1e-1;
-    private SIGMA_LEARNING_RATE = 1e-1;
+    private LAMBDA1_LEARNING_RATE = 1.5e-10;
+    private LAMBDA2_LEARNING_RATE = 1.5e-1;
+    private SIGMA_LEARNING_RATE = 1.5e-1;
 
     private LENGTH_OF_AUCTION_IN_BLOCKS = 32;
     private D_FR_D_SIGMA = Math.log(0.00001);

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -37,3 +37,4 @@ export const PUBLIC_UNIMIND_PARAMETERS = {
   pi: 15,
   tau: 15
 }
+export const UNIMIND_MAX_TAU_BPS = 25

--- a/test/unit/handlers/get-unimind/get-unimind.test.ts
+++ b/test/unit/handlers/get-unimind/get-unimind.test.ts
@@ -73,7 +73,7 @@ describe('Testing get unimind handler', () => {
       intrinsicValues: JSON.stringify({
         lambda1: 0,
         lambda2: 8,
-        Sigma: Math.log(0.0001)
+        Sigma: Math.log(0.00005)
       }),
       count: 0
     })
@@ -90,7 +90,7 @@ describe('Testing get unimind handler', () => {
 
     const body = JSON.parse(response.body)
     expect(body.pi).toBeCloseTo(0.999764, 5)
-    expect(body.tau).toBeCloseTo(31.000235519, 5)
+    expect(body.tau).toBeCloseTo(15.000235519, 5)
     expect(response.statusCode).toBe(200)
     expect(mockQuoteMetadataRepo.put).toHaveBeenCalledWith({
       ...quoteMetadata,

--- a/test/unit/handlers/get-unimind/get-unimind.test.ts
+++ b/test/unit/handlers/get-unimind/get-unimind.test.ts
@@ -60,7 +60,7 @@ describe('Testing get unimind handler', () => {
       quoteId: 'test-quote-id',
       pair: SAMPLE_SUPPORTED_UNIMIND_PAIR,
       referencePrice: '4221.21',
-      priceImpact: 0.713262,
+      priceImpact: 0.01,
       route: STRINGIFIED_ROUTE,
     }
     const quoteQueryParams = {
@@ -71,9 +71,9 @@ describe('Testing get unimind handler', () => {
     mockUnimindParametersRepo.getByPair.mockResolvedValue({
       pair: SAMPLE_SUPPORTED_UNIMIND_PAIR,
       intrinsicValues: JSON.stringify({
-        lambda1: -1,
+        lambda1: 0,
         lambda2: 8,
-        Sigma: -9.210340371976182
+        Sigma: Math.log(0.0001)
       }),
       count: 0
     })
@@ -89,8 +89,8 @@ describe('Testing get unimind handler', () => {
     )
 
     const body = JSON.parse(response.body)
-    expect(body.pi).toBeCloseTo(5.9691917235023, 5)
-    expect(body.tau).toBeCloseTo(-5.965991723502305, 5)
+    expect(body.pi).toBeCloseTo(0.999764, 5)
+    expect(body.tau).toBeCloseTo(31.000235519, 5)
     expect(response.statusCode).toBe(200)
     expect(mockQuoteMetadataRepo.put).toHaveBeenCalledWith({
       ...quoteMetadata,

--- a/test/unit/util/unimind-algorithm.test.ts
+++ b/test/unit/util/unimind-algorithm.test.ts
@@ -164,9 +164,9 @@ describe('unimind-algorithm', () => {
       }
       const result = strategy.unimindAlgorithm(statistics, intrinsicValues, log);
       // Test that they match to 5 decimal places
-      expect(result.lambda1).toBeCloseTo(-1.8457415394781824e-5, 5)
-      expect(result.lambda2).toBeCloseTo(17.08178119556178, 5)
-      expect(result.Sigma).toBeCloseTo(-9.302443775695945, 5)
+      expect(result.lambda1).toBeCloseTo(-5.5372245907992656e-5, 5)
+      expect(result.lambda2).toBeCloseTo(35.24534329861248, 5)
+      expect(result.Sigma).toBeCloseTo(-9.348495477555824, 5)
     });
     
     it('price impact strategy test', () => {
@@ -181,9 +181,9 @@ describe('unimind-algorithm', () => {
         fillStatuses
       }
       const result = strategy.unimindAlgorithm(statistics, intrinsicValues, log);
-      expect(result.lambda1).toBeCloseTo(-1.6592687410774573e-5, 5)
-      expect(result.lambda2).toBeCloseTo(16.804849365270385, 5)
-      expect(result.Sigma).toBeCloseTo(-9.137973411910652, 5)
+      expect(result.lambda1).toBeCloseTo(-5.227310924635774e-5, 5)
+      expect(result.lambda2).toBeCloseTo(35.07513162392661, 5)
+      expect(result.Sigma).toBeCloseTo(-9.10178993187789, 5)
     });
 
     it('Price impact with real data <=1% price impact', () => {
@@ -198,7 +198,7 @@ describe('unimind-algorithm', () => {
       }
       const result = strategy.unimindAlgorithm(statistics, intrinsicValues, log);
       expect(result.lambda1).toBeCloseTo(1.130312497556507e-9, 5)
-      expect(result.lambda2).toBeCloseTo(4.237034026847578, 5)
+      expect(result.lambda2).toBeCloseTo(4.237141695754233, 5)
       expect(result.Sigma).toBeCloseTo(-0.41228565543852524, 5)
     });
 

--- a/test/unit/util/unimind-algorithm.test.ts
+++ b/test/unit/util/unimind-algorithm.test.ts
@@ -3,7 +3,7 @@ import { getStatistics } from '../../../lib/crons/unimind-algorithm';
 import { DutchV3OrderEntity } from '../../../lib/entities';
 import { ORDER_STATUS } from '../../../lib/entities/Order';
 import { mock } from 'jest-mock-extended';
-import { UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_UPDATE_THRESHOLD } from '../../../lib/util/constants';
+import { UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_MAX_TAU_BPS, UNIMIND_UPDATE_THRESHOLD } from '../../../lib/util/constants';
 import { PriceImpactStrategy } from '../../../lib/unimind/priceImpactStrategy';
 import { BatchedStrategy } from '../../../lib/unimind/batchedStrategy';
 import { unimindAddressFilter, UNIMIND_SAMPLE_PERCENT } from '../../../lib/util/unimind';
@@ -204,12 +204,22 @@ describe('unimind-algorithm', () => {
 
     it('price impact strategy test on extrinsic values', () => {
       const strategy = new PriceImpactStrategy()
-      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: Math.log(0.0001)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123',  };
+      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: Math.log(0.00005)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123',  };
       const extrinsicValues: QuoteMetadata = { priceImpact: 0.01, quoteId: '0x000-0x111-123', referencePrice: '100', blockNumber: 100, route: { quote: '100', quoteGasAdjusted: '100', gasPriceWei: '100', gasUseEstimateQuote: '100', gasUseEstimate: '100', methodParameters: {calldata: '0x', value: '0', to: '0x0000000000000000000000000000000000000000'}}, pair: '0x000-0x111-123', usedUnimind: true }
       const result = calculateParameters(strategy, intrinsicValues, extrinsicValues)
 
       expect(result.pi).toBeCloseTo(0.999764, 5)
-      expect(result.tau).toBeCloseTo(31.000235519, 5)
+      expect(result.tau).toBeCloseTo(15.000235519, 5)
+    })
+
+    it('ceiling on tau for price impact strategy', () => {
+      const strategy = new PriceImpactStrategy()
+      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: Math.log(0.0002)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123',  };
+      const extrinsicValues: QuoteMetadata = { priceImpact: 0.01, quoteId: '0x000-0x111-123', referencePrice: '100', blockNumber: 100, route: { quote: '100', quoteGasAdjusted: '100', gasPriceWei: '100', gasUseEstimateQuote: '100', gasUseEstimate: '100', methodParameters: {calldata: '0x', value: '0', to: '0x0000000000000000000000000000000000000000'}}, pair: '0x000-0x111-123', usedUnimind: true }
+      const result = calculateParameters(strategy, intrinsicValues, extrinsicValues)
+
+      expect(result.pi).toBeCloseTo(0.999764, 5)
+      expect(result.tau).toBe(UNIMIND_MAX_TAU_BPS)
     })
   });
 });

--- a/test/unit/util/unimind-algorithm.test.ts
+++ b/test/unit/util/unimind-algorithm.test.ts
@@ -7,6 +7,8 @@ import { UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_UPDATE_THRESHOLD } from '../../../
 import { PriceImpactStrategy } from '../../../lib/unimind/priceImpactStrategy';
 import { BatchedStrategy } from '../../../lib/unimind/batchedStrategy';
 import { unimindAddressFilter, UNIMIND_SAMPLE_PERCENT } from '../../../lib/util/unimind';
+import { calculateParameters } from '../../../lib/handlers/get-unimind/handler';
+import { QuoteMetadata } from '../../../lib/repositories/quote-metadata-repository';
 
 describe('unimind-algorithm', () => {
   const log = mock<Logger>()
@@ -199,6 +201,16 @@ describe('unimind-algorithm', () => {
       expect(result.lambda2).toBeCloseTo(4.237034026847578, 5)
       expect(result.Sigma).toBeCloseTo(-0.41228565543852524, 5)
     });
+
+    it('price impact strategy test on extrinsic values', () => {
+      const strategy = new PriceImpactStrategy()
+      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: Math.log(0.0001)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123',  };
+      const extrinsicValues: QuoteMetadata = { priceImpact: 0.01, quoteId: '0x000-0x111-123', referencePrice: '100', blockNumber: 100, route: { quote: '100', quoteGasAdjusted: '100', gasPriceWei: '100', gasUseEstimateQuote: '100', gasUseEstimate: '100', methodParameters: {calldata: '0x', value: '0', to: '0x0000000000000000000000000000000000000000'}}, pair: '0x000-0x111-123', usedUnimind: true }
+      const result = calculateParameters(strategy, intrinsicValues, extrinsicValues)
+
+      expect(result.pi).toBeCloseTo(0.999764, 5)
+      expect(result.tau).toBeCloseTo(31.000235519, 5)
+    })
   });
 });
 


### PR DESCRIPTION
- Set a ceiling for `tau` for user safety (with test)
- Fix bps unit bug in `f(extrinsic, intrinsic) -> pi, tau`
- Adjust `targetWaitTime` to 8 blocks
- Increase learning rates by 50%