### PR TITLE
feat: pass chainId to ethers StaticJsonRpcProvider constructions

### DIFF
--- a/lib/handlers/EventWatcherMap.ts
+++ b/lib/handlers/EventWatcherMap.ts
@@ -38,7 +38,7 @@ export class EventWatcherMap<T extends UniswapXEventWatcher | RelayEventWatcher>
         new RelayEventWatcher(new ethers.providers.StaticJsonRpcProvider({
           url: CONFIG.rpcUrls.get(chainId),
           headers: RPC_HEADERS
-        }), address)
+        }, chainId), address)
       )
     }
     return map

--- a/lib/handlers/check-order-status/index.ts
+++ b/lib/handlers/check-order-status/index.ts
@@ -29,7 +29,7 @@ for (const chainId of SUPPORTED_CHAINS) {
     new OnChainRelayOrderValidator(new ethers.providers.StaticJsonRpcProvider({
       url: CONFIG.rpcUrls.get(chainId),
       headers: RPC_HEADERS
-    }), chainId)
+    }, chainId), chainId)
   )
 }
 

--- a/lib/handlers/post-limit-order/index.ts
+++ b/lib/handlers/post-limit-order/index.ts
@@ -34,7 +34,7 @@ for (const chainId of SUPPORTED_CHAINS) {
     new OnChainOrderValidator(new ethers.providers.StaticJsonRpcProvider({
       url: CONFIG.rpcUrls.get(chainId),
       headers: RPC_HEADERS
-    }), chainId)
+    }, chainId), chainId)
   )
 }
 
@@ -44,7 +44,7 @@ for (const chainId of SUPPORTED_CHAINS) {
   providerMap.set(chainId, new ethers.providers.StaticJsonRpcProvider({
     url: CONFIG.rpcUrls.get(chainId),
     headers: RPC_HEADERS
-  }))
+  }, chainId))
 }
 
 const orderValidator = new OffChainUniswapXOrderValidator(() => new Date().getTime() / 1000, ONE_YEAR_IN_SECONDS, {
@@ -76,7 +76,7 @@ for (const chainId of SUPPORTED_CHAINS) {
     new OnChainOrderValidator(new ethers.providers.StaticJsonRpcProvider({
       url: CONFIG.rpcUrls.get(chainId),
       headers: RPC_HEADERS
-    }), chainId)
+    }, chainId), chainId)
   )
 }
 const relayOrderService = new RelayOrderService(

--- a/lib/handlers/post-order/index.ts
+++ b/lib/handlers/post-order/index.ts
@@ -40,7 +40,7 @@ for (const chainId of SUPPORTED_CHAINS) {
   const provider = new ethers.providers.StaticJsonRpcProvider({
         url: CONFIG.rpcUrls.get(chainId),
         headers: RPC_HEADERS,
-  })
+  }, chainId)
   onChainValidatorMap.set(chainId, new OnChainOrderValidator(provider, chainId))
   if (OnChainV4QuoterMapping[chainId]) {
     onChainV4ValidatorMap.set(chainId, new OnChainV4OrderValidator(provider, chainId))
@@ -55,7 +55,7 @@ for (const chainId of SUPPORTED_CHAINS) {
     new ethers.providers.StaticJsonRpcProvider({
       url: CONFIG.rpcUrls.get(chainId),
       headers: RPC_HEADERS,
-    })
+    }, chainId)
   )
 }
 
@@ -94,7 +94,7 @@ for (const chainId of SUPPORTED_CHAINS) {
       new ethers.providers.StaticJsonRpcProvider({
         url: CONFIG.rpcUrls.get(chainId),
         headers: RPC_HEADERS,
-      }),
+      }, chainId),
       chainId
     )
   )


### PR DESCRIPTION
## Summary
Pass `chainId` as the second argument to every `ethers.providers.StaticJsonRpcProvider` construction. This skips the auto-detect network round-trip on first use and locks the provider to the expected network.

Touched call sites: `EventWatcherMap`, `check-order-status` (relay validator init), `post-order`, and `post-limit-order`.

## Test plan
- [ ] `yarn build` and `yarn test` pass locally
- [ ] Deploy to a non-prod stage and confirm `post-order`, `post-limit-order`, and `check-order-status` continue to work across all `SUPPORTED_CHAINS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
