### PR TITLE
feat(Reaper): Re-add all order types

### DIFF
--- a/lib/crons/gs-reaper/gs-reaper.ts
+++ b/lib/crons/gs-reaper/gs-reaper.ts
@@ -99,10 +99,10 @@ export class GSReaper {
       throw new Error(`No provider found for chainId ${chainId}`)
     }
     const currentBlock = await provider.getBlockNumber()
-    // Look back 24 hours from current block
-    const blocksIn24Hours = BLOCKS_IN_24_HOURS(chainId)
+    // Look back 1 week from current block
+    const blocksInOneWeek = BLOCKS_IN_24_HOURS(chainId) * 7
     const earliestBlock = Math.max(
-      currentBlock - blocksIn24Hours,
+      currentBlock - blocksInOneWeek,
       OLDEST_BLOCK_BY_CHAIN[chainId as keyof typeof OLDEST_BLOCK_BY_CHAIN]
     )
     this.log.info(`Initializing GS Reaper for chainId ${chainId} with current block ${currentBlock} and earliest block ${earliestBlock}`)

--- a/lib/crons/gs-reaper/gs-reaper.ts
+++ b/lib/crons/gs-reaper/gs-reaper.ts
@@ -2,8 +2,8 @@ import { DynamoDB } from 'aws-sdk'
 import { default as bunyan, default as Logger } from 'bunyan'
 import { ORDER_STATUS, SettledAmount, UniswapXOrderEntity } from '../../entities'
 import { BaseOrdersRepository, QueryResult } from '../../repositories/base'
-// import { DutchOrdersRepository } from '../../repositories/dutch-orders-repository'
-import { BLOCK_RANGE, REAPER_MAX_ATTEMPTS, DYNAMO_BATCH_WRITE_MAX, OLDEST_BLOCK_BY_CHAIN, REAPER_RANGES_PER_RUN, RPC_HEADERS } from '../../util/constants'
+import { DutchOrdersRepository } from '../../repositories/dutch-orders-repository'
+import { BLOCK_RANGE, REAPER_MAX_ATTEMPTS, DYNAMO_BATCH_WRITE_MAX, OLDEST_BLOCK_BY_CHAIN, REAPER_RANGES_PER_RUN, RPC_HEADERS, BLOCKS_IN_24_HOURS } from '../../util/constants'
 import { ethers } from 'ethers'
 import { CosignedPriorityOrder, CosignedV2DutchOrder, CosignedV3DutchOrder, DutchOrder, FillInfo, OrderType, OrderValidation, OrderValidator, REACTOR_ADDRESS_MAPPING, UniswapXEventWatcher, UniswapXOrder } from '@uniswap/uniswapx-sdk'
 import { parseOrder } from '../../handlers/OrderParser'
@@ -99,11 +99,17 @@ export class GSReaper {
       throw new Error(`No provider found for chainId ${chainId}`)
     }
     const currentBlock = await provider.getBlockNumber()
