### PR TITLE
feat, test: immediately notify exclusive filler (#595)

### DIFF
--- a/lib/handlers/order-notification/handler.ts
+++ b/lib/handlers/order-notification/handler.ts
@@ -1,14 +1,15 @@
+import { CosignedV2DutchOrder, OrderType } from '@uniswap/uniswapx-sdk'
+import { Unit } from 'aws-embedded-metrics'
 import axios, { AxiosResponse } from 'axios'
 import Joi from 'joi'
+import { ChainId } from '../../util/chain'
 import { metrics } from '../../util/metrics'
 import { eventRecordToOrder } from '../../util/order'
 import { BatchFailureResponse, DynamoStreamLambdaHandler } from '../base/dynamo-stream-handler'
+import { DUTCHV2_ORDER_LATENCY_THRESHOLD_SEC } from '../constants'
 import { ContainerInjected, RequestInjected } from './injector'
 import { OrderNotificationInputJoi } from './schema'
-import { CosignedV2DutchOrder, OrderType } from '@uniswap/uniswapx-sdk'
-import { DUTCHV2_ORDER_LATENCY_THRESHOLD_SEC } from '../constants'
-import { Unit } from 'aws-embedded-metrics'
-import { ChainId } from '../../util/chain'
+import { ExclusiveFillerWebhookOrder, WebhookLogger, WebhookOrderData, WebhookProviderInterface } from './types'
 
 const WEBHOOK_TIMEOUT_MS = 200
 
@@ -41,54 +42,12 @@ export class OrderNotificationHandler extends DynamoStreamLambdaHandler<Containe
 
         log.info({ order: newOrder, registeredEndpoints }, 'Sending order to registered webhooks.')
 
-        // Randomize the order to prevent any filler from having a consistent advantage
-        const shuffledEndpoints = [...registeredEndpoints].sort(() => Math.random())
-        const requests: Promise<AxiosResponse>[] = shuffledEndpoints.map((endpoint) =>
-          axios.post(
-            endpoint.url,
-            {
-              orderHash: newOrder.orderHash,
-              createdAt: newOrder.createdAt,
-              signature: newOrder.signature,
-              offerer: newOrder.swapper,
-              orderStatus: newOrder.orderStatus,
-              encodedOrder: newOrder.encodedOrder,
-              chainId: newOrder.chainId,
-              ...(newOrder.orderType && { type: newOrder.orderType }),
-              ...(newOrder.quoteId && { quoteId: newOrder.quoteId }),
-              ...(newOrder.filler && { filler: newOrder.filler }),
-              notifiedAt: Date.now(), // Fillers can deduce notification latency
-            },
-            {
-              timeout: WEBHOOK_TIMEOUT_MS,
-              headers: { ...endpoint.headers },
-            }
-          )
-        )
-
-        // we send to each webhook only once but log which ones failed
-        const results = await Promise.allSettled(requests)
-        const failedWebhooks: string[] = []
-
-        results.forEach((result, index) => {
-          metrics.putMetric(`OrderNotificationAttempt-chain-${newOrder.chainId}`, 1)
-          if (result.status == 'fulfilled' && result?.value?.status >= 200 && result?.value?.status <= 202) {
-            delete result.value.request
-            log.info(
-              { result: result.value },
-              `Success: New order record sent to registered webhook ${registeredEndpoints[index].url}.`
-            )
-            metrics.putMetric(`OrderNotificationSendSuccess-chain-${newOrder.chainId}`, 1)
-          } else {
-            failedWebhooks.push(registeredEndpoints[index].url)
-            metrics.putMetric(`OrderNotificationSendFailure-chain-${newOrder.chainId}`, 1)
-          }
-        })
-
-        if (failedWebhooks.length > 0) {
-          log.error({ failedWebhooks }, 'Error: Failed to notify registered webhooks.')
-          // No longer retry webhook delivery failures
+        // Convert to standard webhook format (map swapper -> offerer)
+        const webhookOrderData: WebhookOrderData = {
+          ...newOrder,
+          offerer: newOrder.swapper,
         }
+        await sendWebhookNotifications(registeredEndpoints, webhookOrderData, log)
       } catch (e: unknown) {
         log.error(e instanceof Error ? e.message : e, 'Unexpected failure in handler.')
         failedRecords.push({ itemIdentifier: record.dynamodb?.SequenceNumber })
@@ -159,5 +118,124 @@ export class OrderNotificationHandler extends DynamoStreamLambdaHandler<Containe
       const staleRecordMetricName = `NotificationRecordStaleness-chain-${newOrder.chainId.toString()}`
       metrics.putMetric(staleRecordMetricName, recordTimeDifference)
     }
+  }
+}
+
+/**
+ * Send webhook notifications to all provided endpoints
+ * Extracted from OrderNotificationHandler for reuse in immediate notifications
+ */
+export async function sendWebhookNotifications(
+  endpoints: Array<{ url: string; headers?: { [key: string]: string } }>,
+  order: WebhookOrderData,
+  logger: WebhookLogger
+): Promise<void> {
+  // Randomize the order to prevent any filler from having a consistent advantage
+  const shuffledEndpoints = [...endpoints].sort(() => Math.random())
+  const requests: Promise<AxiosResponse>[] = shuffledEndpoints.map((endpoint) =>
+    axios.post(
+      endpoint.url,
+      {
+        orderHash: order.orderHash,
+        createdAt: order.createdAt,
+        signature: order.signature,
+        offerer: order.offerer,
+        orderStatus: order.orderStatus,
+        encodedOrder: order.encodedOrder,
+        chainId: order.chainId,
+        ...(order.orderType && { type: order.orderType }),
+        ...(order.quoteId && { quoteId: order.quoteId }),
+        ...(order.filler && { filler: order.filler }),
+        notifiedAt: Date.now(), // Fillers can deduce notification latency
+      },
+      {
+        timeout: WEBHOOK_TIMEOUT_MS,
+        headers: { ...endpoint.headers },
+      }
+    )
+  )
+
+  // we send to each webhook only once but log which ones failed
+  const results = await Promise.allSettled(requests)
+  const failedWebhooks: string[] = []
+
+  results.forEach((result, index) => {
+    metrics.putMetric(`OrderNotificationAttempt-chain-${order.chainId}`, 1)
+    if (result.status == 'fulfilled' && result?.value?.status >= 200 && result?.value?.status <= 202) {
+      delete result.value.request
+      logger.info(
+        { result: result.value },
+        `Success: New order record sent to registered webhook ${endpoints[index].url}.`
+      )
+      metrics.putMetric(`OrderNotificationSendSuccess-chain-${order.chainId}`, 1)
+    } else {
+      failedWebhooks.push(endpoints[index].url)
+      metrics.putMetric(`OrderNotificationSendFailure-chain-${order.chainId}`, 1)
+    }
+  })
+
+  if (failedWebhooks.length > 0) {
+    logger.error({ failedWebhooks }, 'Error: Failed to notify registered webhooks.')
+    // No longer retry webhook delivery failures
+  }
+}
+
+/**
+ * Send immediate webhook notification to exclusive filler only
+ * Called synchronously from post-order handler to minimize latency for exclusive fillers
+ *
+ * @param orderEntity - Order entity with validated exclusive filler (caller must ensure filler is non-zero address)
+ * @param orderType - Type of the order
+ * @param webhookProvider - Provider for webhook endpoints
+ * @param logger - Logger instance
+ */
+export async function sendImmediateExclusiveFillerNotification(
+  orderEntity: ExclusiveFillerWebhookOrder,
+  orderType: string,
+  webhookProvider: WebhookProviderInterface,
+  logger: WebhookLogger
+): Promise<void> {
+  try {
+    const startTime = Date.now()
+
+    // Get endpoints specifically for the exclusive filler
+    const exclusiveFillerEndpoints = await webhookProvider.getExclusiveFillerEndpoints(orderEntity.filler)
+
+    if (exclusiveFillerEndpoints.length === 0) {
+      return
+    }
+
+    logger.info(
+      {
+        orderHash: orderEntity.orderHash,
+        filler: orderEntity.filler,
+        endpointCount: exclusiveFillerEndpoints.length,
+      },
+      'Sending immediate webhook notification to exclusive filler'
+    )
+
+    await sendWebhookNotifications(
+      exclusiveFillerEndpoints,
+      {
+        ...orderEntity,
+        orderType,
+      },
+      logger
+    )
+
+    const duration = Date.now() - startTime
+    metrics.putMetric(`ImmediateNotificationDuration-chain-${orderEntity.chainId}`, duration, Unit.Milliseconds)
+    metrics.putMetric(`ImmediateNotificationAttempt-chain-${orderEntity.chainId}`, 1, Unit.Count)
+  } catch (error) {
+    logger.error(
+      {
+        orderHash: orderEntity.orderHash,
+        filler: orderEntity.filler,
+        error,
+      },
+      'Failed to send immediate webhook notification to exclusive filler'
+    )
+    metrics.putMetric(`ImmediateNotificationError-chain-${orderEntity.chainId}`, 1, Unit.Count)
+    // Don't throw - we don't want webhook failures to break order posting
   }
 }

