### PR TITLE
feat, test: immediately notify exclusive filler

### DIFF
--- a/lib/handlers/post-order/index.ts
+++ b/lib/handlers/post-order/index.ts
@@ -14,6 +14,10 @@ import { AnalyticsService } from '../../services/analytics-service'
 import { OrderDispatcher } from '../../services/OrderDispatcher'
 import { RelayOrderService } from '../../services/RelayOrderService'
 import { UniswapXOrderService } from '../../services/UniswapXOrderService'
+import { S3WebhookConfigurationProvider } from '../../providers/s3-webhook-provider'
+import { BETA_WEBHOOK_CONFIG_KEY, PRODUCTION_WEBHOOK_CONFIG_KEY, WEBHOOK_CONFIG_BUCKET } from '../../util/constants'
+import { STAGE } from '../../util/stage'
+import { checkDefined } from '../../preconditions/preconditions'
 import { SUPPORTED_CHAINS } from '../../util/chain'
 import { ONE_DAY_IN_SECONDS, RPC_HEADERS } from '../../util/constants'
 import { OffChainRelayOrderValidator } from '../../util/OffChainRelayOrderValidator'
@@ -61,6 +65,11 @@ const limitRepo = LimitOrdersRepository.create(new DynamoDB.DocumentClient())
 const quoteMetadataRepo = DynamoQuoteMetadataRepository.create(new DynamoDB.DocumentClient())
 const orderValidator = new OffChainUniswapXOrderValidator(() => new Date().getTime() / 1000, ONE_DAY_IN_SECONDS)
 
