### PR TITLE
feat: log fill block for DutchV3 orders

### DIFF
--- a/lib/handlers/check-order-status/fill-event-logger.ts
+++ b/lib/handlers/check-order-status/fill-event-logger.ts
@@ -22,6 +22,7 @@ export type ProcessFillEventRequest = {
   quoteId?: string
   tx?: ethers.providers.TransactionResponse
   block?: ethers.providers.Block
+  fillTimeBlocks?: number
   timestamp: number
 }
 export class FillEventLogger {
@@ -39,6 +40,7 @@ export class FillEventLogger {
     settledAmounts,
     tx,
     block,
+    fillTimeBlocks,
     timestamp,
   }: ProcessFillEventRequest): Promise<SettledAmount[]> {
     if (tx && block) {
@@ -59,6 +61,7 @@ export class FillEventLogger {
           receipt.effectiveGasPrice.toString(),
           receipt.gasUsed.toString(),
           receipt.effectiveGasPrice.sub(block.baseFeePerGas ?? 0).toString(),
+          fillTimeBlocks ?? -1, // -1 means we don't have a fill time in blocks
           filteredOutputs.reduce((prev, cur) => (prev && BigNumber.from(prev.amountOut).gt(cur.amountOut) ? prev : cur))
         )
       } else {

--- a/lib/handlers/check-order-status/service.ts
+++ b/lib/handlers/check-order-status/service.ts
@@ -90,10 +90,6 @@ export class CheckOrderStatusService {
     )
 
     const fromBlock = !startingBlockNumber ? curBlockNumber - this.fillEventBlockLookback(chainId) : startingBlockNumber
-    let fillTimeBlocks = startingBlockNumber ? curBlockNumber - startingBlockNumber : undefined // Approximate for non-DutchV3 orders
-    if (order.type === OrderType.Dutch_V3) { // For DutchV3 orders, we can calculate the exact fill time in blocks
-      fillTimeBlocks = curBlockNumber - order.cosignerData.decayStartBlock; 
-    }
     const commonUpdateInfo = {
       orderHash,
       quoteId,
@@ -122,6 +118,12 @@ export class CheckOrderStatusService {
             provider.getTransaction(fillEvent.txHash),
             provider.getBlock(fillEvent.blockNumber),
           ])
+
+          let fillTimeBlocks = startingBlockNumber ? block.number - startingBlockNumber : undefined // Approximate for non-DutchV3 orders
+          if (order.type === OrderType.Dutch_V3) { // For DutchV3 orders, we can calculate the exact fill time in blocks
+            fillTimeBlocks = block.number - order.cosignerData.decayStartBlock; 
+          }
+
           const settledAmounts = getSettledAmounts(
             fillEvent,
             {

--- a/lib/handlers/check-order-status/service.ts
+++ b/lib/handlers/check-order-status/service.ts
@@ -90,6 +90,7 @@ export class CheckOrderStatusService {
     )
 
     const fromBlock = !startingBlockNumber ? curBlockNumber - this.fillEventBlockLookback(chainId) : startingBlockNumber
+
     const commonUpdateInfo = {
       orderHash,
       quoteId,

--- a/lib/handlers/check-order-status/service.ts
+++ b/lib/handlers/check-order-status/service.ts
@@ -124,7 +124,7 @@ export class CheckOrderStatusService {
           let fillTimeBlocks: number | undefined = undefined;
           const fillBlock = block.number;
           switch (order.type) {
-            case OrderType.Dutch: // Approximatation
+            case OrderType.Dutch: // Approximation
               if (order.decayStartTime) {
                 fillTimeBlocks = fillBlock - timestampToBlockNumber(block, order.decayStartTime, chainId);
               }
@@ -135,10 +135,11 @@ export class CheckOrderStatusService {
             case OrderType.Dutch_V3: // Exact
               fillTimeBlocks = fillBlock - order.cosignerData.decayStartBlock;
               break;
-            case OrderType.Priority: // Approximation
+            case OrderType.Priority: { // Approximation
               const orderCreationBlock = order.cosignerData.auctionTargetBlock - PRIORITY_ORDER_TARGET_BLOCK_BUFFER[chainId as ChainId];
               fillTimeBlocks = fillBlock - orderCreationBlock;
               break;
+            }
           }
 
           const settledAmounts = getSettledAmounts(

--- a/lib/handlers/check-order-status/service.ts
+++ b/lib/handlers/check-order-status/service.ts
@@ -90,7 +90,10 @@ export class CheckOrderStatusService {
     )
 
     const fromBlock = !startingBlockNumber ? curBlockNumber - this.fillEventBlockLookback(chainId) : startingBlockNumber
-
+    let fillTimeBlocks = startingBlockNumber ? curBlockNumber - startingBlockNumber : undefined // Approximate for non-DutchV3 orders
+    if (order.type === OrderType.Dutch_V3) { // For DutchV3 orders, we can calculate the exact fill time in blocks
+      fillTimeBlocks = curBlockNumber - order.cosignerData.decayStartBlock; 
+    }
     const commonUpdateInfo = {
       orderHash,
       quoteId,
@@ -139,6 +142,7 @@ export class CheckOrderStatusService {
             settledAmounts,
             tx,
             block,
+            fillTimeBlocks,
             timestamp: block.timestamp,
           })
 

--- a/lib/handlers/check-order-status/util.ts
+++ b/lib/handlers/check-order-status/util.ts
@@ -261,6 +261,18 @@ export const AVERAGE_BLOCK_TIME = (chainId: ChainId): number => {
   }
 }
 
+// Approximate block number from timestamp
+export function timestampToBlockNumber(
+  referenceBlock: ethers.providers.Block,
+  targetTimestamp: number,
+  chainId: ChainId
+): number {
+  const secondsDifference = targetTimestamp - referenceBlock.timestamp;
+  const blockTimeSec = AVERAGE_BLOCK_TIME(chainId);
+  const blockDifference = Math.floor(secondsDifference / blockTimeSec);
+  return referenceBlock.number + blockDifference;
+};
+
 export const IS_TERMINAL_STATE = (state: ORDER_STATUS): boolean => {
   return [ORDER_STATUS.CANCELLED, ORDER_STATUS.FILLED, ORDER_STATUS.EXPIRED, ORDER_STATUS.ERROR].includes(state)
 }

--- a/lib/handlers/check-order-status/util.ts
+++ b/lib/handlers/check-order-status/util.ts
@@ -271,7 +271,7 @@ export function timestampToBlockNumber(
   const blockTimeSec = AVERAGE_BLOCK_TIME(chainId);
   const blockDifference = Math.floor(secondsDifference / blockTimeSec);
   return referenceBlock.number + blockDifference;
-};
+}
 
 export const IS_TERMINAL_STATE = (state: ORDER_STATUS): boolean => {
   return [ORDER_STATUS.CANCELLED, ORDER_STATUS.FILLED, ORDER_STATUS.EXPIRED, ORDER_STATUS.ERROR].includes(state)

--- a/lib/services/analytics-service.ts
+++ b/lib/services/analytics-service.ts
@@ -118,6 +118,7 @@ export class AnalyticsService implements AnalyticsServiceInterface {
     gasPriceWei: string,
     gasUsed: string,
     effectivePriorityFee: string,
+    fillTimeBlocks: number,
     userAmount: SettledAmount
   ): void {
     log.info('Fill Info', {
@@ -144,6 +145,7 @@ export class AnalyticsService implements AnalyticsServiceInterface {
         gasUsed: gasUsed,
         gasCostInETH: gasCostInETH,
         effectivePriorityFee: effectivePriorityFee,
+        fillTimeBlocks: fillTimeBlocks,
         logTime: Math.floor(Date.now() / 1000).toString(),
       },
     })

--- a/test/unit/handlers/fill-event-logger.test.ts
+++ b/test/unit/handlers/fill-event-logger.test.ts
@@ -114,6 +114,7 @@ describe('processFillEvent', () => {
       '1',
       '100',
       '0',
+      -1,
       settledAmounts  // Expect settleAmounts since it matches the output token
     )
   })


### PR DESCRIPTION
For DutchV3 orders, we can calculate an exact fill time in units of blocks. Logging it in `FillEventLogger` will propagate it to the Redshift S3 so that we can ingest it into BigQuery to add to our dashboards.