### PR TITLE
Increase Base auction start by 1 block

### DIFF
--- a/lib/handlers/constants.ts
+++ b/lib/handlers/constants.ts
@@ -17,7 +17,7 @@ export const HIGH_MAX_OPEN_ORDERS = 200
 export const PRIORITY_ORDER_TARGET_BLOCK_BUFFER: Record<ChainId, number> = {
   [ChainId.MAINNET]: 3,
   [ChainId.UNICHAIN]: 4,
-  [ChainId.BASE]: 2,
+  [ChainId.BASE]: 3,
   [ChainId.OPTIMISM]: 3,
   [ChainId.ARBITRUM_ONE]: 3,
   [ChainId.POLYGON]: 3,


### PR DESCRIPTION
The tight timing is impacting auction competition and performance.