### PR TITLE
feat, test: add Unimind computation guardrails; fine-tune learning rates

### DIFF
--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -7,7 +7,7 @@ import { Unit } from 'aws-embedded-metrics'
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
 import { metrics } from '../../util/metrics'
 import { UnimindQueryParams, unimindQueryParamsSchema } from './schema'
-import { DEFAULT_UNIMIND_PARAMETERS, PUBLIC_UNIMIND_PARAMETERS, UNIMIND_ALGORITHM_VERSION, UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_MAX_TAU_BPS } from '../../util/constants'
+import { DEFAULT_UNIMIND_PARAMETERS, PUBLIC_UNIMIND_PARAMETERS, UNIMIND_ALGORITHM_VERSION, UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_MAX_TAU_BPS, USE_CLASSIC_PARAMETERS } from '../../util/constants'
 import { IUnimindAlgorithm, supportedUnimindTokens, unimindAddressFilter } from '../../util/unimind'
 import { PriceImpactIntrinsicParameters, PriceImpactStrategy } from '../../unimind/priceImpactStrategy'
 import { validateParameters } from '../../crons/unimind-algorithm'
@@ -44,10 +44,7 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
         }
         return {
           statusCode: 200,
-          body: {
-            pi: 0,
-            tau: 0
-          }
+          body: USE_CLASSIC_PARAMETERS
         }
       }
 
@@ -85,7 +82,7 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
 
       const beforeCalculateTime = Date.now()
       const strategy = new PriceImpactStrategy()
-      const parameters = calculateParameters(strategy, unimindParameters, quoteMetadata)
+      const parameters = calculateParameters(strategy, unimindParameters, quoteMetadata, log)
       // TODO: Add condition for not using Unimind with bad parameters
       const afterCalculateTime = Date.now()
       const calculateTime = afterCalculateTime - beforeCalculateTime
@@ -163,8 +160,41 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
   }
 }
 
