### PR TITLE
fix(lambda): bump PostOrder/PostLimitOrder memorySize 512→1024 MB

### DIFF
--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -221,7 +221,9 @@ export class LambdaStack extends cdk.NestedStack {
       entry: path.join(__dirname, '../../lib/handlers/post-order/index.ts'),
       handler: 'postOrderHandler',
       timeout: Duration.seconds(29),
-      memorySize: 512,
+      // Module-load builds StaticJsonRpcProvider + OrderValidator (+ V4) maps
+      // for every SUPPORTED_CHAIN; 512 MB OOMs at cold-start past ~16 chains.
+      memorySize: 1024,
       bundling: {
         minify: true,
         sourceMap: true,
@@ -237,7 +239,9 @@ export class LambdaStack extends cdk.NestedStack {
       entry: path.join(__dirname, '../../lib/handlers/post-limit-order/index.ts'),
       handler: 'postLimitOrderHandler',
       timeout: Duration.seconds(29),
-      memorySize: 512,
+      // Same per-chain map construction as PostOrder above — bumped to avoid
+      // cold-start OOM as the supported-chain list grew.
+      memorySize: 1024,
       bundling: {
         minify: true,
         sourceMap: true,


### PR DESCRIPTION
## Summary

Bump the `PostOrder` and `PostLimitOrder` Lambda `memorySize` from 512 MB to 1024 MB so cold-start init can fit the per-chain provider/validator maps as `SUPPORTED_CHAINS` continues to grow.

## What broke

While deploying the V3 multi-chain rollout to beta, the `PostOrder` Lambda began OOMing during cold-start init:

```
INIT_REPORT Init Duration: 3609.31 ms Phase: init Status: error
Error Type: Runtime.OutOfMemory
```

Surfaced upstream as 2-second axios timeouts from `x-parameterization-api` → `x-service`:

```
{"name":"hardQuoteInjector","quoter":"UniswapXOrderService","code":"ECONNABORTED",
 "msg":"Error posting order to UniswapX Service"}
```

## Root cause

`lib/handlers/post-order/index.ts` builds three maps at module load — one `StaticJsonRpcProvider`, one `OnChainOrderValidator`, and one (conditional) `OnChainV4OrderValidator` per entry in `SUPPORTED_CHAINS`. With the rollout taking `SUPPORTED_CHAINS` from ~4 to 18, total module-load memory crossed the 512 MB ceiling. `PostLimitOrder` follows the same pattern.

## Fix

Bump both Lambdas to 1024 MB, matching what `check-order-status` and `get-orders` already use (they iterate the same list at module load and were sized accordingly).

## Follow-ups (not in this PR)

- Refactor `OnChainValidatorMap` / `EventWatcherMap` to lazy-init entries on first `get(chainId)` rather than eager construction at module load. Halves cold-start memory and time; necessary before the next chain rollout pushes us past 1024 MB.

## Test plan

- [x] `yarn build` clean
- [x] CDK `synth` matches expected diff
- [ ] Deploy to beta, confirm `PostOrder` cold-start succeeds and the param-api integ test (`successfully skips quotes with forceOpenOrder`) returns 200/201

🤖 Generated with [Claude Code](https://claude.com/claude-code)