### PR TITLE
chore: double get-orders rate limit

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -63,7 +63,7 @@ export class APIStack extends cdk.Stack {
       chainIdToStatusTrackingStateMachineArn,
       checkStatusFunction,
       getUnimindLambdaAlias,
-      getUnimindLambda
+      getUnimindLambda,
     } = new LambdaStack(this, `${SERVICE_NAME}LambdaStack`, {
       provisionedConcurrency,
       stage: stage as STAGE,
@@ -192,7 +192,9 @@ export class APIStack extends cdk.Stack {
           priority: 2,
           statement: {
             rateBasedStatement: {
-              limit: throttlingOverride ? parseInt(throttlingOverride) : 900,
+              // rate limit across all chains
+              // default evaluation window: 5 minutes => 6 per second
+              limit: throttlingOverride ? parseInt(throttlingOverride) : 1800,
               aggregateKeyType: 'FORWARDED_IP',
               scopeDownStatement: {
                 byteMatchStatement: {


### PR DESCRIPTION
default evaluation window is 5 mins, so old rate limit is effectively 3 RPS which is a little too low given that we added more chains, and that chains now have sub-second block time