### PR TITLE
feat: env-specific log retention (prod 90d, staging 60d, dev 30d)

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -74,7 +74,9 @@ export class APIStack extends cdk.Stack {
       chatbotSNSArn,
     })
 
-    const accessLogGroup = new aws_logs.LogGroup(this, `${SERVICE_NAME}APIGAccessLogs`)
+    const accessLogGroup = new aws_logs.LogGroup(this, `${SERVICE_NAME}APIGAccessLogs`, {
+      retention: aws_logs.RetentionDays.ONE_MONTH,
+    })
 
     const api = new aws_apigateway.RestApi(this, `${SERVICE_NAME}`, {
       restApiName: `${SERVICE_NAME}`,

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -9,7 +9,7 @@ import * as aws_logs from 'aws-cdk-lib/aws-logs'
 import * as aws_sns from 'aws-cdk-lib/aws-sns'
 import * as aws_waf from 'aws-cdk-lib/aws-wafv2'
 import { Construct } from 'constructs'
-import { STAGE } from '../../lib/util/stage'
+import { STAGE, logRetentionDays } from '../../lib/util/stage'
 import { SERVICE_NAME } from '../constants'
 import { DashboardStack } from './dashboard-stack'
 import { IndexCapacityConfig, TableCapacityConfig } from './dynamo-stack'
@@ -75,7 +75,7 @@ export class APIStack extends cdk.Stack {
     })
 
     const accessLogGroup = new aws_logs.LogGroup(this, `${SERVICE_NAME}APIGAccessLogs`, {
-      retention: aws_logs.RetentionDays.ONE_MONTH,
+      retention: logRetentionDays(stage as STAGE),
     })
 
     const api = new aws_apigateway.RestApi(this, `${SERVICE_NAME}`, {

--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -35,6 +35,7 @@ export class CronStack extends cdk.NestedStack {
       environment: {
         NODE_OPTIONS: '--enable-source-maps',
       },
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
 
     new aws_events.Rule(this, `${SERVICE_NAME}UnimindAlgorithmCron`, {

--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -7,9 +7,11 @@ import { Construct } from 'constructs'
 import path from 'path'
 
 import { SERVICE_NAME, UNIMIND_ALGORITHM_CRON_INTERVAL, FILTER_PATTERNS } from '../constants'
+import { STAGE, logRetentionDays } from '../../lib/util/stage'
 
 export interface CronStackProps extends cdk.NestedStackProps {
   lambdaRole: aws_iam.Role
+  stage: STAGE
   chatbotSNSArn?: string
   envVars?: { [key: string]: string }
 }
@@ -35,7 +37,7 @@ export class CronStack extends cdk.NestedStack {
       environment: {
         NODE_OPTIONS: '--enable-source-maps',
       },
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(props.stage),
     })
 
     new aws_events.Rule(this, `${SERVICE_NAME}UnimindAlgorithmCron`, {

--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -6,6 +6,7 @@ import { CfnEIP, NatProvider, Vpc } from 'aws-cdk-lib/aws-ec2'
 import * as aws_iam from 'aws-cdk-lib/aws-iam'
 import * as aws_kms from 'aws-cdk-lib/aws-kms'
 import * as aws_lambda from 'aws-cdk-lib/aws-lambda'
+import * as aws_logs from 'aws-cdk-lib/aws-logs'
 import { DynamoEventSource, SqsDlq } from 'aws-cdk-lib/aws-lambda-event-sources'
 import * as aws_lambda_nodejs from 'aws-cdk-lib/aws-lambda-nodejs'
 import { Queue } from 'aws-cdk-lib/aws-sqs'
@@ -146,6 +147,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: getOrdersEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
 
     this.orderNotificationLambda = new aws_lambda_nodejs.NodejsFunction(this, `OrderNotification${lambdaName}`, {
@@ -171,6 +173,7 @@ export class LambdaStack extends cdk.NestedStack {
       vpcSubnets: {
         subnets: [...vpc.privateSubnets],
       },
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
 
     const notificationConfig = {
@@ -226,6 +229,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: postOrderEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
 
     this.postLimitOrderLambda = new aws_lambda_nodejs.NodejsFunction(this, `PostLimitOrder${lambdaName}`, {
@@ -241,6 +245,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: postOrderEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
 
     this.getLimitOrdersLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetLimitOrders${lambdaName}`, {
@@ -255,6 +260,7 @@ export class LambdaStack extends cdk.NestedStack {
         sourceMap: true,
       },
       environment: getOrdersEnv,
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
 
     this.getNonceLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetNonce${lambdaName}`, {
@@ -276,6 +282,7 @@ export class LambdaStack extends cdk.NestedStack {
         NODE_OPTIONS: '--enable-source-maps',
       },
       tracing: aws_lambda.Tracing.ACTIVE,
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
 
     this.getDocsLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetDocs${lambdaName}`, {
@@ -295,6 +302,7 @@ export class LambdaStack extends cdk.NestedStack {
         VERSION: '5',
         NODE_OPTIONS: '--enable-source-maps',
       },
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
 
     this.getDocsUILambda = new aws_lambda_nodejs.NodejsFunction(this, `GetDocsUI${lambdaName}`, {
@@ -314,6 +322,7 @@ export class LambdaStack extends cdk.NestedStack {
         VERSION: '5',
         NODE_OPTIONS: '--enable-source-maps',
       },
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
 
     this.getUnimindLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetUnimind${lambdaName}`, {
@@ -329,6 +338,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: postOrderEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
 
     if (props.envVars['POSTED_ORDER_DESTINATION_ARN']) {

--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -6,14 +6,13 @@ import { CfnEIP, NatProvider, Vpc } from 'aws-cdk-lib/aws-ec2'
 import * as aws_iam from 'aws-cdk-lib/aws-iam'
 import * as aws_kms from 'aws-cdk-lib/aws-kms'
 import * as aws_lambda from 'aws-cdk-lib/aws-lambda'
-import * as aws_logs from 'aws-cdk-lib/aws-logs'
 import { DynamoEventSource, SqsDlq } from 'aws-cdk-lib/aws-lambda-event-sources'
 import * as aws_lambda_nodejs from 'aws-cdk-lib/aws-lambda-nodejs'
 import { Queue } from 'aws-cdk-lib/aws-sqs'
 import { Construct } from 'constructs'
 import * as path from 'path'
 import { SUPPORTED_CHAINS } from '../../lib/util/chain'
-import { STAGE } from '../../lib/util/stage'
+import { STAGE, logRetentionDays } from '../../lib/util/stage'
 import { SERVICE_NAME, FILTER_PATTERNS } from '../constants'
 import { CronStack } from './cron-stack'
 import { DynamoStack, IndexCapacityConfig, TableCapacityConfig } from './dynamo-stack'
@@ -147,7 +146,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: getOrdersEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.orderNotificationLambda = new aws_lambda_nodejs.NodejsFunction(this, `OrderNotification${lambdaName}`, {
@@ -173,7 +172,7 @@ export class LambdaStack extends cdk.NestedStack {
       vpcSubnets: {
         subnets: [...vpc.privateSubnets],
       },
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(props.stage),
     })
 
     const notificationConfig = {
@@ -229,7 +228,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: postOrderEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.postLimitOrderLambda = new aws_lambda_nodejs.NodejsFunction(this, `PostLimitOrder${lambdaName}`, {
@@ -245,7 +244,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: postOrderEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.getLimitOrdersLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetLimitOrders${lambdaName}`, {
@@ -260,7 +259,7 @@ export class LambdaStack extends cdk.NestedStack {
         sourceMap: true,
       },
       environment: getOrdersEnv,
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.getNonceLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetNonce${lambdaName}`, {
@@ -282,7 +281,7 @@ export class LambdaStack extends cdk.NestedStack {
         NODE_OPTIONS: '--enable-source-maps',
       },
       tracing: aws_lambda.Tracing.ACTIVE,
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.getDocsLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetDocs${lambdaName}`, {
@@ -302,7 +301,7 @@ export class LambdaStack extends cdk.NestedStack {
         VERSION: '5',
         NODE_OPTIONS: '--enable-source-maps',
       },
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.getDocsUILambda = new aws_lambda_nodejs.NodejsFunction(this, `GetDocsUI${lambdaName}`, {
@@ -322,7 +321,7 @@ export class LambdaStack extends cdk.NestedStack {
         VERSION: '5',
         NODE_OPTIONS: '--enable-source-maps',
       },
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.getUnimindLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetUnimind${lambdaName}`, {
@@ -338,7 +337,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: postOrderEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(props.stage),
     })
 
     if (props.envVars['POSTED_ORDER_DESTINATION_ARN']) {
@@ -642,6 +641,7 @@ export class LambdaStack extends cdk.NestedStack {
     /* cron stack */
     new CronStack(this, `${SERVICE_NAME}CronStack`, {
       lambdaRole,
+      stage: props.stage,
       envVars: props.envVars,
       chatbotSNSArn: props.chatbotSNSArn,
     })

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -53,6 +53,7 @@ export class StepFunctionStack extends cdk.NestedStack {
         ...props.envVars,
         stage: stage,
       },
+      logRetention: aws_logs.RetentionDays.ONE_MONTH,
     })
     this.checkStatusFunction = checkStatusFunction
 

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -7,7 +7,7 @@ import { Construct } from 'constructs'
 import path from 'path'
 import { checkDefined } from '../../lib/preconditions/preconditions'
 import { SUPPORTED_CHAINS } from '../../lib/util/chain'
-import { STAGE } from '../../lib/util/stage'
+import { STAGE, logRetentionDays } from '../../lib/util/stage'
 import { SERVICE_NAME, FILTER_PATTERNS } from '../constants'
 import orderStatusTrackingStateMachine from '../definitions/order-tracking-sfn.json'
 
@@ -53,7 +53,7 @@ export class StepFunctionStack extends cdk.NestedStack {
         ...props.envVars,
         stage: stage,
       },
-      logRetention: aws_logs.RetentionDays.ONE_MONTH,
+      logRetention: logRetentionDays(stage),
     })
     this.checkStatusFunction = checkStatusFunction
 

--- a/lib/util/stage.ts
+++ b/lib/util/stage.ts
@@ -1,5 +1,18 @@
+import { RetentionDays } from 'aws-cdk-lib/aws-logs'
+
 export enum STAGE {
   BETA = 'beta',
   PROD = 'prod',
   LOCAL = 'local',
+}
+
+export function logRetentionDays(stage: STAGE): RetentionDays {
+  switch (stage) {
+    case STAGE.PROD:
+      return RetentionDays.THREE_MONTHS
+    case STAGE.BETA:
+      return RetentionDays.TWO_MONTHS
+    default:
+      return RetentionDays.ONE_MONTH
+  }
 }


### PR DESCRIPTION
## Summary

- Adds a `logRetentionDays(stage)` helper in `lib/util/stage.ts` that maps environment to the appropriate CloudWatch log retention period
- Replaces all hardcoded `ONE_MONTH` retention with the helper across all stacks
- Adds `stage` prop to `CronStackProps` so it can derive retention from its environment

| Environment | Retention |
|-------------|-----------|
| `prod` | 90 days (THREE_MONTHS) |
| `beta` (staging) | 60 days (TWO_MONTHS) |
| `local` (dev) | 30 days (ONE_MONTH) |

## Stacks updated
- `lambda-stack.ts` (9 lambdas)
- `api-stack.ts` (API Gateway access log group)
- `step-function-stack.ts` (check-status lambda)
- `cron-stack.ts` (unimind algorithm cron lambda)

## Test plan
- [x] `yarn build` passes with no TS errors
- [x] `yarn test` — no regressions (14 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)