### PR TITLE
Update sfn naming to prevent conflicts

### DIFF
--- a/lib/handlers/check-order-status/handler.ts
+++ b/lib/handlers/check-order-status/handler.ts
@@ -28,6 +28,9 @@ export class CheckOrderStatusHandler extends SfnLambdaHandler<ContainerInjected,
     const retryCount = input.requestInjected?.retryCount ?? 0
     if (retryCount > 300) {
       const stateMachineArn = input.requestInjected.stateMachineArn
+      const currentRunIndex = input.requestInjected.runIndex || 0
+      const nextRunIndex = currentRunIndex + 1
+      
       await kickoffOrderTrackingSfn(
         {
           orderHash: input.requestInjected.orderHash,
@@ -36,9 +39,9 @@ export class CheckOrderStatusHandler extends SfnLambdaHandler<ContainerInjected,
           quoteId: input.requestInjected.quoteId,
           orderType: input.requestInjected.orderType,
           stateMachineArn: input.requestInjected.stateMachineArn,
+          runIndex: nextRunIndex,
         },
-        stateMachineArn,
-        retryCount
+        stateMachineArn
       )
       powertoolsMetric
         .singleMetric()
@@ -51,6 +54,7 @@ export class CheckOrderStatusHandler extends SfnLambdaHandler<ContainerInjected,
         ...response,
         orderType: input.requestInjected.orderType,
         stateMachineArn: input.requestInjected.stateMachineArn,
+        runIndex: input.requestInjected.runIndex,
       }
     } else if (input.requestInjected.orderType === OrderType.Relay) {
       const response = await this.relayOrderService.checkOrderStatus(
@@ -66,6 +70,7 @@ export class CheckOrderStatusHandler extends SfnLambdaHandler<ContainerInjected,
         ...response,
         orderType: input.requestInjected.orderType,
         stateMachineArn: input.requestInjected.stateMachineArn,
+        runIndex: input.requestInjected.runIndex,
       }
     } else {
       // Dutch, Dutch_V2, Dutch_V3, Priority
@@ -74,6 +79,7 @@ export class CheckOrderStatusHandler extends SfnLambdaHandler<ContainerInjected,
         ...response,
         orderType: input.requestInjected.orderType,
         stateMachineArn: input.requestInjected.stateMachineArn,
+        runIndex: input.requestInjected.runIndex,
       }
     }
   }

