### PR TITLE
Update to QN

### DIFF
--- a/bin/stacks/reaper-stack.ts
+++ b/bin/stacks/reaper-stack.ts
@@ -61,7 +61,7 @@ export class ReaperStack extends Stack {
           ...environmentVariables,
           AWS_EMF_ENVIRONMENT: "Local",
           // update to trigger deployment
-          VERSION: "1",
+          VERSION: "2",
         },
         logging: this.logDriver,
       })


### PR DESCRIPTION
uniRPC isn't yet able to query events across block ranges due to AWS lambda limitation. Migrating back to QN until it's supported.