### PR TITLE
fix: correct Secrets Manager path separator for TAPI secrets

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -287,11 +287,11 @@ export class APIPipeline extends Stack {
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
           TAPI_QUOTE_URL: {
-            value: `${stage}/gouda-service/integ-test:tapi_url`,
+            value: `${stage}/gouda-service/integ-test/tapi_url`,
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
           TAPI_API_KEY: {
-            value: `${stage}/gouda-service/integ-test:tapi_api_key`,
+            value: `${stage}/gouda-service/integ-test/tapi_api_key`,
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
           GPA_SERVICE_URL: {


### PR DESCRIPTION
## Summary

- Fix secret path separator for `TAPI_QUOTE_URL` and `TAPI_API_KEY` in `bin/app.ts`
- Change from `:` to `/` to match the actual AWS Secrets Manager secret path format

## Test plan

- [ ] Verify integ test pipeline can resolve TAPI secrets after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)