-    this.log.info(`Initializing GS Reaper for chainId ${chainId} with current block ${currentBlock} and earliest block ${OLDEST_BLOCK_BY_CHAIN[chainId as keyof typeof OLDEST_BLOCK_BY_CHAIN]}`)
+    // Look back 24 hours from current block
+    const blocksIn24Hours = BLOCKS_IN_24_HOURS(chainId)
+    const earliestBlock = Math.max(
+      currentBlock - blocksIn24Hours,
+      OLDEST_BLOCK_BY_CHAIN[chainId as keyof typeof OLDEST_BLOCK_BY_CHAIN]
+    )
+    this.log.info(`Initializing GS Reaper for chainId ${chainId} with current block ${currentBlock} and earliest block ${earliestBlock}`)
     return {
       chainId,
       currentBlock,
-      earliestBlock: OLDEST_BLOCK_BY_CHAIN[chainId as keyof typeof OLDEST_BLOCK_BY_CHAIN],
+      earliestBlock,
       orderUpdates: {},
       orderHashes: [],
       stage: ReaperStage.GET_OPEN_ORDERS
@@ -476,14 +482,14 @@ async function getOrderFillInfo(
 }
 
 async function startReapers() {
-  // const dutchReaper = new GSReaper(DutchOrdersRepository.create(new DynamoDB.DocumentClient()))
+  const dutchReaper = new GSReaper(DutchOrdersRepository.create(new DynamoDB.DocumentClient()))
   const limitReaper = new GSReaper(LimitOrdersRepository.create(new DynamoDB.DocumentClient()))
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    // await dutchReaper.start().catch(error => {
-    //   console.error('Fatal error in GS Reaper:', error)
-    //   process.exit(1)
-    // })
+    await dutchReaper.start().catch(error => {
+      console.error('Fatal error in GS Reaper:', error)
+      process.exit(1)
+    })
     await limitReaper.start().catch(error => {
       console.error('Fatal error in GS Reaper:', error)
       process.exit(1)

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -9,9 +9,9 @@ export const ONE_DAY_IN_SECONDS = 60 * 60 * 24
 export const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365
 export const OLDEST_BLOCK_BY_CHAIN = {
   [ChainId.MAINNET]: 20120259,
-  // [ChainId.ARBITRUM_ONE]: 253597707,
-  // [ChainId.BASE]: 22335646,
-  // [ChainId.UNICHAIN]: 6747397,
+  [ChainId.ARBITRUM_ONE]: 253597707,
+  [ChainId.BASE]: 22335646,
+  [ChainId.UNICHAIN]: 6747397,
 }
 export const BLOCK_TIME_MS_BY_CHAIN = {
   [ChainId.MAINNET]: 12000,

--- a/test/unit/handlers/gs-reaper/gs-reaper.test.ts
+++ b/test/unit/handlers/gs-reaper/gs-reaper.test.ts
@@ -57,10 +57,10 @@ const mockOrdersRepository = {
   })
 }
 
-// 48 hours from oldest block to test the 24 hour lookback
+// 2 weeks from oldest block to test the 1 week lookback
 const getCurrentBlock = (chainId: ChainId) => {
-  const blocksIn48Hours = BLOCKS_IN_24_HOURS(chainId) * 2
-  return OLDEST_BLOCK_BY_CHAIN[chainId] + blocksIn48Hours
+  const blocksInTwoWeeks = BLOCKS_IN_24_HOURS(chainId) * 14
+  return OLDEST_BLOCK_BY_CHAIN[chainId] + blocksInTwoWeeks
 }
 
 // Setup mock provider
@@ -187,7 +187,7 @@ describe('GSReaper', () => {
       expect(state).toEqual({
         chainId: ChainId.MAINNET,
         currentBlock,
-        earliestBlock: currentBlock - BLOCKS_IN_24_HOURS(ChainId.MAINNET),
+        earliestBlock: currentBlock - (BLOCKS_IN_24_HOURS(ChainId.MAINNET) * 7),
         orderUpdates: {},
         orderHashes: [],
         stage: ReaperStage.GET_OPEN_ORDERS

--- a/test/unit/handlers/gs-reaper/gs-reaper.test.ts
+++ b/test/unit/handlers/gs-reaper/gs-reaper.test.ts
@@ -4,7 +4,7 @@ import { OrderType, REACTOR_ADDRESS_MAPPING, OrderValidation } from '@uniswap/un
 import { default as bunyan, default as Logger } from 'bunyan'
 import { GSReaper, ReaperStage } from '../../../../lib/crons/gs-reaper/gs-reaper'
 import { ORDER_STATUS } from '../../../../lib/entities'
-import { BLOCK_RANGE, REAPER_RANGES_PER_RUN, OLDEST_BLOCK_BY_CHAIN, REAPER_MAX_ATTEMPTS } from '../../../../lib/util/constants'
+import { BLOCK_RANGE, REAPER_RANGES_PER_RUN, OLDEST_BLOCK_BY_CHAIN, REAPER_MAX_ATTEMPTS, BLOCKS_IN_24_HOURS } from '../../../../lib/util/constants'
 import { ChainId } from '../../../../lib/util/chain'
 import { MOCK_ORDER_ENTITY, MOCK_V2_ORDER_ENTITY } from '../../../test-data'
 
@@ -57,12 +57,19 @@ const mockOrdersRepository = {
   })
 }
 
+// 48 hours from oldest block to test the 24 hour lookback
+const getCurrentBlock = (chainId: ChainId) => {
+  const blocksIn48Hours = BLOCKS_IN_24_HOURS(chainId) * 2
+  return OLDEST_BLOCK_BY_CHAIN[chainId] + blocksIn48Hours
+}
+
 // Setup mock provider
 const mockProviders = new Map<ChainId, ethers.providers.StaticJsonRpcProvider>()
 for (const chainIdKey of Object.keys(OLDEST_BLOCK_BY_CHAIN)) {
   const chainId = Number(chainIdKey)
+  const currentBlock = getCurrentBlock(chainId)
   const mockProvider = {
-    getBlockNumber: jest.fn().mockResolvedValue(OLDEST_BLOCK_BY_CHAIN[chainId] + BLOCK_RANGE * REAPER_RANGES_PER_RUN),
+    getBlockNumber: jest.fn().mockResolvedValue(currentBlock),
     getTransaction: jest.fn().mockResolvedValue({
       gasPrice: '1000000000',
       maxPriorityFeePerGas: null,
@@ -175,11 +182,12 @@ describe('GSReaper', () => {
   describe('state machine', () => {
     it('initializes first chain state correctly', async () => {
       const state = await reaper.initializeChainState(ChainId.MAINNET)
+      const currentBlock = getCurrentBlock(ChainId.MAINNET)
       
       expect(state).toEqual({
         chainId: ChainId.MAINNET,
-        currentBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET] + BLOCK_RANGE * REAPER_RANGES_PER_RUN,
-        earliestBlock: OLDEST_BLOCK_BY_CHAIN[ChainId.MAINNET],
+        currentBlock,
+        earliestBlock: currentBlock - BLOCKS_IN_24_HOURS(ChainId.MAINNET),
         orderUpdates: {},
         orderHashes: [],
         stage: ReaperStage.GET_OPEN_ORDERS
@@ -274,9 +282,8 @@ describe('GSReaper', () => {
 
       // Verify we're moving to the next chain
       const chainIds = Object.keys(OLDEST_BLOCK_BY_CHAIN).map(Number)
-      // Temporarily disable this test until re-add other chains
-      // expect(result?.chainId).toBe(chainIds[chainIds.indexOf(ChainId.MAINNET) + 1])
-      // expect(result?.stage).toBe(ReaperStage.GET_OPEN_ORDERS)
+      expect(result?.chainId).toBe(chainIds[chainIds.indexOf(ChainId.MAINNET) + 1])
+      expect(result?.stage).toBe(ReaperStage.GET_OPEN_ORDERS)
     })
 
     it('returns null when processing UPDATE_DB stage for the last chain', async () => {


### PR DESCRIPTION
Now that we've processed through the backlog of incorrectly labeled orders, we can decrease the lookback and reintroduce all chains/order-types.

- Lookback of 1 week
  - We still have a lot of open limit orders so if it takes multiple days to go through all orders, we want to make sure we don't miss any updates.
- Re-adds dutchReaper and non-Mainnet chains

Since each reaper instance keeps track of the current order query `cursor` by chain, the flow will look something like this:
1. DutchReaper
  a.  Process 1000 orders for Mainnet
  b.  Process 1000 orders for Arbitrum
  c.  Process 1000 orders for Base
  d.  Process 1000 orders for Unichain
2. LimitOrder
  a.  Process 1000 orders for Mainnet
3. DutchReaper
  a.  Process _the next_ 1000 orders for Mainnet
  b.  Process _the next_ 1000 orders for Arbitrum
  c. ...

After all orders have been processed, reset cursor to 0 and reprocess the first 1000.