### PR TITLE
feat: add dashboard panel for proportion of Unimind orders with negative pi parameter

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -63,7 +63,7 @@ export class APIStack extends cdk.Stack {
       chainIdToStatusTrackingStateMachineArn,
       checkStatusFunction,
       getUnimindLambdaAlias,
-      // getUnimindLambda, TODO: dashboard
+      getUnimindLambda
     } = new LambdaStack(this, `${SERVICE_NAME}LambdaStack`, {
       provisionedConcurrency,
       stage: stage as STAGE,
@@ -438,6 +438,7 @@ export class APIStack extends cdk.Stack {
       postOrderLambdaName: postOrderLambda.functionName,
       getNonceLambdaName: getNonceLambda.functionName,
       getOrdersLambdaName: getOrdersLambda.functionName,
+      getUnimindLambdaName: getUnimindLambda.functionName,
       chainIdToStatusTrackingStateMachineArn,
       orderStatusLambdaName: checkStatusFunction.functionName,
     })

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -592,6 +592,32 @@ export class DashboardStack extends cdk.NestedStack {
               title: 'Unimind Calculation Times (ms)',
             },
           },
+          {
+            height: 6,
+            width: 12,
+            y: 6,
+            x: 0,
+            type: 'metric',
+            properties: {
+              metrics: [
+                [{ expression: '(negativePi/successfulRequests) * 100', label: 'Negative Pi Percentage', id: 'e1' }],
+                ['Uniswap', 'UnimindNegativePi', 'Service', 'UniswapXService', { id: 'negativePi', visible: false }],
+                ['Uniswap', 'GetUnimindStatus2XX', 'Service', 'UniswapXService', { id: 'successfulRequests', visible: false }],
+              ],
+              view: 'timeSeries',
+              stacked: false,
+              region,
+              stat: 'Sum',
+              period: 300,
+              title: 'Percentage of Orders with Negative Pi',
+              yAxis: {
+                left: {
+                  showUnits: false,
+                  label: '%',
+                },
+              },
+            },
+          },
         ],
       }),
     })

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -614,9 +614,9 @@ export class DashboardStack extends cdk.NestedStack {
             type: 'metric',
             properties: {
               metrics: [
-                [{ expression: '(negativePi/successfulRequests) * 100', label: 'Negative Pi Percentage', id: 'e1' }],
+                [{ expression: '(negativePi/(positivePi + negativePi)) * 100', label: 'Negative Pi Percentage', id: 'e1' }],
                 ['Uniswap', 'UnimindNegativePi', 'Service', 'UniswapXService', { id: 'negativePi', visible: false }],
-                ['Uniswap', 'GetUnimindStatus2XX', 'Service', 'UniswapXService', { id: 'successfulRequests', visible: false }],
+                ['Uniswap', 'UnimindPositivePi', 'Service', 'UniswapXService', { id: 'positivePi', visible: false }],
               ],
               view: 'timeSeries',
               stacked: false,
@@ -630,6 +630,38 @@ export class DashboardStack extends cdk.NestedStack {
                   label: '%',
                 },
               },
+            },
+          },
+          {
+            height: 6,
+            width: 6,
+            y: 6,
+            x: 12,
+            type: 'metric',
+            properties: {
+              metrics: [
+                ['Uniswap', 'UnimindPositivePi', 'Service', 'UniswapXService', { stat: 'Sum' }],
+              ],
+              view: 'singleValue',
+              region,
+              period: 86400,
+              title: 'Positive Pi Requests (Last 24h)',
+            },
+          },
+          {
+            height: 6,
+            width: 6,
+            y: 6,
+            x: 18,
+            type: 'metric',
+            properties: {
+              metrics: [
+                ['Uniswap', 'UnimindNegativePi', 'Service', 'UniswapXService', { stat: 'Sum' }],
+              ],
+              view: 'singleValue',
+              region,
+              period: 86400,
+              title: 'Negative Pi Requests (Last 24h)',
             },
           },
         ],

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -562,10 +562,10 @@ export class DashboardStack extends cdk.NestedStack {
             type: 'metric',
             properties: {
               metrics: [
-                ['Uniswap', 'PostUnimindRequest', 'Service', 'UniswapXService'],
-                ['.', 'PostUnimindStatus2XX', '.', '.'],
-                ['.', 'PostUnimindStatus4XX', '.', '.'],
-                ['.', 'PostUnimindStatus5XX', '.', '.'],
+                ['Uniswap', 'GetUnimindRequest', 'Service', 'UniswapXService'],
+                ['.', 'GetUnimindStatus2XX', '.', '.'],
+                ['.', 'GetUnimindStatus4XX', '.', '.'],
+                ['.', 'GetUnimindStatus5XX', '.', '.'],
               ],
               view: 'timeSeries',
               stacked: false,

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -614,7 +614,7 @@ export class DashboardStack extends cdk.NestedStack {
             x: 0,
             type: 'log',
             properties: {
-              query: `SOURCE '/aws/lambda/${getUnimindLambdaName}' | filter eventType = "UnimindPiCalculated" | stats count(*) as total, count(pi < 0) as negative, count(pi > 0) as positive | fields (negative / (negative + positive)) * 100 as negativePiPercentage`,
+              query: `SOURCE '/aws/lambda/${getUnimindLambdaName}' | filter eventType = "UnimindPiCalculated" | stats count(*) as total, count(pi <= 0) as negative, count(pi > 0) as positive | fields (negative / (negative + positive)) * 100 as negativePiPercentage`,
               region,
               stacked: false,
               view: 'timeSeries',

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -612,25 +612,13 @@ export class DashboardStack extends cdk.NestedStack {
             width: 12,
             y: 6,
             x: 0,
-            type: 'metric',
+            type: 'log',
             properties: {
-              metrics: [
-                [{ expression: '(negativePi/(positivePi + negativePi)) * 100', label: 'Negative Pi Percentage', id: 'e1' }],
-                ['Uniswap', 'UnimindNegativePi', 'Service', 'UniswapXService', { id: 'negativePi', visible: false }],
-                ['Uniswap', 'UnimindPositivePi', 'Service', 'UniswapXService', { id: 'positivePi', visible: false }],
-              ],
-              view: 'timeSeries',
-              stacked: false,
+              query: `SOURCE '/aws/lambda/${getUnimindLambdaName}' | filter eventType = "UnimindPiCalculated" | stats count(*) as total, count(pi < 0) as negative, count(pi > 0) as positive | fields (negative / (negative + positive)) * 100 as negativePiPercentage`,
               region,
-              stat: 'Sum',
-              period: 300,
+              stacked: false,
+              view: 'timeSeries',
               title: 'Percentage of Orders with Negative Pi',
-              yAxis: {
-                left: {
-                  showUnits: false,
-                  label: '%',
-                },
-              },
             },
           },
           {

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -669,7 +669,7 @@ export class DashboardStack extends cdk.NestedStack {
             x: 0,
             type: 'log',
             properties: {
-              query: `SOURCE '/aws/lambda/${getUnimindLambdaName}' | fields floor(pi) as bucket | filter eventType = "UnimindPiCalculated" | filter bucket >= -15 and bucket <= 15 | stats count() by bucket | sort bucket asc`,
+              query: `SOURCE '/aws/lambda/${getUnimindLambdaName}' | filter eventType = "UnimindPiCalculated" | fields floor(max(min(pi, 15.999), -15)) as bucket | stats count() by bucket | sort bucket asc`,
               region,
               stacked: false,
               view: 'bar',

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -571,7 +571,14 @@ export class DashboardStack extends cdk.NestedStack {
               stacked: false,
               region,
               stat: 'Sum',
+              period: 300,
               title: 'Unimind Requests/Responses',
+              yAxis: {
+                left: {
+                  showUnits: true,
+                  label: 'Count',
+                },
+              },
             },
           },
           {
@@ -589,7 +596,14 @@ export class DashboardStack extends cdk.NestedStack {
               stacked: false,
               region,
               stat: 'Average',
+              period: 300,
               title: 'Unimind Calculation Times (ms)',
+              yAxis: {
+                left: {
+                  showUnits: true,
+                  label: 'Milliseconds',
+                },
+              },
             },
           },
           {

--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -94,14 +94,7 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
       // Track pi values for distribution analysis
       metrics.putMetric(`UnimindPiValue`, parameters.pi, Unit.None)
       
-      // Track negative and positive pi values for counting
-      if (parameters.pi <= 0) {
-        metrics.putMetric(`UnimindNegativePi`, 1, Unit.Count)
-      } else if (parameters.pi > 0) {
-        metrics.putMetric(`UnimindPositivePi`, 1, Unit.Count)
-      }
-      
-      // Log pi values for histogram analysis in CloudWatch Logs Insights
+      // Log pi values for all analysis in CloudWatch Logs Insights
       log.info({
         eventType: 'UnimindPiCalculated',
         pi: parameters.pi,

--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -91,12 +91,14 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
       const calculateTime = afterCalculateTime - beforeCalculateTime
       metrics.putMetric(`final-parameters-calculation-time`, calculateTime)
 
-      // Track negative pi values
+      // Track negative and positive pi values
       if (parameters.pi < 0) {
         metrics.putMetric(`UnimindNegativePi`, 1, Unit.Count)
         log.info(
           `Negative pi detected for pair ${requestQueryParams.pair} with pi=${parameters.pi}, quoteId=${quoteMetadata.quoteId}`
         )
+      } else if (parameters.pi > 0) {
+        metrics.putMetric(`UnimindPositivePi`, 1, Unit.Count)
       }
 
       log.info(

--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -91,15 +91,25 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
       const calculateTime = afterCalculateTime - beforeCalculateTime
       metrics.putMetric(`final-parameters-calculation-time`, calculateTime)
 
-      // Track negative and positive pi values
-      if (parameters.pi < 0) {
+      // Track pi values for distribution analysis
+      metrics.putMetric(`UnimindPiValue`, parameters.pi, Unit.None)
+      
+      // Track negative and positive pi values for counting
+      if (parameters.pi <= 0) {
         metrics.putMetric(`UnimindNegativePi`, 1, Unit.Count)
-        log.info(
-          `Negative pi detected for pair ${requestQueryParams.pair} with pi=${parameters.pi}, quoteId=${quoteMetadata.quoteId}`
-        )
       } else if (parameters.pi > 0) {
         metrics.putMetric(`UnimindPositivePi`, 1, Unit.Count)
       }
+      
+      // Log pi values for histogram analysis in CloudWatch Logs Insights
+      log.info({
+        eventType: 'UnimindPiCalculated',
+        pi: parameters.pi,
+        tau: parameters.tau,
+        pair: requestQueryParams.pair,
+        quoteId: quoteMetadata.quoteId,
+        priceImpact: quoteMetadata.priceImpact
+      })
 
       log.info(
         `For the pair ${requestQueryParams.pair} with price impact of ${quoteMetadata.priceImpact}, pi is ${parameters.pi} and tau is ${parameters.tau}. The quoteId is ${quoteMetadata.quoteId}`

--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -91,6 +91,14 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
       const calculateTime = afterCalculateTime - beforeCalculateTime
       metrics.putMetric(`final-parameters-calculation-time`, calculateTime)
 
+      // Track negative pi values
+      if (parameters.pi < 0) {
+        metrics.putMetric(`UnimindNegativePi`, 1, Unit.Count)
+        log.info(
+          `Negative pi detected for pair ${requestQueryParams.pair} with pi=${parameters.pi}, quoteId=${quoteMetadata.quoteId}`
+        )
+      }
+
       log.info(
         `For the pair ${requestQueryParams.pair} with price impact of ${quoteMetadata.priceImpact}, pi is ${parameters.pi} and tau is ${parameters.tau}. The quoteId is ${quoteMetadata.quoteId}`
       )


### PR DESCRIPTION
- Fix typo in the requests/responses panel
- Add panel for the % of the Unimind orders that are suggested an auction start price lower than the AMM
- Add panel for the percentiles of pi values
- Add panel for the histogram of pi values (bucketed by 1bps)