### PR TITLE
chore: disable provisioned concurrency in prod to diagnose PC FAILED

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -222,7 +222,9 @@ export class APIPipeline extends Stack {
     // Prod us-east-2
     const prodUsEast2Stage = new APIStage(this, 'prod-us-east-2', {
       env: { account: '316116520258', region: 'us-east-2' },
-      provisionedConcurrency: 5,
+      // Temporarily disabled to diagnose PostOrderLiveAlias PC FAILED on deploy.
+      // Restore to 5 once root cause is identified.
+      provisionedConcurrency: 0,
       internalApiKey: internalApiKey.secretValue.toString(),
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       stage: STAGE.PROD,


### PR DESCRIPTION
## Summary

- Sets prod's `provisionedConcurrency` from `5` to `0` (`bin/app.ts:225`)
- Companion to #655 (beta). Temporary diagnostic change — restore to `5` once root cause is identified.

## ⚠️ Latency impact

Removing PC from prod means every PostOrder/GetOrders/etc. request hits a cold start until PC is restored. Cold starts on these handlers are ~1–3s due to heavy module-init (RPC providers per chain, DynamoDB clients, S3 webhook provider) — see `lib/handlers/post-order/index.ts:39-118`. Plan to merge during low-traffic window and watch p99 latency on PostOrder during the rollout.

## Why

Prod deploy of #646 failed with `PostOrderLiveAlias` reporting:

> Provisioned Concurrency configuration failed to be applied. Reason: FAILED

A retry produced the same failure, ruling out a transient init flake. The three candidate root causes are:

1. Orphaned `FAILED` PC config from the first failed deploy that Lambda keeps returning cached
2. Application AutoScaling racing with CFN for control of PC on the alias (both write to `function:<fn>:live`)
3. Module-init exceeding the 10s PC init budget on the new version

Setting `provisionedConcurrency: 0` removes PC from every alias in prod so the stack can converge. The follow-up PR restoring PC=5 either succeeds (orphaned-config theory confirmed) or fails again with a fresh `StatusReason` from `aws lambda get-provisioned-concurrency-config` that points at autoscaling-race or init-budget.

## Merge order

1. Merge #655 first; verify beta deploys cleanly with PC=0.
2. Then merge this PR.
3. Follow-up PR restores both beta to `2` and prod to `5`; capture `StatusReason` if it fails again.

## Test plan

- [ ] CI passes
- [ ] #655 has deployed cleanly to beta before this is merged
- [ ] Prod deploy succeeds with PC=0 (alias updates without `FAILED`)
- [ ] PostOrder p99 latency monitored during/after rollout
- [ ] Follow-up PR restoring `provisionedConcurrency: 5` deploys cleanly; if not, capture `StatusReason`

🤖 Generated with [Claude Code](https://claude.com/claude-code)