### PR TITLE
feat: specify node version in CodeBuild

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -113,6 +113,20 @@ export class APIPipeline extends Stack {
       pipelineName: `${SERVICE_NAME}`,
       crossAccountKeys: true,
       synth: synthStep,
+      codeBuildDefaults: {
+        buildEnvironment: {
+          buildImage: cdk.aws_codebuild.LinuxBuildImage.STANDARD_7_0,
+        },
+        partialBuildSpec: BuildSpec.fromObject({
+          phases: {
+            install: {
+              'runtime-versions': {
+                nodejs: '18',
+              },
+            },
+          },
+        }),
+      },
     })
 
     // Secrets are stored in secrets manager in the pipeline account. Accounts we deploy to


### PR DESCRIPTION
AWS CDK from `2.1017` -> `2.1018` broke the CodeBuild pipeline:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'aws-cdk@2.1018.0',
npm WARN EBADENGINE   required: { node: '>= 18.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }
```
The default CodeBuild config seems to still use Node 16, which we should override