### PR TITLE
fix(reaper + check-order-status): Permissioned token status check

### DIFF
--- a/jest-dynamodb-config.js
+++ b/jest-dynamodb-config.js
@@ -311,5 +311,5 @@ module.exports = {
       ProvisionedThroughput: { ReadCapacityUnits: 1, WriteCapacityUnits: 1 }
     }
   ],
-  port: 8000,
+  port: 8001,
 }

--- a/jest-dynamodb-config.js
+++ b/jest-dynamodb-config.js
@@ -311,5 +311,5 @@ module.exports = {
       ProvisionedThroughput: { ReadCapacityUnits: 1, WriteCapacityUnits: 1 }
     }
   ],
-  port: 8001,
+  port: 8000,
 }

--- a/lib/crons/gs-reaper/gs-reaper.ts
+++ b/lib/crons/gs-reaper/gs-reaper.ts
@@ -11,6 +11,7 @@ import { getSettledAmounts } from '../../handlers/check-order-status/util'
 import { ChainId } from '../../util/chain'
 import { LimitOrdersRepository } from '../../repositories/limit-orders-repository'
 import { PermissionedTokenValidator } from '@uniswap/uniswapx-sdk'
+import { Permit2Validator } from '../../util/Permit2Validator'
 
 type OrderUpdate = {
   status: ORDER_STATUS,
@@ -339,8 +340,10 @@ async function checkCancelledOrders(
     if (!orderUpdates[orderHash]) {
       try {
         const { order, signature } = await getOrderByHash(repo, orderHash)
+        // We only check for nonce used and expired for permissioned tokens
+        // since the order quoter can't move input tokens
         const validation = PermissionedTokenValidator.isPermissionedToken(order.info.input.token, chainId)
-          ? OrderValidation.OK 
+          ? await new Permit2Validator(provider, chainId).validate(order)
           : await quoter.validate({
             order: order,
             signature: signature,

--- a/lib/util/Permit2Validator.ts
+++ b/lib/util/Permit2Validator.ts
@@ -1,0 +1,70 @@
+import { ethers } from 'ethers'
+import { OrderValidation, UniswapXOrder } from '@uniswap/uniswapx-sdk'
+import { ChainId } from './chain'
+import { permit2Address, SignatureProvider, PermitTransferFrom, TokenPermissions } from '@uniswap/permit2-sdk'
+
+export interface ValidationContext {
+  chainId: ChainId
+  currentBlock: number
+  currentTimestamp: number
+  provider: ethers.providers.Provider
+}
+
+/**
+ * Permit2Validator performs on-chain validation checks for UniswapX orders.
+ * It checks for Expired and NonceUsed conditions.
+ * 
+ * This validator is designed to be used in scenarios where the OrderQuoter is not
+ * usable (e.g. for permissioned tokens).
+ */
+export class Permit2Validator {
+  private provider: ethers.providers.Provider
+  private chainId: ChainId
+
+  constructor(provider: ethers.providers.Provider, chainId: ChainId) {
+    this.provider = provider
+    this.chainId = chainId
+  }
+
+  /**
+   * Validates an order for all supported validation checks
+   * @param order - The UniswapX order to validate
+   * @returns Promise<ValidationResult>
+   */
+  public async validate(
+    order: UniswapXOrder
+  ): Promise<OrderValidation> {
+
+    // Check if order deadline has passed
+    const currentTimestamp = Math.floor(Date.now() / 1000)
+    if (currentTimestamp > order.info.deadline) {
+      return OrderValidation.Expired
+    }
+
+    const address = permit2Address(this.chainId)
+    const signatureProvider = new SignatureProvider(this.provider, address)
+
+    // Construct PermitTransferFrom from order data
+    const permitTransferFrom: PermitTransferFrom = {
+      permitted: {
+        token: order.info.input.token,
+        amount: 0 // Amount is not used in validation
+      } as TokenPermissions,
+      spender: order.info.swapper,
+      nonce: order.info.nonce,
+      deadline: order.info.deadline
+    }
+
+    const permitValidation = await signatureProvider.validatePermit(permitTransferFrom)
+
+    if (permitValidation.isUsed) {
+      return OrderValidation.NonceUsed
+    }
+
+    if (permitValidation.isExpired) {
+      return OrderValidation.Expired
+    }
+
+    return OrderValidation.OK
+  }
+}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@swc/core": "^1.3.101",
     "@swc/jest": "^0.2.29",
     "@types/sinon": "^10.0.13",
+    "@uniswap/permit2-sdk": "^1.4.0",
     "@uniswap/signer": "^0.0.4",
     "@uniswap/uniswapx-sdk": "3.0.0-beta.9",
     "@uniswap/universal-router-sdk": "^4.18.1",

--- a/test/integ/handlers/check-order-status.test.ts
+++ b/test/integ/handlers/check-order-status.test.ts
@@ -449,8 +449,8 @@ describe('Testing check order status handler', () => {
       const mockPermit2Validator = {
         validate: jest.fn().mockResolvedValue(OrderValidation.OK)
       }
-      jest.spyOn(require('../../../lib/util/Permit2Validator'), 'Permit2Validator')
-        .mockImplementation(() => mockPermit2Validator)
+      const { Permit2Validator: MockedPermit2Validator } = jest.requireMock('../../../lib/util/Permit2Validator')
+      MockedPermit2Validator.mockImplementation(() => mockPermit2Validator)
 
       // Mock OrderValidator to track if validate is called
       const mockOrderValidator = jest.requireMock('@uniswap/uniswapx-sdk').OrderValidator

--- a/test/unit/handlers/gs-reaper/gs-reaper.test.ts
+++ b/test/unit/handlers/gs-reaper/gs-reaper.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
 import { OrderType, REACTOR_ADDRESS_MAPPING, OrderValidation, PermissionedTokenValidator } from '@uniswap/uniswapx-sdk'
+import { Permit2Validator } from '../../../../lib/util/Permit2Validator'
 import { default as bunyan, default as Logger } from 'bunyan'
 import { GSReaper, ReaperStage } from '../../../../lib/crons/gs-reaper/gs-reaper'
 import { ORDER_STATUS } from '../../../../lib/entities'
@@ -480,8 +481,7 @@ describe('GSReaper', () => {
       const mockPermit2Validator = {
         validate: jest.fn().mockResolvedValue(OrderValidation.OK)
       }
-      jest.spyOn(require('../../../../lib/util/Permit2Validator'), 'Permit2Validator')
-        .mockImplementation(() => mockPermit2Validator)
+      Permit2Validator.mockImplementation(() => mockPermit2Validator)
 
       // Mock OrderValidator to track if validate is called
       const mockOrderValidator = jest.requireMock('@uniswap/uniswapx-sdk').OrderValidator

--- a/test/unit/util/Permit2Validator.test.ts
+++ b/test/unit/util/Permit2Validator.test.ts
@@ -22,8 +22,8 @@ describe('Permit2Validator', () => {
     mockSignatureProvider = {
       validatePermit: jest.fn()
     }
-    const { SignatureProvider } = require('@uniswap/permit2-sdk')
-    SignatureProvider.mockImplementation(() => mockSignatureProvider)
+    const { SignatureProvider: MockedSignatureProvider } = jest.requireMock('@uniswap/permit2-sdk')
+    MockedSignatureProvider.mockImplementation(() => mockSignatureProvider)
 
     // Create validator instance
     validator = new Permit2Validator(undefined as any, ChainId.MAINNET)

--- a/test/unit/util/Permit2Validator.test.ts
+++ b/test/unit/util/Permit2Validator.test.ts
@@ -1,0 +1,117 @@
+import { ethers } from 'ethers'
+import { OrderValidation, UniswapXOrder } from '@uniswap/uniswapx-sdk'
+import { ChainId } from '../../../lib/util/chain'
+import { Permit2Validator } from '../../../lib/util/Permit2Validator'
+
+// Mock the permit2-sdk
+jest.mock('@uniswap/permit2-sdk', () => ({
+  permit2Address: jest.fn(),
+  SignatureProvider: jest.fn()
+}))
+
+describe('Permit2Validator', () => {
+  let validator: Permit2Validator
+  let mockSignatureProvider: jest.Mocked<any>
+  let testOrder: UniswapXOrder
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks()
+
+    // Mock SignatureProvider
+    mockSignatureProvider = {
+      validatePermit: jest.fn()
+    }
+    const { SignatureProvider } = require('@uniswap/permit2-sdk')
+    SignatureProvider.mockImplementation(() => mockSignatureProvider)
+
+    // Create validator instance
+    validator = new Permit2Validator(undefined as any, ChainId.MAINNET)
+
+    testOrder = {
+      info: {
+        deadline: Math.floor(Date.now() / 1000) + 3600,
+        nonce: ethers.BigNumber.from(123),
+        swapper: '0x1234567890123456789012345678901234567890',
+        input: {
+          token: '0x1234567890123456789012345678901234567890',
+          amount: ethers.BigNumber.from('1000000000000000000')
+        }
+      }
+    } as UniswapXOrder
+  })
+
+  describe('validate', () => {
+    it('should return NonceUsed when permit is already used', async () => {
+      mockSignatureProvider.validatePermit.mockResolvedValue({
+        isUsed: true,
+        isExpired: false,
+        isValid: false
+      })
+
+      const result = await validator.validate(testOrder)
+
+      expect(result).toBe(OrderValidation.NonceUsed)
+      expect(mockSignatureProvider.validatePermit).toHaveBeenCalledWith({
+        permitted: {
+          token: testOrder.info.input.token,
+          amount: 0
+        },
+        spender: testOrder.info.swapper,
+        nonce: testOrder.info.nonce,
+        deadline: testOrder.info.deadline
+      })
+    })
+
+    it('should return Expired when permit is expired', async () => {
+      mockSignatureProvider.validatePermit.mockResolvedValue({
+        isUsed: false,
+        isExpired: true,
+        isValid: false
+      })
+
+      const result = await validator.validate(testOrder)
+
+      expect(result).toBe(OrderValidation.Expired)
+      expect(mockSignatureProvider.validatePermit).toHaveBeenCalledWith({
+        permitted: {
+          token: testOrder.info.input.token,
+          amount: 0
+        },
+        spender: testOrder.info.swapper,
+        nonce: testOrder.info.nonce,
+        deadline: testOrder.info.deadline
+      })
+    })
+
+    it('should return OK when permit is valid', async () => {
+      mockSignatureProvider.validatePermit.mockResolvedValue({
+        isUsed: false,
+        isExpired: false,
+        isValid: true
+      })
+
+      const result = await validator.validate(testOrder)
+
+      expect(result).toBe(OrderValidation.OK)
+      expect(mockSignatureProvider.validatePermit).toHaveBeenCalledWith({
+        permitted: {
+          token: testOrder.info.input.token,
+          amount: 0
+        },
+        spender: testOrder.info.swapper,
+        nonce: testOrder.info.nonce,
+        deadline: testOrder.info.deadline
+      })
+    })
+  })
+
+  describe('error handling', () => {
+    it('should propagate errors from SignatureProvider', async () => {
+      const error = new Error('Network error')
+      mockSignatureProvider.validatePermit.mockRejectedValue(error)
+
+      await expect(validator.validate(testOrder)).rejects.toThrow('Network error')
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4666,6 +4666,14 @@
     ethers "^5.7.0"
     tiny-invariant "^1.1.0"
 
+"@uniswap/permit2-sdk@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/permit2-sdk/-/permit2-sdk-1.4.0.tgz#eafb48e89bd747b893a88d3cabd2422a81528b80"
+  integrity sha512-l/aGhfhB93M76vXs4eB8QNwhELE6bs66kh7F1cyobaPtINaVpMmlJv+j3KmHeHwAZIsh7QXyYzhDxs07u0Pe4Q==
+  dependencies:
+    ethers "^5.7.0"
+    tiny-invariant "^1.1.0"
+
 "@uniswap/router-sdk@^1.22.2":
   version "1.22.3"
   resolved "https://registry.yarnpkg.com/@uniswap/router-sdk/-/router-sdk-1.22.3.tgz#2b2e2fda24aa2ea6f0564b4ea910949ac5a80691"


### PR DESCRIPTION
We can't use the default quoter for permissioned tokens since the input tokens cannot be transferred and fails with insufficient-token. Therefore, we should skip the quoter for permissioned tokens and use a new Permit2Validator which only checks if the nonce is used (cancelled) or expired.

The fill event tracker will pick up filled orders.

This is used in the async order status checkers: `check-order-status` and `gs-reaper`.