### PR TITLE
fix: prevent pair from being string "undefined"

### DIFF
--- a/lib/crons/unimind-algorithm.ts
+++ b/lib/crons/unimind-algorithm.ts
@@ -167,16 +167,10 @@ function getOrderCountsByPair(
 
   for (const order of orders) {
     let pair = order.pair;
-    // If pair is not already set, create it from input and output tokens
-    if (!pair && order.input && order.outputs) {
-      const inputToken = order.input.token;
-      const outputToken = order.outputs[0].token;
-      pair = `${inputToken}-${outputToken}-${order.chainId}`;
+    // If pair doesn't exist, it means there was no quote metadata, indicating that Unimind was not used
+    if (pair) {
+      pairCounts.set(pair, (pairCounts.get(pair) || 0) + 1);
     }
-    
-    if (!pair) continue;
-
-    pairCounts.set(pair, (pairCounts.get(pair) || 0) + 1);
   }
   
   return pairCounts;

--- a/lib/models/DutchV3Order.ts
+++ b/lib/models/DutchV3Order.ts
@@ -81,11 +81,13 @@ export class DutchV3Order extends Order {
       quoteId: this.quoteId,
       requestId: this.requestId,
       createdAt: this.createdAt,
-      referencePrice: quoteMetadata?.referencePrice,
-      priceImpact: quoteMetadata?.priceImpact,
-      route: quoteMetadata?.route,
-      pair: quoteMetadata?.pair,
-      usedUnimind: quoteMetadata?.usedUnimind
+      ...(quoteMetadata && {
+        referencePrice: quoteMetadata.referencePrice,
+        priceImpact: quoteMetadata.priceImpact,
+        route: quoteMetadata.route,
+        pair: quoteMetadata.pair,
+        usedUnimind: quoteMetadata.usedUnimind
+      })
     }
 
     return order


### PR DESCRIPTION
- When orders don't use Unimind, they don't have `QuoteMetadata` saved in the service
- When these orders are processed by Unimind, they appear to be the pair `"undefined"`
- Orders that did not use Unimind should have their `QuoteMetadata` be `undefined` and should not be processed by the Unimind cron