### PR TITLE
Fix Typo in Dynamo Stream Handler Documentation

### DIFF
--- a/lib/handlers/base/dynamo-stream-handler.ts
+++ b/lib/handlers/base/dynamo-stream-handler.ts
@@ -51,7 +51,7 @@ export abstract class DynamoStreamInjector<CInj, RInj> {
  *
  * DynamoDB streams will trigger this handler for new stream events
  * that fit the filter pattern in the lambda stack. The handler will
- * receieve a stream event and then parse the batched records to
+ * receive a stream event and then parse the batched records to
  * perform some action.
  */
 export abstract class DynamoStreamLambdaHandler<CInj, RInj> {


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the documentation comment of the DynamoStreamHandler class. The word `recieve` has been changed to the correct spelling `receive` for improved clarity and professionalism in the codebase. No functional code changes were made.
