### PR TITLE
fix(pipeline): Set buildspec version

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -98,6 +98,8 @@ export class APIPipeline extends Stack {
         'npx cdk synth',
       ],
       partialBuildSpec: BuildSpec.fromObject({
+        // v0.2 runs all commands in the same context
+        version: '0.2',
         phases: {
           install: {
             'runtime-versions': {
@@ -118,6 +120,8 @@ export class APIPipeline extends Stack {
           buildImage: cdk.aws_codebuild.LinuxBuildImage.STANDARD_7_0,
         },
         partialBuildSpec: BuildSpec.fromObject({
+          // v0.2 runs all commands in the same context
+          version: '0.2',
           phases: {
             install: {
               'runtime-versions': {


### PR DESCRIPTION
[Container] 2025/06/05 20:00:49.825481 Running command npm install -g aws-cdk@2
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'aws-cdk@2.1018.0',
npm WARN EBADENGINE   required: { node: '>= 18.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }

The URA deployment is working and this is the only difference that I see:
https://github.com/Uniswap/backend/blob/52ba7430601d32b6b6914b175fac4d33d096d15c/packages/services/unified-routing-api/bin/app.ts#L95

This might ensure that the runtime-versions specification from in the synth step gets properly inherited by the self-mutate stage.