+// Set up webhook provider for immediate notifications
+const stage = checkDefined(process.env['stage'], 'stage should be defined in the .env')
+const s3Key = stage === STAGE.BETA ? BETA_WEBHOOK_CONFIG_KEY : PRODUCTION_WEBHOOK_CONFIG_KEY
+const webhookProvider = new S3WebhookConfigurationProvider(`${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key)
+
 const uniswapXOrderService = new UniswapXOrderService(
   orderValidator,
   onChainValidatorMap,
@@ -70,7 +79,8 @@ const uniswapXOrderService = new UniswapXOrderService(
   log,
   getMaxOpenOrders,
   AnalyticsService.create(),
-  providerMap
+  providerMap,
+  webhookProvider
 )
 
 const relayOrderValidator = new OffChainRelayOrderValidator(() => new Date().getTime() / 1000)

--- a/lib/services/UniswapXOrderService.ts
+++ b/lib/services/UniswapXOrderService.ts
@@ -35,6 +35,8 @@ import { QuoteMetadata, QuoteMetadataRepository } from '../repositories/quote-me
 import { OffChainUniswapXOrderValidator } from '../util/OffChainUniswapXOrderValidator'
 import { DUTCH_LIMIT, formatOrderEntity } from '../util/order'
 import { AnalyticsServiceInterface } from './analytics-service'
+import { sendImmediateExclusiveFillerNotification } from '../handlers/order-notification/handler'
+import { WebhookProvider } from '../providers/base'
 
 const MAX_QUERY_RETRY = 10
 
@@ -48,11 +50,12 @@ export class UniswapXOrderService {
     private logger: Logger,
     private readonly getMaxOpenOrders: (offerer: string) => number,
     private analyticsService: AnalyticsServiceInterface,
-    private readonly providerMap: ProviderMap
+    private readonly providerMap: ProviderMap,
+    private readonly webhookProvider?: WebhookProvider
   ) {}
 
   async createOrder(order: DutchV1Order | LimitOrder | DutchV2Order | PriorityOrder | DutchV3Order): Promise<string> {
-    let orderEntity
+    let orderEntity: UniswapXOrderEntity
     if (order instanceof DutchV1Order || order instanceof LimitOrder) {
       await this.validateOrder(order.inner, order.signature, order.chainId)
       orderEntity = formatOrderEntity(order.inner, order.signature, OrderType.Dutch, ORDER_STATUS.OPEN, order.quoteId)
@@ -93,6 +96,35 @@ export class UniswapXOrderService {
 
     const realOrderType = order.orderType
     await this.logOrderCreatedEvent(orderEntity, realOrderType)
+
+    // Send immediate notification to exclusive filler if present
+    if (this.webhookProvider && orderEntity.filler) {
+      // Don't await to minimize latency-add to order posting flow
+      sendImmediateExclusiveFillerNotification(
+        {
+          orderHash: orderEntity.orderHash,
+          createdAt: orderEntity.createdAt ?? Date.now(),
+          signature: orderEntity.signature,
+          offerer: orderEntity.offerer,
+          orderStatus: orderEntity.orderStatus,
+          encodedOrder: orderEntity.encodedOrder,
+          chainId: orderEntity.chainId,
+          quoteId: orderEntity.quoteId,
+          filler: orderEntity.filler,
+        },
+        realOrderType,
+        this.webhookProvider,
+        this.logger
+      ).catch((error) => {
+        this.logger.warn(
+          { 
+            orderHash: orderEntity.orderHash, 
+            error: error.message || error,
+            message: 'Immediate webhook notification failed, will rely on DynamoDB stream'
+          }
+        )
+      })
+    }
 
     // TODO: cleanup with generic order model
     const quoteId = 'quoteId' in order ? order.quoteId : undefined

--- a/test/unit/handlers/order-notification.test.ts
+++ b/test/unit/handlers/order-notification.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { OrderNotificationHandler } from '../../../lib/handlers/order-notification/handler'
+import { OrderNotificationHandler, sendWebhookNotifications, sendImmediateExclusiveFillerNotification } from '../../../lib/handlers/order-notification/handler'
 
 jest.mock('axios')
 jest.mock('@uniswap/uniswapx-sdk')
@@ -163,5 +163,169 @@ describe('Testing new order Notification handler.', () => {
 
   it('Testing no records validation error.', async () => {
     await expect(async () => await orderNotificationHandler(MOCK_ORDER, {})).rejects.toThrow(Error)
+  })
+})
+
+describe('sendWebhookNotifications', () => {
+  const mockedAxios = axios as jest.Mocked<typeof axios>
+  const mockLogger = {
+    info: jest.fn(),
+    error: jest.fn()
+  }
+  
+  const mockEndpoints = [
+    { url: 'https://webhook1.com' },
+    { url: 'https://webhook2.com', headers: { 'Authorization': 'Bearer token' } }
+  ]
+  
+  const mockOrder = {
+    orderHash: '0x123',
+    createdAt: 1670976836865,
+    signature: '0xsig',
+    swapper: '0xswapper',
+    orderStatus: 'open',
+    encodedOrder: '0xencodedorder',
+    chainId: 1,
+    orderType: 'Dutch_V2',
+    filler: '0xfiller'
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should send webhooks to all endpoints', async () => {
+    mockedAxios.post.mockResolvedValue({ status: 200 })
+    
+    await sendWebhookNotifications(mockEndpoints, mockOrder, mockLogger)
+    
+    expect(mockedAxios.post).toHaveBeenCalledTimes(2)
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'https://webhook1.com',
+      expect.objectContaining({
+        orderHash: '0x123',
+        offerer: '0xswapper',
+        filler: '0xfiller',
+        type: 'Dutch_V2'
+      }),
+      expect.objectContaining({ timeout: 200 })
+    )
+    expect(mockLogger.info).toHaveBeenCalledTimes(2)
+  })
+
+  it('should handle webhook failures gracefully', async () => {
+    mockedAxios.post.mockRejectedValue(new Error('Network error'))
+    
+    await sendWebhookNotifications(mockEndpoints, mockOrder, mockLogger)
+    
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      { failedWebhooks: ['https://webhook1.com', 'https://webhook2.com'] },
+      'Error: Failed to notify registered webhooks.'
+    )
+  })
+})
+
+describe('sendImmediateExclusiveFillerNotification', () => {
+  const mockedAxios = axios as jest.Mocked<typeof axios>
+  const mockWebhookProvider = {
+    getEndpoints: jest.fn()
+  }
+  const mockLogger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+  
+  const mockOrderEntity = {
+    orderHash: '0x123',
+    createdAt: 1670976836865,
+    signature: '0xsig',
+    offerer: '0xofferer',
+    orderStatus: 'open',
+    encodedOrder: '0xencodedorder',
+    chainId: 1,
+    filler: '0xfiller'
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should send immediate notification to exclusive filler', async () => {
+    const mockEndpoints = [{ url: 'https://filler-webhook.com' }]
+    mockWebhookProvider.getEndpoints.mockResolvedValue(mockEndpoints)
+    mockedAxios.post.mockResolvedValue({ status: 200 })
+    
+    await sendImmediateExclusiveFillerNotification(
+      mockOrderEntity,
+      'Dutch_V2',
+      mockWebhookProvider,
+      mockLogger
+    )
+    
+    expect(mockWebhookProvider.getEndpoints).toHaveBeenCalledWith({
+      offerer: '0xofferer',
+      orderStatus: 'open',
+      filler: '0xfiller',
+      orderType: 'Dutch_V2'
+    })
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'https://filler-webhook.com',
+      expect.objectContaining({
+        orderHash: '0x123',
+        filler: '0xfiller',
+        offerer: '0xofferer'
+      }),
+      expect.any(Object)
+    )
+    expect(mockLogger.info).toHaveBeenCalled()
+  })
+
+  it('should skip notification when no filler', async () => {
+    const orderWithoutFiller = { ...mockOrderEntity, filler: undefined }
+    
+    await sendImmediateExclusiveFillerNotification(
+      orderWithoutFiller,
+      'Dutch_V2',
+      mockWebhookProvider,
+      mockLogger
+    )
+    
+    expect(mockWebhookProvider.getEndpoints).not.toHaveBeenCalled()
+    expect(mockedAxios.post).not.toHaveBeenCalled()
+  })
+
+  it('should skip notification when no endpoints found', async () => {
+    mockWebhookProvider.getEndpoints.mockResolvedValue([])
+    
+    await sendImmediateExclusiveFillerNotification(
+      mockOrderEntity,
+      'Dutch_V2',
+      mockWebhookProvider,
+      mockLogger
+    )
+    
+    expect(mockWebhookProvider.getEndpoints).toHaveBeenCalled()
+    expect(mockedAxios.post).not.toHaveBeenCalled()
+  })
+
+  it('should handle webhook provider errors gracefully', async () => {
+    mockWebhookProvider.getEndpoints.mockRejectedValue(new Error('S3 error'))
+    
+    await sendImmediateExclusiveFillerNotification(
+      mockOrderEntity,
+      'Dutch_V2',
+      mockWebhookProvider,
+      mockLogger
+    )
+    
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderHash: '0x123',
+        filler: '0xfiller',
+        error: expect.any(Error)
+      }),
+      'Failed to send immediate webhook notification to exclusive filler'
+    )
   })
 })


### PR DESCRIPTION
Dynamo Streams aren't very low-latency, so the notification lambda is occasionally not triggered fast enough. This can cause exclusive fillers to be late on fills on Mainnet. This change ensures that exclusive fillers are notified as soon as an order is created instead of waiting for it to be picked up by Dynamo Streams.