### PR TITLE
feat, test: track unimind param iterations with batchNumber field; update sigma learning rate & default params

### DIFF
--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -74,7 +74,9 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
             intrinsicValues: DEFAULT_UNIMIND_PARAMETERS,
             pair: requestQueryParams.pair,
             count: 0,
-            version: UNIMIND_ALGORITHM_VERSION
+            version: UNIMIND_ALGORITHM_VERSION,
+            batchNumber: 0,
+            lastUpdatedAt: Math.floor(Date.now() / 1000)
         }
         await unimindParametersRepository.put(entry)
         unimindParameters = entry

--- a/lib/repositories/unimind-parameters-repository.ts
+++ b/lib/repositories/unimind-parameters-repository.ts
@@ -9,6 +9,8 @@ export interface UnimindParameters {
   intrinsicValues: string
   count: number
   version: number
+  batchNumber: number        // Tracks parameter update iterations
+  lastUpdatedAt?: number     // Unix timestamp for update tracking
 }
 
 export interface UnimindParametersRepository {
@@ -38,6 +40,8 @@ export class DynamoUnimindParametersRepository implements UnimindParametersRepos
         intrinsicValues: { type: DYNAMODB_TYPES.STRING, required: true },
         count: { type: DYNAMODB_TYPES.NUMBER, required: true },
         version: { type: DYNAMODB_TYPES.NUMBER, required: true },
+        batchNumber: { type: DYNAMODB_TYPES.NUMBER, required: true, default: 0 },
+        lastUpdatedAt: { type: DYNAMODB_TYPES.NUMBER, required: false },
       },
       table,
     } as const)

--- a/lib/unimind/priceImpactStrategy.ts
+++ b/lib/unimind/priceImpactStrategy.ts
@@ -18,7 +18,7 @@ export class PriceImpactStrategy implements IUnimindAlgorithm<PriceImpactIntrins
     private BETA = 1;
     private LAMBDA1_LEARNING_RATE = 3.625e-10; // Midpoint of 1.5e-10 and 5.75e-10
     private LAMBDA2_LEARNING_RATE = 0.3625; // Midpoint of 0.15 and 0.575
-    private SIGMA_LEARNING_RATE = 1e-6;
+    private SIGMA_LEARNING_RATE = 1.5e-6; // 1e-6 seemed too slow -- 8/30/25
 
     private LENGTH_OF_AUCTION_IN_BLOCKS = 32;
     private D_FR_D_SIGMA = Math.log(0.00001);

--- a/test/unit/handlers/get-unimind/get-unimind.test.ts
+++ b/test/unit/handlers/get-unimind/get-unimind.test.ts
@@ -79,7 +79,8 @@ describe('Testing get unimind handler', () => {
         Sigma: Math.log(0.00005)
       }),
       version: UNIMIND_ALGORITHM_VERSION,
