### PR TITLE
feat: bump get-orders lambda memory

### DIFF
--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -139,7 +139,7 @@ export class LambdaStack extends cdk.NestedStack {
       entry: path.join(__dirname, '../../lib/handlers/get-orders/index.ts'),
       handler: 'getOrdersHandler',
       timeout: Duration.seconds(29),
-      memorySize: 512,
+      memorySize: 1024,
       bundling: {
         minify: true,
         sourceMap: true,


### PR DESCRIPTION
Bumping the memory allocation for the `get-orders` lambda from 512mb to 1024mb after observing its higher memory footprint after adding the fast notification feature