### PR TITLE
DO NOT MERGE chore: remove GetUnimind from 5xx alarm endpoints

### DIFF
--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -601,7 +601,6 @@ export class LambdaStack extends cdk.NestedStack {
       { name: 'PostOrder', requestMetric: 'PostOrderRequest', errorMetric: 'PostOrderStatus5XX' },
       { name: 'GetOrders', requestMetric: 'GetOrdersRequest', errorMetric: 'GetOrdersStatus5XX' },
       { name: 'GetNonce', requestMetric: 'GetNonceRequest', errorMetric: 'GetNonceStatus5XX' },
-      { name: 'GetUnimind', requestMetric: 'GetUnimindRequest', errorMetric: 'GetUnimindStatus5XX' },
     ]
 
     for (const { name, requestMetric, errorMetric } of endpointsForFiveXxAlarms) {


### PR DESCRIPTION
## Summary
- Removes `GetUnimind` from `endpointsForFiveXxAlarms` in `bin/stacks/lambda-stack.ts` so a 5xx error-rate alarm is no longer provisioned for that endpoint.

## Test plan
- [ ] `yarn build` passes
- [ ] `cdk diff` shows only the GetUnimind 5xx alarm being removed (no other alarm changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)