--- a/lib/handlers/order-notification/types.ts
+++ b/lib/handlers/order-notification/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Canonical webhook order data structure
+ * This is the standardized format for all webhook notifications
+ */
+export interface WebhookOrderData {
+  orderHash: string
+  createdAt: number
+  signature: string
+  offerer: string // Standardized field name used in webhook payloads
+  orderStatus: string
+  encodedOrder: string
+  chainId: number
+  orderType?: string
+  quoteId?: string
+  filler?: string
+}
+
+/**
+ * Webhook order data for exclusive filler notifications
+ * Guarantees that filler field is present and non-null
+ */
+export type ExclusiveFillerWebhookOrder = WebhookOrderData & {
+  filler: string
+}
+
+/**
+ * Logger interface for webhook operations
+ */
+export interface WebhookLogger {
+  info: (obj: any, msg: string) => void
+  warn: (obj: any, msg: string) => void
+  error: (obj: any, msg: string) => void
+}
+
+/**
+ * Webhook provider interface
+ */
+export interface WebhookProviderInterface {
+  getEndpoints: (filter: {
+    offerer: string
+    orderStatus: string
+    filler?: string
+    orderType?: string
+  }) => Promise<Array<{ url: string; headers?: { [key: string]: string } }>>
+  getExclusiveFillerEndpoints: (filler: string) => Promise<Array<{ url: string; headers?: { [key: string]: string } }>>
+}

