### PR TITLE
chore: restore provisioned concurrency in beta to 2

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -182,9 +182,7 @@ export class APIPipeline extends Stack {
     // Beta us-east-2
     const betaUsEast2Stage = new APIStage(this, 'beta-us-east-2', {
       env: { account: '321377678687', region: 'us-east-2' },
-      // Temporarily disabled to diagnose PostOrderLiveAlias PC FAILED on deploy.
-      // Restore to 2 once root cause is identified.
-      provisionedConcurrency: 0,
+      provisionedConcurrency: 2,
       internalApiKey: internalApiKey.secretValue.toString(),
       stage: STAGE.BETA,
       envVars: {


### PR DESCRIPTION
## Summary

- Reverts beta's `provisionedConcurrency` from `0` back to `2` (`bin/app.ts:185`)
- Removes the temporary diagnostic comment from #655
- **Diagnostic gate for the prod equivalent** — merge prod restore only if this PR deploys cleanly

## Why

#655 set beta to `0` to let the stack converge after the `PostOrderLiveAlias` PC FAILED state from #646. This PR re-applies PC=2 on a freshly-deployed Lambda version.

The deploy outcome is the diagnostic signal:

| Result | What it tells us | Next step |
|--------|------------------|-----------|
| **Deploys cleanly** | Root cause was an orphaned `FAILED` PC config from the original #646 attempt — clearing PC then re-applying it on a new version is sufficient | Merge #656 (prod=0), then a prod-restore PR mirroring this one |
| **Fails with `Reason: FAILED`** | Either autoscaling racing CFN for control of the alias's PC, or module-init exceeding the 10s PC-init budget on the new version | Run `aws lambda get-provisioned-concurrency-config` against the failed version, capture `StatusReason`, do **not** merge the prod restore until understood |

## Merge order

1. ✅ #655 merged (beta → 0)
2. **This PR** — verify PC re-applies cleanly in beta
3. #656 (prod → 0) — only after step 2 succeeds
4. Prod restore PR (prod → 5) — only after #656 deploys cleanly

## Test plan

- [ ] CI passes
- [ ] Beta deploy succeeds (no `PostOrderLiveAlias` failure)
- [ ] `aws lambda list-provisioned-concurrency-configs` against the PostOrder beta function shows `Status: READY` on the live alias
- [ ] PostOrder p99 latency drops back to pre-#655 baseline (PC warm again)

🤖 Generated with [Claude Code](https://claude.com/claude-code)