### PR TITLE
chore: bump VERSION env vars for reaper and step function stacks

### DIFF
--- a/bin/stacks/reaper-stack.ts
+++ b/bin/stacks/reaper-stack.ts
@@ -61,7 +61,7 @@ export class ReaperStack extends Stack {
           ...environmentVariables,
           AWS_EMF_ENVIRONMENT: "Local",
           // update to trigger deployment
-          VERSION: "2",
+          VERSION: "3",
         },
         logging: this.logDriver,
       })

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -48,7 +48,7 @@ export class StepFunctionStack extends cdk.NestedStack {
       },
       timeout: Duration.minutes(5),
       environment: {
-        VERSION: '3',
+        VERSION: '4',
         NODE_OPTIONS: '--enable-source-maps',
         ...props.envVars,
         stage: stage,


### PR DESCRIPTION
## Summary
- Bump `VERSION` env var on the reaper ECS task from `2` to `3` to trigger redeployment
- Bump `VERSION` env var on the step function lambda from `3` to `4` to trigger redeployment

## Test plan
- [ ] CDK synth passes in CI
- [ ] Deploy picks up the new VERSION values and redeploys the affected resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)