### PR TITLE
Reapply: env-specific log retention (prod 90d, staging 60d, dev 30d)

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -9,7 +9,7 @@ import * as aws_logs from 'aws-cdk-lib/aws-logs'
 import * as aws_sns from 'aws-cdk-lib/aws-sns'
 import * as aws_waf from 'aws-cdk-lib/aws-wafv2'
 import { Construct } from 'constructs'
-import { STAGE } from '../../lib/util/stage'
+import { STAGE, logRetentionDays } from '../../lib/util/stage'
 import { SERVICE_NAME } from '../constants'
 import { DashboardStack } from './dashboard-stack'
 import { IndexCapacityConfig, TableCapacityConfig } from './dynamo-stack'
@@ -74,7 +74,9 @@ export class APIStack extends cdk.Stack {
       chatbotSNSArn,
     })
 
-    const accessLogGroup = new aws_logs.LogGroup(this, `${SERVICE_NAME}APIGAccessLogs`)
+    const accessLogGroup = new aws_logs.LogGroup(this, `${SERVICE_NAME}APIGAccessLogs`, {
+      retention: logRetentionDays(stage as STAGE),
+    })
 
     const api = new aws_apigateway.RestApi(this, `${SERVICE_NAME}`, {
       restApiName: `${SERVICE_NAME}`,

--- a/bin/stacks/cron-stack.ts
+++ b/bin/stacks/cron-stack.ts
@@ -7,9 +7,11 @@ import { Construct } from 'constructs'
 import path from 'path'
 
 import { SERVICE_NAME, UNIMIND_ALGORITHM_CRON_INTERVAL, FILTER_PATTERNS } from '../constants'
+import { STAGE, logRetentionDays } from '../../lib/util/stage'
 
 export interface CronStackProps extends cdk.NestedStackProps {
   lambdaRole: aws_iam.Role
+  stage: STAGE
   chatbotSNSArn?: string
   envVars?: { [key: string]: string }
 }
@@ -35,6 +37,7 @@ export class CronStack extends cdk.NestedStack {
       environment: {
         NODE_OPTIONS: '--enable-source-maps',
       },
+      logRetention: logRetentionDays(props.stage),
     })
 
     new aws_events.Rule(this, `${SERVICE_NAME}UnimindAlgorithmCron`, {

--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -12,7 +12,7 @@ import { Queue } from 'aws-cdk-lib/aws-sqs'
 import { Construct } from 'constructs'
 import * as path from 'path'
 import { SUPPORTED_CHAINS } from '../../lib/util/chain'
-import { STAGE } from '../../lib/util/stage'
+import { STAGE, logRetentionDays } from '../../lib/util/stage'
 import { SERVICE_NAME, FILTER_PATTERNS } from '../constants'
 import { CronStack } from './cron-stack'
 import { DynamoStack, IndexCapacityConfig, TableCapacityConfig } from './dynamo-stack'
@@ -146,6 +146,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: getOrdersEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.orderNotificationLambda = new aws_lambda_nodejs.NodejsFunction(this, `OrderNotification${lambdaName}`, {
@@ -171,6 +172,7 @@ export class LambdaStack extends cdk.NestedStack {
       vpcSubnets: {
         subnets: [...vpc.privateSubnets],
       },
+      logRetention: logRetentionDays(props.stage),
     })
 
     const notificationConfig = {
@@ -228,6 +230,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: postOrderEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.postLimitOrderLambda = new aws_lambda_nodejs.NodejsFunction(this, `PostLimitOrder${lambdaName}`, {
@@ -245,6 +248,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: postOrderEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.getLimitOrdersLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetLimitOrders${lambdaName}`, {
@@ -259,6 +263,7 @@ export class LambdaStack extends cdk.NestedStack {
         sourceMap: true,
       },
       environment: getOrdersEnv,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.getNonceLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetNonce${lambdaName}`, {
@@ -280,6 +285,7 @@ export class LambdaStack extends cdk.NestedStack {
         NODE_OPTIONS: '--enable-source-maps',
       },
       tracing: aws_lambda.Tracing.ACTIVE,
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.getDocsLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetDocs${lambdaName}`, {
@@ -299,6 +305,7 @@ export class LambdaStack extends cdk.NestedStack {
         VERSION: '6',
         NODE_OPTIONS: '--enable-source-maps',
       },
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.getDocsUILambda = new aws_lambda_nodejs.NodejsFunction(this, `GetDocsUI${lambdaName}`, {
@@ -318,6 +325,7 @@ export class LambdaStack extends cdk.NestedStack {
         VERSION: '6',
         NODE_OPTIONS: '--enable-source-maps',
       },
+      logRetention: logRetentionDays(props.stage),
     })
 
     this.getUnimindLambda = new aws_lambda_nodejs.NodejsFunction(this, `GetUnimind${lambdaName}`, {
@@ -333,6 +341,7 @@ export class LambdaStack extends cdk.NestedStack {
       },
       environment: postOrderEnv,
       tracing: aws_lambda.Tracing.ACTIVE,
+      logRetention: logRetentionDays(props.stage),
     })
 
     if (props.envVars['POSTED_ORDER_DESTINATION_ARN']) {
@@ -707,6 +716,7 @@ export class LambdaStack extends cdk.NestedStack {
     /* cron stack */
     new CronStack(this, `${SERVICE_NAME}CronStack`, {
       lambdaRole,
+      stage: props.stage,
       envVars: props.envVars,
       chatbotSNSArn: props.chatbotSNSArn,
     })

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -7,7 +7,7 @@ import { Construct } from 'constructs'
 import path from 'path'
 import { checkDefined } from '../../lib/preconditions/preconditions'
 import { SUPPORTED_CHAINS } from '../../lib/util/chain'
-import { STAGE } from '../../lib/util/stage'
+import { STAGE, logRetentionDays } from '../../lib/util/stage'
 import { SERVICE_NAME, FILTER_PATTERNS } from '../constants'
 import orderStatusTrackingStateMachine from '../definitions/order-tracking-sfn.json'
 
@@ -53,6 +53,7 @@ export class StepFunctionStack extends cdk.NestedStack {
         ...props.envVars,
         stage: stage,
       },
+      logRetention: logRetentionDays(stage),
     })
     this.checkStatusFunction = checkStatusFunction
 

--- a/lib/util/stage.ts
+++ b/lib/util/stage.ts
@@ -1,5 +1,18 @@
+import { RetentionDays } from 'aws-cdk-lib/aws-logs'
+
 export enum STAGE {
   BETA = 'beta',
   PROD = 'prod',
   LOCAL = 'local',
+}
+
+export function logRetentionDays(stage: STAGE): RetentionDays {
+  switch (stage) {
+    case STAGE.PROD:
+      return RetentionDays.THREE_MONTHS
+    case STAGE.BETA:
+      return RetentionDays.TWO_MONTHS
+    default:
+      return RetentionDays.ONE_MONTH
+  }
 }


### PR DESCRIPTION
Reapplies #646 (which was reverted in #659).

Restores the `logRetentionDays(stage)` helper in `lib/util/stage.ts` and the per-stack call sites that derive CloudWatch log retention from the deploy stage.

| Environment | Retention |
|-------------|-----------|
| `prod` | 90 days (THREE_MONTHS) |
| `beta` (staging) | 60 days (TWO_MONTHS) |
| `local` (dev) | 30 days (ONE_MONTH) |

## Test plan

- [x] `yarn build` clean
- [ ] CDK synth diff: `logGroupRetentionDays` flips back to the per-stage values from #646
- [ ] Whatever broke last time around the original #646 deploy is now resolved (the original revert was #659)

🤖 Generated with [Claude Code](https://claude.com/claude-code)