### PR TITLE
chore: disable provisioned concurrency in beta to diagnose PC FAILED

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -182,7 +182,9 @@ export class APIPipeline extends Stack {
     // Beta us-east-2
     const betaUsEast2Stage = new APIStage(this, 'beta-us-east-2', {
       env: { account: '321377678687', region: 'us-east-2' },
-      provisionedConcurrency: 2,
+      // Temporarily disabled to diagnose PostOrderLiveAlias PC FAILED on deploy.
+      // Restore to 2 once root cause is identified.
+      provisionedConcurrency: 0,
       internalApiKey: internalApiKey.secretValue.toString(),
       stage: STAGE.BETA,
       envVars: {


### PR DESCRIPTION
## Summary

- Sets beta's `provisionedConcurrency` from `2` to `0` (`bin/app.ts:185`)
- Temporary diagnostic change — restore to `2` once the root cause is identified

## Why

Beta deploy of #646 failed with `PostOrderLiveAlias` reporting:

> Provisioned Concurrency configuration failed to be applied. Reason: FAILED

A retry produced the same failure, ruling out a transient init flake. The three candidate root causes are:

1. Orphaned `FAILED` PC config from the first failed deploy that Lambda keeps returning cached
2. Application AutoScaling racing with CFN for control of PC on the alias (both write to `function:<fn>:live`)
3. Module-init exceeding the 10s PC init budget on the new version

Setting `provisionedConcurrency: 0` removes PC from every alias in beta. If beta deploys cleanly:
- We've isolated the failure to PC specifically
- A follow-up deploy restoring PC to `2` gives a clean PC allocation on a fresh version, which either succeeds (confirming root cause was orphaned config) or fails again (pointing at autoscaling-race or init-budget)

Beta is the right place to do this — prod runs PC=5 and the blast radius of removing PC there is too high.

## Test plan

- [ ] CI passes
- [ ] Beta deploy succeeds with PC=0 (alias updates without `FAILED`)
- [ ] Follow-up PR restoring `provisionedConcurrency: 2` deploys cleanly; if not, capture `StatusReason` from `aws lambda get-provisioned-concurrency-config` to identify which of the three causes

🤖 Generated with [Claude Code](https://claude.com/claude-code)