### PR TITLE
feat: clean detection of Unimind orders; detailed logging

### DIFF
--- a/lib/models/DutchV3Order.ts
+++ b/lib/models/DutchV3Order.ts
@@ -81,12 +81,12 @@ export class DutchV3Order extends Order {
       quoteId: this.quoteId,
       requestId: this.requestId,
       createdAt: this.createdAt,
+      usedUnimind: quoteMetadata?.usedUnimind ?? false,
       ...(quoteMetadata && {
         referencePrice: quoteMetadata.referencePrice,
         priceImpact: quoteMetadata.priceImpact,
         route: quoteMetadata.route,
-        pair: quoteMetadata.pair,
-        usedUnimind: quoteMetadata.usedUnimind
+        pair: quoteMetadata.pair
       })
     }
 

--- a/lib/repositories/IndexMappers/OffchainOrderIndexMapper.ts
+++ b/lib/repositories/IndexMappers/OffchainOrderIndexMapper.ts
@@ -107,7 +107,6 @@ export class OffchainOrderIndexMapper<T extends UniswapXOrderEntity | RelayOrder
       chainId_orderStatus: `${order.chainId}_${order.orderStatus}`,
       chainId_orderStatus_filler: `${order.chainId}_${order.orderStatus}_${order.filler}`,
       filler_offerer_orderStatus: `${order.filler}_${order.offerer}_${order.orderStatus}`,
-      pair: `${order.pair}`,
     }
   }
 
@@ -122,7 +121,6 @@ export class OffchainOrderIndexMapper<T extends UniswapXOrderEntity | RelayOrder
       filler_offerer_orderStatus: `${order.filler}_${order.offerer}_${newStatus}`,
       chainId_orderStatus: `${order.chainId}_${newStatus}`,
       chainId_orderStatus_filler: `${order.chainId}_${newStatus}_${order.filler}`,
-      pair: `${order.pair}`,
     }
   }
 }

--- a/test/integ/crons/unimind-algorithm.test.ts
+++ b/test/integ/crons/unimind-algorithm.test.ts
@@ -80,7 +80,7 @@ const mockOrder: DutchV3OrderEntity = {
     }
   },
   pair: "0x1-0x2-21",
-  usedUnimind: false
+  usedUnimind: true,
 }
 
 const mockOldPair = '0x4444444444444444444444444444444444444444-0x2222222222222222222222222222222222222222-42161'
@@ -88,6 +88,7 @@ const mockOldPairOrder: DutchV3OrderEntity = {
   ...mockOrder,
   orderHash: '0x1',
   pair: mockOldPair,
+  usedUnimind: true,
 }
 
 const mockNewPair = '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-42161'
@@ -95,6 +96,7 @@ const mockNewPairOrder : DutchV3OrderEntity = {
   ...mockOrder,
   orderHash: '0x0',
   pair: mockNewPair,
+  usedUnimind: true,
 }
 
 afterAll(async () => {

--- a/test/unit/repositories/OffchainOrderIndexMapper.test.ts
+++ b/test/unit/repositories/OffchainOrderIndexMapper.test.ts
@@ -129,7 +129,6 @@ describe('OffchainOrderIndexMapper', () => {
         filler_offerer_orderStatus: '0xFiller_0xOfferer_filled',
         filler_orderStatus: '0xFiller_filled',
         offerer_orderStatus: '0xOfferer_filled',
-        pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       })
     })
   })
@@ -151,7 +150,6 @@ describe('OffchainOrderIndexMapper', () => {
         filler_orderStatus: '0xFiller_insufficient-funds',
         offerer_orderStatus: '0xOfferer_insufficient-funds',
         orderStatus: 'insufficient-funds',
-        pair: '0x0000000000000000000000000000000000000000-0x1111111111111111111111111111111111111111-123',
       })
     })
   })


### PR DESCRIPTION
When non-Unimind `Dutch_V3` are posted in the `Orders` table, they do not have `QuoteMetadata` and thus have missing fields. 
One of these missing fields is the `pair` field, which is converted to the string `"undefined"` when fetched by DynamoDB.
Before, we tried to look at the existence of this field to determine if an order used Unimind or not. 
This change intelligently sets the `usedUnimind` variable upon insertion to the `Orders` table based on if `QuoteMetadata` exists. 

This works because Unimind orders have corresponding `QuoteMetadata` entries indexed by their `quoteId`. If `QuoteMetadata` exists, it's still possible for `usedUnimind` to still be set to `false`, which occurs when Unimind decides to assign public parameters (default 15, 15) to the quote. This case is also handled.