### PR TITLE
feat: save quote metadata for public parameter path

### DIFF
--- a/lib/handlers/get-unimind/handler.ts
+++ b/lib/handlers/get-unimind/handler.ts
@@ -55,9 +55,15 @@ export class GetUnimindHandler extends APIGLambdaHandler<ContainerInjected, Requ
       }
 
       if (!swapper || !unimindAddressFilter(swapper) || !supportedUnimindTokens(quoteMetadata.pair)) {
+        quoteMetadata.usedUnimind = false
+        try {
+          await quoteMetadataRepository.put(quoteMetadata)
+        } catch (error) {
+          log.error({ error, quoteId: quoteMetadata.quoteId }, 'Failed to store quote metadata for public parameters path')
+        } // Don't signal failure when assigning public params while still attempting to persist metadata
         return {
-            statusCode: 200,
-            body: PUBLIC_UNIMIND_PARAMETERS
+          statusCode: 200,
+          body: PUBLIC_UNIMIND_PARAMETERS
         }
       }
 


### PR DESCRIPTION
- Persist quote metadata even when assigning default pi, tau parameters so that we can reference the saved route for PI data calculation