-      count: 0
+      count: 0,
+      batchNumber: 0
     })
 
     const response = await getUnimindHandler.handler(
@@ -165,7 +166,8 @@ describe('Testing get unimind handler', () => {
         Sigma: Math.log(0.00005)
       }),
       version: UNIMIND_ALGORITHM_VERSION - 1,
-      count: 0
+      count: 0,
+      batchNumber: 0
     })
 
     const response = await getUnimindHandler.handler(
@@ -184,7 +186,8 @@ describe('Testing get unimind handler', () => {
       pair: SAMPLE_SUPPORTED_UNIMIND_PAIR,
       intrinsicValues: DEFAULT_UNIMIND_PARAMETERS, // Should return based on calculations with default parameters
       count: 0,
-      version: UNIMIND_ALGORITHM_VERSION
+      version: UNIMIND_ALGORITHM_VERSION,
+      batchNumber: 0
     }
     const expectedBody = calculateParameters(new PriceImpactStrategy(), expectedUnimindParameters, {
       quoteId: quoteMetadata.quoteId,
@@ -689,7 +692,8 @@ describe('Correctly modify URA calldata for Artemis support', () => {
           Sigma: Math.log(0.00005)
         }),
         version: UNIMIND_ALGORITHM_VERSION,
-        count: 0
+        count: 0,
+        batchNumber: 0
       }
       const quoteMetadata = {
         quoteId: 'test-quote-id',
@@ -725,7 +729,8 @@ describe('Correctly modify URA calldata for Artemis support', () => {
           Sigma: Math.log(0.00005)
         }),
         version: UNIMIND_ALGORITHM_VERSION,
-        count: 0
+        count: 0,
+        batchNumber: 0
       }
       const quoteMetadata = {
         quoteId: 'test-quote-id',
@@ -761,7 +766,8 @@ describe('Correctly modify URA calldata for Artemis support', () => {
           Sigma: Math.log(0.00005)
         }),
         version: UNIMIND_ALGORITHM_VERSION,
-        count: 0
+        count: 0,
+        batchNumber: 0
       }
       const quoteMetadata = {
         quoteId: 'test-quote-id',

--- a/test/unit/repositories/unimind-parameters-repository.test.ts
+++ b/test/unit/repositories/unimind-parameters-repository.test.ts
@@ -13,7 +13,8 @@ describe('UnimindParametersRepository', () => {
       tau: 4.2,
     }),
     version: UNIMIND_ALGORITHM_VERSION,
-    count: 42
+    count: 42,
+    batchNumber: 0
   }
 
   beforeEach(() => {

--- a/test/unit/util/unimind-algorithm.test.ts
+++ b/test/unit/util/unimind-algorithm.test.ts
@@ -124,21 +124,21 @@ describe('unimind-algorithm', () => {
   describe('unimindAlgorithm', () => {
     it('should return the same parameters if the statistics are empty', () => {
       const strategy = new PriceImpactStrategy()
-      const previousParameters = { intrinsicValues: JSON.stringify({ pi: 0.5, tau: 0.5 }), pair: '0x000-0x111-123', count: 25, version: UNIMIND_ALGORITHM_VERSION };
+      const previousParameters = { intrinsicValues: JSON.stringify({ pi: 0.5, tau: 0.5 }), pair: '0x000-0x111-123', count: 25, version: UNIMIND_ALGORITHM_VERSION, batchNumber: 0 };
       const statistics = { waitTimes: [], fillStatuses: [], priceImpacts: [] };
       const result = strategy.unimindAlgorithm(statistics, previousParameters, log);
       expect(result).toEqual(JSON.parse(previousParameters.intrinsicValues));
     });
     it('should treat negative wait times as 0', () => {
       const strategy = new PriceImpactStrategy()
-      const previousParameters = { intrinsicValues: JSON.stringify({ pi: 0.5, tau: 0.5 }), pair: '0x000-0x111-123', count: 25, version: UNIMIND_ALGORITHM_VERSION };
+      const previousParameters = { intrinsicValues: JSON.stringify({ pi: 0.5, tau: 0.5 }), pair: '0x000-0x111-123', count: 25, version: UNIMIND_ALGORITHM_VERSION, batchNumber: 0 };
       const statistics = { waitTimes: [-1, 1, 2], fillStatuses: [1, 1, 1], priceImpacts: [0.01, 0.02, 0.03] };
       strategy.unimindAlgorithm(statistics, previousParameters, log);
       expect(statistics.waitTimes).toEqual([0, 1, 2]);
     });
     it('should treat undefined wait times as auction duration (32) for average calculation', () => {
       const strategy = new BatchedStrategy()
-      const previousParameters = { intrinsicValues: JSON.stringify({ pi: 5, tau: 5 }), pair: '0x000-0x111-123', count: 25, version: UNIMIND_ALGORITHM_VERSION };
+      const previousParameters = { intrinsicValues: JSON.stringify({ pi: 5, tau: 5 }), pair: '0x000-0x111-123', count: 25, version: UNIMIND_ALGORITHM_VERSION, batchNumber: 0 };
       
       // Four defined wait times (all value 2) and one undefined wait time
       const statistics = { 
@@ -156,7 +156,7 @@ describe('unimind-algorithm', () => {
     });
     it('small price impact strategy test', () => {
       const strategy = new PriceImpactStrategy()
-      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: -9.210340371976182}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION };
+      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: -9.210340371976182}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION, batchNumber: 0 };
       const statistics = {
         priceImpacts: [71.326195,37.776453,65.712047,36.1534175,44.643392,65.690826,47.046204,60.366931,55.34904,53.1279089],
         waitTimes: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -174,7 +174,7 @@ describe('unimind-algorithm', () => {
       const priceImpacts = [71.326195,37.776453,65.712047,36.153417999999995,44.643392999999996,65.690826,47.046204,60.366931,55.34904,53.127908999999995,54.423511999999995,65.19417,62.022089,28.424546,49.078837,60.291282,31.713279,31.788921,70.89384600000001,56.324037000000004,53.515316,36.00114,69.551742,50.28837000000001,6.034174,42.604586,51.818982000000005,40.301666000000004,67.99754300000001,54.95465899999999,63.586809,62.746431,44.801485,62.056180000000005,70.62629700000001,56.774623999999996,37.786426,61.479227,42.824314,61.774944,70.264211,69.505023,45.516844,64.30273600000001,23.470843,24.29946,39.499266,44.837317,59.333055,35.663519,65.081785,70.32589,25.96255,41.386369,21.869225,64.201201,71.04847,71.655709,32.122751,43.039179,65.179817,6.391489,66.003474,2.740532,59.078206,51.044363999999995,72.25811,49.290612,11.821516,63.689742];
       const fillStatuses = [1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1];
       const waitTimes = [0,0,0,0,0,0,0,0,0,0,0,0,0,undefined,undefined,undefined,undefined,undefined,0,0,0,0,0,0,0,8,0,6,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,4,3,0,2,0,2,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0];
-      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: -9.210340371976182}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION };
+      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: -9.210340371976182}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION, batchNumber: 0 };
       const statistics = {
         priceImpacts,
         waitTimes,
@@ -188,7 +188,7 @@ describe('unimind-algorithm', () => {
 
     it('Price impact with real data <=1% price impact', () => {
       const strategy = new PriceImpactStrategy()
-      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 1.211937426072722e-9, lambda2: 4.237036738493101, Sigma: -0.41228565543852524}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION };
+      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 1.211937426072722e-9, lambda2: 4.237036738493101, Sigma: -0.41228565543852524}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION, batchNumber: 0 };
       const waitTimes = [25, 3, 2, 1, 2, 2, 2, 1, 3, 2, 2, 2, 2, 3, 16, 2, 3, 2, 2, 7, 2, 1, 3, 2, 3, 1, 2, 2, 1, 2, 4, 2, 1, 2, 1, 2, 2, undefined, 21, 9, 1, 6, 1, 5, 1, 2, undefined, 10, 3, 3];
       const priceImpacts = [0.28, 0.45, 0.02, 0.07, 0.66, 0.43, 0.38, 0.13, 0.81, 0.57, 0.40, 0.07, 1.00, 0.64, 0.89, 0.41, 0.37, 0.26, 0.13, 0.25, 0.34, 0.53, 0.58, 0.46, 0.08, 0.49, 0.15, 0.27, 0.30, 0.25, 0.56, 0.39, 0.50, 0.48, 0.46, 0.33, 0.29, 0.69, 0.45, 0.10, 0.10, 0.45, 0.52, 0.73, 0.15, 0.61, 0.29, 0.89, 0.44, 0.65];
       const statistics = {
@@ -204,7 +204,7 @@ describe('unimind-algorithm', () => {
 
     it('price impact strategy test on extrinsic values', () => {
       const strategy = new PriceImpactStrategy()
-      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: Math.log(0.00005)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION };
+      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: Math.log(0.00005)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION, batchNumber: 0 };
       const extrinsicValues: QuoteMetadata = { priceImpact: 0.01, quoteId: '0x000-0x111-123', referencePrice: '100', blockNumber: 100, route: { quote: '100', quoteGasAdjusted: '100', gasPriceWei: '100', gasUseEstimateQuote: '100', gasUseEstimate: '100', methodParameters: {calldata: '0x', value: '0', to: '0x0000000000000000000000000000000000000000'}}, pair: '0x000-0x111-123', usedUnimind: true }
       const result = calculateParameters(strategy, intrinsicValues, extrinsicValues)
 
@@ -214,7 +214,7 @@ describe('unimind-algorithm', () => {
 
     it('price impact strategy test on extrinsic values with big price impact', () => {
       const strategy = new PriceImpactStrategy()
-      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 1, Sigma: Math.log(0.00005)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION };
+      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 1, Sigma: Math.log(0.00005)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION, batchNumber: 0 };
       const extrinsicValues: QuoteMetadata = { priceImpact: UNIMIND_LARGE_PRICE_IMPACT_THRESHOLD + 0.1, quoteId: '0x000-0x111-123', referencePrice: '100', blockNumber: 100, route: { quote: '100', quoteGasAdjusted: '100', gasPriceWei: '100', gasUseEstimateQuote: '100', gasUseEstimate: '100', methodParameters: {calldata: '0x', value: '0', to: '0x0000000000000000000000000000000000000000'}}, pair: '0x000-0x111-123', usedUnimind: true }
       const result = calculateParameters(strategy, intrinsicValues, extrinsicValues)
 
@@ -225,7 +225,7 @@ describe('unimind-algorithm', () => {
 
     it('ceiling on tau for price impact strategy', () => {
       const strategy = new PriceImpactStrategy()
-      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: Math.log(0.0002)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION };
+      const intrinsicValues = { intrinsicValues: JSON.stringify({lambda1: 0, lambda2: 8, Sigma: Math.log(0.0002)}), count: UNIMIND_UPDATE_THRESHOLD, pair: '0x000-0x111-123', version: UNIMIND_ALGORITHM_VERSION, batchNumber: 0 };
       const extrinsicValues: QuoteMetadata = { priceImpact: 0.01, quoteId: '0x000-0x111-123', referencePrice: '100', blockNumber: 100, route: { quote: '100', quoteGasAdjusted: '100', gasPriceWei: '100', gasUseEstimateQuote: '100', gasUseEstimate: '100', methodParameters: {calldata: '0x', value: '0', to: '0x0000000000000000000000000000000000000000'}}, pair: '0x000-0x111-123', usedUnimind: true }
       const result = calculateParameters(strategy, intrinsicValues, extrinsicValues)
 


### PR DESCRIPTION
1. Update default intrinsic parameters
When expanding the token list (and removing it), we observed that the default parameters that new pairs start off with is suboptimal. We should change them so they more closely reflect the (15, 15) behavior at the start and have Unimind take the wheel from there.
2. Bump Sigma learning rate
Previously, we have been binary searching optimal learning rates for Lambda1 and Lambda2. From what we can observe, they are doing fine now and we should begin tuning Sigma. This will begin with us increasing the learning rate.
3. Add a new batch number identifier to the DB of pairs handled by Unimind
This makes it easier to track inter-batch performance which will help us make more confident, data-driven decisions when tweaking Unimind in the future.
It also gives us things like per-batch Fill Rate and Average Wait Time for free because they can be computed with a SQL query if we have this field.