--- a/lib/handlers/check-order-status/injector.ts
+++ b/lib/handlers/check-order-status/injector.ts
@@ -21,6 +21,7 @@ export interface RequestInjected {
   orderStatus: ORDER_STATUS
   getFillLogAttempts: number
   retryCount: number
+  runIndex: number
   provider: ethers.providers.StaticJsonRpcProvider
   orderWatcher: UniswapXEventWatcher
   orderQuoter: OrderValidator
@@ -75,6 +76,7 @@ export class CheckOrderStatusInjector extends SfnInjector<ContainerInjected, Req
       orderStatus: event.orderStatus as ORDER_STATUS,
       getFillLogAttempts: event.getFillLogAttempts ? (event.getFillLogAttempts as number) : 0,
       retryCount: event.retryCount ? (event.retryCount as number) : 0,
+      runIndex: event.runIndex ? (event.runIndex as number) : 0,
       provider: provider,
       orderWatcher: watcher,
       orderQuoter: quoter,

--- a/lib/handlers/check-order-status/service.ts
+++ b/lib/handlers/check-order-status/service.ts
@@ -268,6 +268,7 @@ export class CheckOrderStatusUtils {
     fillBlock?: number
     settledAmounts?: SettledAmount[]
     getFillLogAttempts?: number
+    runIndex?: number
   }): Promise<SfnStateInputOutput> {
     const {
       orderHash,
@@ -282,6 +283,7 @@ export class CheckOrderStatusUtils {
       settledAmounts,
       getFillLogAttempts,
       validation,
+      runIndex,
     } = params
 
     // Avoid updating the order if the status is unchanged.
@@ -324,6 +326,7 @@ export class CheckOrderStatusUtils {
       retryWaitSeconds: this.calculateRetryWaitSeconds(chainId, retryCount),
       startingBlockNumber: startingBlockNumber,
       chainId: chainId,
+      runIndex: runIndex || 0,
       ...(settledAmounts && { settledAmounts }),
       ...(txHash && { txHash }),
       ...(fillBlock && { fillBlock }),

--- a/lib/handlers/shared/sfn.ts
+++ b/lib/handlers/shared/sfn.ts
@@ -11,20 +11,25 @@ export type OrderTrackingSfnInput = {
   quoteId: string
   orderType: OrderType
   stateMachineArn: string
+  runIndex?: number
 }
 
 export async function kickoffOrderTrackingSfn(
   sfnInput: OrderTrackingSfnInput,
-  stateMachineArn: string,
-  retryCount = 0
+  stateMachineArn: string
 ) {
   log.info('starting state machine')
   const region = checkDefined(process.env['REGION'], 'REGION is undefined')
   const sfnClient = new SFNClient({ region: region })
+  
+  // Use runIndex if provided, otherwise fall back to random number
+  const BIG_NUMBER = 1000000000000
+  const rand = Math.floor(Math.random() * BIG_NUMBER)
+  const nameSuffix = sfnInput.runIndex !== undefined ? sfnInput.runIndex : rand
   const startExecutionCommand = new StartExecutionCommand({
     stateMachineArn: stateMachineArn,
     input: JSON.stringify(sfnInput),
-    name: sfnInput.orderHash + '_' + retryCount,
+    name: sfnInput.orderHash + '_' + nameSuffix,
   })
   log.info('Starting state machine execution', { startExecutionCommand })
   await sfnClient.send(startExecutionCommand)

--- a/lib/services/UniswapXOrderService.ts
+++ b/lib/services/UniswapXOrderService.ts
@@ -249,8 +249,7 @@ export class UniswapXOrderService {
         orderType,
         stateMachineArn,
       },
-      stateMachineArn,
-      0
+      stateMachineArn
     )
   }
 

--- a/test/unit/handlers/post-order/post-limit-order.test.ts
+++ b/test/unit/handlers/post-order/post-limit-order.test.ts
@@ -164,8 +164,7 @@ describe('Testing post limit order handler.', () => {
       expect(validatorMock).toBeCalledWith(order)
       expect(kickoffOrderTrackingSfn).toHaveBeenCalledWith(
         expect.objectContaining({ orderType: 'Limit' }),
-        expect.anything(),
-        0
+        expect.anything()
       )
       expect(postOrderResponse).toEqual({
         body: JSON.stringify({ hash: expectedOrderEntity.orderHash }),

--- a/test/unit/services/RelayOrderService.test.ts
+++ b/test/unit/services/RelayOrderService.test.ts
@@ -270,6 +270,7 @@ describe('RelayOrderService', () => {
       quoteId: '',
       retryCount: 1,
       retryWaitSeconds: 12,
+      runIndex: 0,
       startingBlockNumber: 100,
     })
   })
@@ -337,6 +338,7 @@ describe('RelayOrderService', () => {
       quoteId: '',
       retryCount: 1,
       retryWaitSeconds: 12,
+      runIndex: 0,
       settledAmounts: [
         {
           amountIn: '1000000',
@@ -413,6 +415,7 @@ describe('RelayOrderService', () => {
       quoteId: '',
       retryCount: 1,
       retryWaitSeconds: 12,
+      runIndex: 0,
       settledAmounts: [
         {
           amountIn: '1000000',

--- a/test/unit/services/UniswapXOrderService.test.ts
+++ b/test/unit/services/UniswapXOrderService.test.ts
@@ -83,8 +83,7 @@ describe('UniswapXOrderService', () => {
         quoteId: '',
         stateMachineArn: undefined,
       },
-      undefined,
-      0
+      undefined
     )
   })
 
@@ -135,8 +134,7 @@ describe('UniswapXOrderService', () => {
         quoteId: '',
         stateMachineArn: undefined,
       },
-      undefined,
-      0
+      undefined
     )
   })
 


### PR DESCRIPTION
Currently the name of the sfn is postfixed with the `retryCount` which always ends at 301, resulting in naming conflicts. This PR updates the name to be an ever-incrementing index that is unique per sfn instance.