### PR TITLE
fix: allow 0 priceImpact

### DIFF
--- a/lib/crons/unimind-algorithm.ts
+++ b/lib/crons/unimind-algorithm.ts
@@ -193,14 +193,14 @@ export function getStatistics(orders: DutchV3OrderEntity[], log: Logger): Unimin
   const priceImpacts: number[] = [];
 
   for (const order of orders) {
-    if (order.fillBlock && order.cosignerData?.decayStartBlock && order.priceImpact && 
+    if (order.fillBlock && order.cosignerData?.decayStartBlock && order.priceImpact != null && 
       order.orderStatus === ORDER_STATUS.FILLED) {
       waitTimes.push(order.fillBlock - order.cosignerData.decayStartBlock);
       fillStatuses.push(1);
       priceImpacts.push(order.priceImpact);
       log.info(`Unimind getStatistics: order ${order.orderHash} filled with wait time ${order.fillBlock - order.cosignerData.decayStartBlock}.` + 
                ` Its price impact was ${order.priceImpact}`)
-    } else if (order.priceImpact && order.orderStatus === ORDER_STATUS.EXPIRED) {
+    } else if (order.priceImpact != null && order.orderStatus === ORDER_STATUS.EXPIRED) {
       waitTimes.push(undefined);
       fillStatuses.push(0);
       priceImpacts.push(order.priceImpact);


### PR DESCRIPTION
After the price impact calculation fixes, sometimes price impact can be equal to 0
This would short-circuit a check that was intended to see if the field was accessible