--- a/lib/handlers/post-order/index.ts
+++ b/lib/handlers/post-order/index.ts
@@ -14,6 +14,10 @@ import { AnalyticsService } from '../../services/analytics-service'
 import { OrderDispatcher } from '../../services/OrderDispatcher'
 import { RelayOrderService } from '../../services/RelayOrderService'
 import { UniswapXOrderService } from '../../services/UniswapXOrderService'
+import { S3WebhookConfigurationProvider } from '../../providers/s3-webhook-provider'
+import { BETA_WEBHOOK_CONFIG_KEY, PRODUCTION_WEBHOOK_CONFIG_KEY, WEBHOOK_CONFIG_BUCKET } from '../../util/constants'
+import { STAGE } from '../../util/stage'
+import { checkDefined } from '../../preconditions/preconditions'
 import { SUPPORTED_CHAINS } from '../../util/chain'
 import { ONE_DAY_IN_SECONDS, RPC_HEADERS } from '../../util/constants'
 import { OffChainRelayOrderValidator } from '../../util/OffChainRelayOrderValidator'
@@ -61,6 +65,11 @@ const limitRepo = LimitOrdersRepository.create(new DynamoDB.DocumentClient())
 const quoteMetadataRepo = DynamoQuoteMetadataRepository.create(new DynamoDB.DocumentClient())
 const orderValidator = new OffChainUniswapXOrderValidator(() => new Date().getTime() / 1000, ONE_DAY_IN_SECONDS)
 