-export function calculateParameters(strategy: IUnimindAlgorithm<PriceImpactIntrinsicParameters>, unimindParameters: UnimindParameters, extrinsicValues: QuoteMetadata): UnimindResponse {
+export function calculateParameters(strategy: IUnimindAlgorithm<PriceImpactIntrinsicParameters>, unimindParameters: UnimindParameters, extrinsicValues: QuoteMetadata, log?: any): UnimindResponse {
   const intrinsicValues = JSON.parse(unimindParameters.intrinsicValues)
+  
+  // Guardrail 1: Disallow negative lambda2 values
+  if (intrinsicValues.lambda2 < 0) {
+    if (log) {
+      log.info({
+        eventType: 'UnimindGuardrailTriggered',
+        guardrailType: 'lambda2_negative',
+        lambda2: intrinsicValues.lambda2,
+        pair: unimindParameters.pair,
+        quoteId: extrinsicValues.quoteId,
+        priceImpact: extrinsicValues.priceImpact
+      }, `Unimind guardrail triggered: Lambda2 < 0 (${intrinsicValues.lambda2}), returning classic parameters`)
+    }
+    metrics.putMetric('UnimindGuardrailLambda2Negative', 1)
+    return USE_CLASSIC_PARAMETERS
+  }
+  
+  // Guardrail 2: Disallow large price impact
+  if (extrinsicValues.priceImpact > 2) {
+    if (log) {
+      log.info({
+        eventType: 'UnimindGuardrailTriggered',
+        guardrailType: 'price_impact_too_high',
+        priceImpact: extrinsicValues.priceImpact,
+        pair: unimindParameters.pair,
+        quoteId: extrinsicValues.quoteId,
+        lambda2: intrinsicValues.lambda2
+      }, `Unimind guardrail triggered: Price impact > 2% (${extrinsicValues.priceImpact}%), returning classic parameters`)
+    }
+    metrics.putMetric('UnimindGuardrailPriceImpactHigh', 1)
+    return USE_CLASSIC_PARAMETERS
+  }
+  
   // Keeping intrinsic extrinsic naming for consistency with algorithm
   const pi = strategy.computePi(intrinsicValues, extrinsicValues)
   // Ceiling tau at UNIMIND_MAX_TAU_BPS for safety

--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -7,7 +7,7 @@ import { Unit } from 'aws-embedded-metrics'
 import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda'
 import { metrics } from '../../util/metrics'
 import { UnimindQueryParams, unimindQueryParamsSchema } from './schema'
-import { DEFAULT_UNIMIND_PARAMETERS, PUBLIC_UNIMIND_PARAMETERS, UNIMIND_ALGORITHM_VERSION, UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_MAX_TAU_BPS, USE_CLASSIC_PARAMETERS } from '../../util/constants'
+import { DEFAULT_UNIMIND_PARAMETERS, PUBLIC_UNIMIND_PARAMETERS, UNIMIND_ALGORITHM_VERSION, UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD, UNIMIND_MAX_TAU_BPS, USE_CLASSIC_PARAMETERS } from '../../util/constants'
 import { IUnimindAlgorithm, supportedUnimindTokens, unimindAddressFilter } from '../../util/unimind'
 import { PriceImpactIntrinsicParameters, PriceImpactStrategy } from '../../unimind/priceImpactStrategy'
 import { validateParameters } from '../../crons/unimind-algorithm'
@@ -180,7 +180,7 @@ export function calculateParameters(strategy: IUnimindAlgorithm<PriceImpactIntri
   }
   
   // Guardrail 2: Disallow large price impact
-  if (extrinsicValues.priceImpact > 2) {
+  if (extrinsicValues.priceImpact > UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD) {
     if (log) {
       log.info({
         eventType: 'UnimindGuardrailTriggered',
@@ -189,7 +189,7 @@ export function calculateParameters(strategy: IUnimindAlgorithm<PriceImpactIntri
         pair: unimindParameters.pair,
         quoteId: extrinsicValues.quoteId,
         lambda2: intrinsicValues.lambda2
-      }, `Unimind guardrail triggered: Price impact > 2% (${extrinsicValues.priceImpact}%), returning classic parameters`)
+      }, `Unimind guardrail triggered: Price impact > ${UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD}% (${extrinsicValues.priceImpact}%), returning classic parameters`)
     }
     metrics.putMetric('UnimindGuardrailPriceImpactHigh', 1)
     return USE_CLASSIC_PARAMETERS

--- a/lib/unimind/priceImpactStrategy.ts
+++ b/lib/unimind/priceImpactStrategy.ts
@@ -16,8 +16,8 @@ export class PriceImpactStrategy implements IUnimindAlgorithm<PriceImpactIntrins
     private TARGET_FILL_RATE = 0.96;
     private TARGET_WAIT_TIME_IN_BLOCKS = 8;
     private BETA = 1;
-    private LAMBDA1_LEARNING_RATE = 5.75e-10; // Midpoint of 1.5e-10 and 1e-9
-    private LAMBDA2_LEARNING_RATE = 0.575; // Midpoint of 1 and 1.5e-1
+    private LAMBDA1_LEARNING_RATE = 3.625e-10; // Midpoint of 1.5e-10 and 5.75e-10
+    private LAMBDA2_LEARNING_RATE = 0.3625; // Midpoint of 0.15 and 0.575
     private SIGMA_LEARNING_RATE = 1e-6;
 
     private LENGTH_OF_AUCTION_IN_BLOCKS = 32;

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -43,6 +43,7 @@ export const PUBLIC_UNIMIND_PARAMETERS = {
   tau: 15
 }
 export const UNIMIND_MAX_TAU_BPS = 25
+export const UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD = 2 // 2% price impact threshold
 
 // When pi = 0, AMM will be favored over Dutch Auction
 export const USE_CLASSIC_PARAMETERS = {

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -44,6 +44,12 @@ export const PUBLIC_UNIMIND_PARAMETERS = {
 }
 export const UNIMIND_MAX_TAU_BPS = 25
 
+// When pi = 0, AMM will be favored over Dutch Auction
+export const USE_CLASSIC_PARAMETERS = {
+  pi: 0,
+  tau: 0
+}
+
 export const RPC_HEADERS = {
   'x-uni-service-id': 'x_order_service'
 } as const

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -29,7 +29,7 @@ export const REAPER_RANGES_PER_RUN = 10
 //Dynamo limits batch write to 25
 export const DYNAMO_BATCH_WRITE_MAX = 25
 
-export const UNIMIND_ALGORITHM_VERSION = 3;
+export const UNIMIND_ALGORITHM_VERSION = 4;
 export const DEFAULT_UNIMIND_PARAMETERS = JSON.stringify({
   lambda1: 0,
   lambda2: 5,

--- a/test/unit/handlers/get-unimind/get-unimind.test.ts
+++ b/test/unit/handlers/get-unimind/get-unimind.test.ts
@@ -5,7 +5,7 @@ import { calculateParameters, GetUnimindHandler } from '../../../../lib/handlers
 import { QuoteMetadataRepository } from '../../../../lib/repositories/quote-metadata-repository'
 import { UnimindParametersRepository } from '../../../../lib/repositories/unimind-parameters-repository'
 import { ErrorCode } from '../../../../lib/handlers/base'
-import { DEFAULT_UNIMIND_PARAMETERS, UNIMIND_ALGORITHM_VERSION, UNIMIND_DEV_SWAPPER_ADDRESS } from '../../../../lib/util/constants'
+import { DEFAULT_UNIMIND_PARAMETERS, UNIMIND_ALGORITHM_VERSION, UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD } from '../../../../lib/util/constants'
 import { CommandParser, CommandType } from '@uniswap/universal-router-sdk'
 import { Interface } from 'ethers/lib/utils'
 import { artemisModifyCalldata, UniversalRouterCalldata } from '../../../../lib/util/UniversalRouterCalldata'
@@ -715,7 +715,7 @@ describe('Correctly modify URA calldata for Artemis support', () => {
       )
     })
     
-    it('returns classic parameters (0,0) when price impact > 2%', () => {
+    it(`returns classic parameters (0,0) when price impact > ${UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD}%`, () => {
       const strategy = new PriceImpactStrategy()
       const unimindParameters = {
         pair: SAMPLE_SUPPORTED_UNIMIND_PAIR,
@@ -731,7 +731,7 @@ describe('Correctly modify URA calldata for Artemis support', () => {
         quoteId: 'test-quote-id',
         pair: SAMPLE_SUPPORTED_UNIMIND_PAIR,
         referencePrice: '4221.21',
-        priceImpact: 2.5, // > 2%
+        priceImpact: UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD + 0.5, // > threshold
         route: SAMPLE_ROUTE,
         blockNumber: 12345,
         usedUnimind: true
@@ -745,13 +745,13 @@ describe('Correctly modify URA calldata for Artemis support', () => {
         expect.objectContaining({
           eventType: 'UnimindGuardrailTriggered',
           guardrailType: 'price_impact_too_high',
-          priceImpact: 2.5
+          priceImpact: UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD + 0.5
         }),
-        expect.stringContaining('Price impact > 2%')
+        expect.stringContaining(`Price impact > ${UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD}%`)
       )
     })
     
-    it('computes normal parameters when both lambda2 >= 0 and price impact <= 2%', () => {
+    it(`computes normal parameters when both lambda2 >= 0 and price impact <= ${UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD}%`, () => {
       const strategy = new PriceImpactStrategy()
       const unimindParameters = {
         pair: SAMPLE_SUPPORTED_UNIMIND_PAIR,

--- a/test/unit/util/unimind-algorithm.test.ts
+++ b/test/unit/util/unimind-algorithm.test.ts
@@ -212,6 +212,17 @@ describe('unimind-algorithm', () => {
       expect(result.tau).toBeCloseTo(15.000235519, 5)
     })
 
+    it('price impact strategy test on extrinsic values with big price impact', () => {
+      const strategy = new PriceImpactStrategy()
+      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 1, Sigma: Math.log(0.00005)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION };
+      const extrinsicValues: QuoteMetadata = { priceImpact: 2.1, quoteId: '0x000-0x111-123', referencePrice: '100', blockNumber: 100, route: { quote: '100', quoteGasAdjusted: '100', gasPriceWei: '100', gasUseEstimateQuote: '100', gasUseEstimate: '100', methodParameters: {calldata: '0x', value: '0', to: '0x0000000000000000000000000000000000000000'}}, pair: '0x000-0x111-123', usedUnimind: true }
+      const result = calculateParameters(strategy, intrinsicValues, extrinsicValues)
+
+      // With guardrail, price impact > 2% should return classic parameters (0,0)
+      expect(result.pi).toBe(0)
+      expect(result.tau).toBe(0)
+    })
+
     it('ceiling on tau for price impact strategy', () => {
       const strategy = new PriceImpactStrategy()
       const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: Math.log(0.0002)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION };

--- a/test/unit/util/unimind-algorithm.test.ts
+++ b/test/unit/util/unimind-algorithm.test.ts
@@ -3,7 +3,7 @@ import { getStatistics } from '../../../lib/crons/unimind-algorithm';
 import { DutchV3OrderEntity } from '../../../lib/entities';
 import { ORDER_STATUS } from '../../../lib/entities/Order';
 import { mock } from 'jest-mock-extended';
-import { UNIMIND_ALGORITHM_VERSION, UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_MAX_TAU_BPS, UNIMIND_UPDATE_THRESHOLD } from '../../../lib/util/constants';
+import { UNIMIND_ALGORITHM_VERSION, UNIMIND_DEV_SWAPPER_ADDRESS, UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD, UNIMIND_MAX_TAU_BPS, UNIMIND_UPDATE_THRESHOLD } from '../../../lib/util/constants';
 import { PriceImpactStrategy } from '../../../lib/unimind/priceImpactStrategy';
 import { BatchedStrategy } from '../../../lib/unimind/batchedStrategy';
 import { unimindAddressFilter, UNIMIND_SAMPLE_PERCENT } from '../../../lib/util/unimind';
@@ -215,10 +215,10 @@ describe('unimind-algorithm', () => {
     it('price impact strategy test on extrinsic values with big price impact', () => {
       const strategy = new PriceImpactStrategy()
       const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 1, Sigma: Math.log(0.00005)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION };
-      const extrinsicValues: QuoteMetadata = { priceImpact: 2.1, quoteId: '0x000-0x111-123', referencePrice: '100', blockNumber: 100, route: { quote: '100', quoteGasAdjusted: '100', gasPriceWei: '100', gasUseEstimateQuote: '100', gasUseEstimate: '100', methodParameters: {calldata: '0x', value: '0', to: '0x0000000000000000000000000000000000000000'}}, pair: '0x000-0x111-123', usedUnimind: true }
+      const extrinsicValues: QuoteMetadata = { priceImpact: UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD + 0.1, quoteId: '0x000-0x111-123', referencePrice: '100', blockNumber: 100, route: { quote: '100', quoteGasAdjusted: '100', gasPriceWei: '100', gasUseEstimateQuote: '100', gasUseEstimate: '100', methodParameters: {calldata: '0x', value: '0', to: '0x0000000000000000000000000000000000000000'}}, pair: '0x000-0x111-123', usedUnimind: true }
       const result = calculateParameters(strategy, intrinsicValues, extrinsicValues)
 
-      // With guardrail, price impact > 2% should return classic parameters (0,0)
+      // With guardrail, price impact > threshold should return classic parameters (0,0)
       expect(result.pi).toBe(0)
       expect(result.tau).toBe(0)
     })

--- a/test/unit/util/unimind-algorithm.test.ts
+++ b/test/unit/util/unimind-algorithm.test.ts
@@ -164,8 +164,8 @@ describe('unimind-algorithm', () => {
       }
       const result = strategy.unimindAlgorithm(statistics, intrinsicValues, log);
       // Test that they match to 5 decimal places
-      expect(result.lambda1).toBeCloseTo(-0.0002122602759806385, 5)
-      expect(result.lambda2).toBeCloseTo(112.44048264468115, 5)
+      expect(result.lambda1).toBeCloseTo(-0.000133816, 5)
+      expect(result.lambda2).toBeCloseTo(73.84291297164683, 5)
       expect(result.Sigma).toBeCloseTo(-9.210341293010218, 5)
     });
     
@@ -181,8 +181,8 @@ describe('unimind-algorithm', () => {
         fillStatuses
       }
       const result = strategy.unimindAlgorithm(statistics, intrinsicValues, log);
-      expect(result.lambda1).toBeCloseTo(-0.000200380252111038, 5)
-      expect(result.lambda2).toBeCloseTo(111.78800455838532, 5)
+      expect(result.lambda1).toBeCloseTo(-0.00012632668, 5)
+      expect(result.lambda2).toBeCloseTo(73.43156809115597, 5)
       expect(result.Sigma).toBeCloseTo(-9.210339648306581, 5)
     });
 
@@ -197,8 +197,8 @@ describe('unimind-algorithm', () => {
         fillStatuses: waitTimes.map(wt => typeof wt === 'number' ? 1 : 0)
       }
       const result = strategy.unimindAlgorithm(statistics, intrinsicValues, log);
-      expect(result.lambda1).toBeCloseTo(-6.23298013929823e-9, 11)
-      expect(result.lambda2).toBeCloseTo(4.237439074660775, 5)
+      expect(result.lambda1).toBeCloseTo(-3.48159756e-9, 11)
+      expect(result.lambda2).toBeCloseTo(4.237290385, 5)
       expect(result.Sigma).toBeCloseTo(-0.41228565543852524, 5)
     });
 


### PR DESCRIPTION
1. Add guardrail to prevent negative Lambda2 from being used
2. Add guardrail to prevent large price impacts from feeding into Unimind (>2% price impact)
3. Further fine-tune learning rates as part of the binary search
4. Bump algorithm version to get negative Lambda2 pairs unstuck