+// Set up webhook provider for immediate notifications
+const stage = checkDefined(process.env['stage'], 'stage should be defined in the .env')
+const s3Key = stage === STAGE.BETA ? BETA_WEBHOOK_CONFIG_KEY : PRODUCTION_WEBHOOK_CONFIG_KEY
+const webhookProvider = new S3WebhookConfigurationProvider(`${WEBHOOK_CONFIG_BUCKET}-${stage}-1`, s3Key)
+
 const uniswapXOrderService = new UniswapXOrderService(
   orderValidator,
   onChainValidatorMap,
@@ -70,7 +79,8 @@ const uniswapXOrderService = new UniswapXOrderService(
   log,
   getMaxOpenOrders,
   AnalyticsService.create(),
-  providerMap
+  providerMap,
+  webhookProvider
 )
 
 const relayOrderValidator = new OffChainRelayOrderValidator(() => new Date().getTime() / 1000)

--- a/lib/providers/base.ts
+++ b/lib/providers/base.ts
@@ -9,4 +9,5 @@ export type OrderFilter = {
 
 export interface WebhookProvider {
   getEndpoints(filter: OrderFilter): Promise<Webhook[]>
+  getExclusiveFillerEndpoints(filler: string): Promise<Webhook[]>
 }

--- a/lib/providers/json-webhook-provider.ts
+++ b/lib/providers/json-webhook-provider.ts
@@ -13,6 +13,10 @@ export class JsonWebhookProvider implements WebhookProvider {
   public async getEndpoints(filter: OrderFilter): Promise<Webhook[]> {
     return findEndpointsMatchingFilter(filter, this.jsonDocument)
   }
+
+  public async getExclusiveFillerEndpoints(filler: string): Promise<Webhook[]> {
+    return this.jsonDocument.filter[FILTER_FIELD.FILLER][filler] ?? []
+  }
 }
 
 export function findEndpointsMatchingFilter(filter: OrderFilter, definition: WebhookDefinition): Webhook[] {

--- a/lib/providers/s3-webhook-provider.ts
+++ b/lib/providers/s3-webhook-provider.ts
@@ -2,7 +2,7 @@ import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import { checkDefined } from '../preconditions/preconditions'
 import { OrderFilter, WebhookProvider } from './base'
 import { findEndpointsMatchingFilter } from './json-webhook-provider'
-import { Webhook, WebhookDefinition } from './types'
+import { FILTER_FIELD, Webhook, WebhookDefinition } from './types'
 
 export class S3WebhookConfigurationProvider implements WebhookProvider {
   private static UPDATE_ENDPOINTS_PERIOD_MS = 5 * 60000
@@ -19,6 +19,11 @@ export class S3WebhookConfigurationProvider implements WebhookProvider {
   public async getEndpoints(filter: OrderFilter): Promise<Webhook[]> {
     const definition = await this.getDefinition()
     return findEndpointsMatchingFilter(filter, definition)
+  }
+
+  public async getExclusiveFillerEndpoints(filler: string): Promise<Webhook[]> {
+    const definition = await this.getDefinition()
+    return definition.filter[FILTER_FIELD.FILLER][filler] ?? []
   }
 
   async getDefinition(): Promise<WebhookDefinition> {

--- a/lib/services/UniswapXOrderService.ts
+++ b/lib/services/UniswapXOrderService.ts
@@ -35,6 +35,10 @@ import { QuoteMetadata, QuoteMetadataRepository } from '../repositories/quote-me
 import { OffChainUniswapXOrderValidator } from '../util/OffChainUniswapXOrderValidator'
 import { DUTCH_LIMIT, formatOrderEntity } from '../util/order'
 import { AnalyticsServiceInterface } from './analytics-service'
+import { sendImmediateExclusiveFillerNotification } from '../handlers/order-notification/handler'
+import { ExclusiveFillerWebhookOrder } from '../handlers/order-notification/types'
+import { WebhookProvider } from '../providers/base'
+import { hasExclusiveFiller } from '../util/address'
 
 const MAX_QUERY_RETRY = 10
 
@@ -48,11 +52,12 @@ export class UniswapXOrderService {
     private logger: Logger,
     private readonly getMaxOpenOrders: (offerer: string) => number,
     private analyticsService: AnalyticsServiceInterface,
-    private readonly providerMap: ProviderMap
+    private readonly providerMap: ProviderMap,
+    private readonly webhookProvider?: WebhookProvider
   ) {}
 
   async createOrder(order: DutchV1Order | LimitOrder | DutchV2Order | PriorityOrder | DutchV3Order): Promise<string> {
-    let orderEntity
+    let orderEntity: UniswapXOrderEntity
     if (order instanceof DutchV1Order || order instanceof LimitOrder) {
       await this.validateOrder(order.inner, order.signature, order.chainId)
       orderEntity = formatOrderEntity(order.inner, order.signature, OrderType.Dutch, ORDER_STATUS.OPEN, order.quoteId)
@@ -93,6 +98,39 @@ export class UniswapXOrderService {
 
     const realOrderType = order.orderType
     await this.logOrderCreatedEvent(orderEntity, realOrderType)
+
+    // Send immediate notification to exclusive filler if present
+    if (this.webhookProvider && hasExclusiveFiller(orderEntity.filler)) {
+      // Create properly typed webhook order data
+      const exclusiveFillerOrder: ExclusiveFillerWebhookOrder = {
+        orderHash: orderEntity.orderHash,
+        createdAt: orderEntity.createdAt ?? Date.now(),
+        signature: orderEntity.signature,
+        offerer: orderEntity.offerer,
+        orderStatus: orderEntity.orderStatus,
+        encodedOrder: orderEntity.encodedOrder,
+        chainId: orderEntity.chainId,
+        quoteId: orderEntity.quoteId,
+        filler: orderEntity.filler,
+        orderType: realOrderType,
+      }
+      
+      // Don't await to minimize latency-add to order posting flow
+      sendImmediateExclusiveFillerNotification(
+        exclusiveFillerOrder,
+        realOrderType,
+        this.webhookProvider,
+        this.logger
+      ).catch((error) => {
+        this.logger.warn(
+          { 
+            orderHash: orderEntity.orderHash, 
+            error: error.message || error,
+            message: 'Immediate webhook notification failed, will rely on DynamoDB stream'
+          }
+        )
+      })
+    }
 
     // TODO: cleanup with generic order model
     const quoteId = 'quoteId' in order ? order.quoteId : undefined

--- a/lib/util/address.ts
+++ b/lib/util/address.ts
@@ -1,0 +1,12 @@
+import { ethers } from 'ethers'
+
+/**
+ * Checks if the given filler address represents an exclusive filler
+ * An exclusive filler is any non-zero address
+ * 
+ * @param filler - The filler address to check
+ * @returns true if the filler is exclusive (not zero address), false otherwise
+ */
+export function hasExclusiveFiller(filler?: string): filler is string {
+  return !!filler && filler.toLowerCase() !== ethers.constants.AddressZero.toLowerCase()
+}

--- a/test/unit/providers/json-webhook-provider.test.ts
+++ b/test/unit/providers/json-webhook-provider.test.ts
@@ -20,3 +20,17 @@ describe('JsonWebHookProvider test', () => {
     ).toEqual([{ url: 'webhook.com/1' }, { url: 'webhook.com/2' }, { url: 'webhook.com/4' }])
   })
 })
+
+describe('getExclusiveFillerEndpoints', () => {
+  it('Returns endpoints for a filler', async () => {
+    const webhookProvider = JsonWebhookProvider.create({
+      filter: {
+        filler: {
+          '0x1': [{ url: 'webhook.com/1' }],
+        },
+        orderStatus: { open: [{ url: 'webhook.com/2' }, { url: 'webhook.com/3' }] },
+      },
+    } as any)
+    expect(await webhookProvider.getExclusiveFillerEndpoints('0x1')).toEqual([{ url: 'webhook.com/1' }])
+  })
+})

--- a/test/unit/util/address.test.ts
+++ b/test/unit/util/address.test.ts
@@ -1,0 +1,28 @@
+import { ethers } from 'ethers'
+import { hasExclusiveFiller } from '../../../lib/util/address'
+
+describe('hasExclusiveFiller', () => {
+  it('should return true for non-zero addresses', () => {
+    expect(hasExclusiveFiller('0xabc1234567890123456789012345678901234567')).toBe(true)
+    expect(hasExclusiveFiller('0x123456789abcdef123456789abcdef123456789a')).toBe(true)
+    expect(hasExclusiveFiller('0xdef456789012345678901234567890123456789b')).toBe(true)
+  })
+
+  it('should return false for zero address', () => {
+    expect(hasExclusiveFiller(ethers.constants.AddressZero)).toBe(false)
+    expect(hasExclusiveFiller('0x0000000000000000000000000000000000000000')).toBe(false)
+    expect(hasExclusiveFiller('0x0000000000000000000000000000000000000000'.toUpperCase())).toBe(false)
+  })
+
+  it('should return false for undefined or empty values', () => {
+    expect(hasExclusiveFiller(undefined)).toBe(false)
+    expect(hasExclusiveFiller('')).toBe(false)
+  })
+
+  it('should be case insensitive', () => {
+    const testAddress = '0xabc1234567890123456789012345678901234567'
+    expect(hasExclusiveFiller(testAddress.toLowerCase())).toBe(true)
+    expect(hasExclusiveFiller(testAddress.toUpperCase())).toBe(true)
+    expect(hasExclusiveFiller(testAddress)).toBe(true)
+  })
+})


### PR DESCRIPTION
Re-introducing commit `401eb5e63a04166856cf52b5309abb16f54b67bf`.
It appears that spike of errors we saw was due to the deployment rollout and not this particular change.