### PR TITLE
chore: disable PC in beta only (2→0) to unblock OOM deploy fix

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -182,7 +182,10 @@ export class APIPipeline extends Stack {
     // Beta us-east-2
     const betaUsEast2Stage = new APIStage(this, 'beta-us-east-2', {
       env: { account: '321377678687', region: 'us-east-2' },
-      provisionedConcurrency: 2,
+      // Temporarily set to 0 so the 1024 MB memory fix (PostOrder/PostLimitOrder)
+      // can land without PC stabilization failing on cold-start OOM.
+      // Restore to 2 once this deploy succeeds. See #658.
+      provisionedConcurrency: 0,
       internalApiKey: internalApiKey.secretValue.toString(),
       stage: STAGE.BETA,
       envVars: {
@@ -220,7 +223,10 @@ export class APIPipeline extends Stack {
     // Prod us-east-2
     const prodUsEast2Stage = new APIStage(this, 'prod-us-east-2', {
       env: { account: '316116520258', region: 'us-east-2' },
-      provisionedConcurrency: 5,
+      // Temporarily set to 0 so the 1024 MB memory fix (PostOrder/PostLimitOrder)
+      // can land without PC stabilization failing on cold-start OOM.
+      // Restore to 5 once this deploy succeeds. See #658.
+      provisionedConcurrency: 0,
       internalApiKey: internalApiKey.secretValue.toString(),
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       stage: STAGE.PROD,

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -182,9 +182,8 @@ export class APIPipeline extends Stack {
     // Beta us-east-2
     const betaUsEast2Stage = new APIStage(this, 'beta-us-east-2', {
       env: { account: '321377678687', region: 'us-east-2' },
-      // Temporarily set to 0 so the 1024 MB memory fix (PostOrder/PostLimitOrder)
-      // can land without PC stabilization failing on cold-start OOM.
-      // Restore to 2 once this deploy succeeds. See #658.
+      // Temporarily 0 (was 2) to break PC deadlock in beta only.
+      // Prod left at 5 until beta confirms clean deploy. See #658, #663.
       provisionedConcurrency: 0,
       internalApiKey: internalApiKey.secretValue.toString(),
       stage: STAGE.BETA,
@@ -223,10 +222,7 @@ export class APIPipeline extends Stack {
     // Prod us-east-2
     const prodUsEast2Stage = new APIStage(this, 'prod-us-east-2', {
       env: { account: '316116520258', region: 'us-east-2' },
-      // Temporarily set to 0 so the 1024 MB memory fix (PostOrder/PostLimitOrder)
-      // can land without PC stabilization failing on cold-start OOM.
-      // Restore to 5 once this deploy succeeds. See #658.
-      provisionedConcurrency: 0,
+      provisionedConcurrency: 5,
       internalApiKey: internalApiKey.secretValue.toString(),
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
       stage: STAGE.PROD,


### PR DESCRIPTION
## Summary

Scopes the provisioned concurrency change to **beta only**. Prod remains at `provisionedConcurrency: 5` until beta confirms a clean deploy.

- Beta: `2 → 0` (breaks the PC pre-warming deadlock so the 1024 MB + provider dedup fix can land)
- Prod: `5 → 5` (unchanged, no risk to prod traffic)

## Context

Every deploy since May 18 fails at `PostOrderLiveAlias2009E9C1` with:
> `"Provisioned Concurrency configuration failed to be applied. Reason: FAILED"`

Root cause confirmed in CloudWatch (`PostOrderGoudaServiceLam-c8Lpr0OH6M6Q`): the PostOrder Lambda OOMs during PC pre-warming on every attempt —`INIT_REPORT Phase: init  Status: error  Error Type: Runtime.OutOfMemory` with `Max Memory Used: 512 MB`.

## Merge sequence
1. ✅ Merge this PR (beta PC = 0, unblocks deploy)
2. Watch beta deploy succeed and Lambda init cleanly (no OOM)
3. Merge prod equivalent once beta is confirmed

## Test plan
- [ ] Pipeline beta-deploy stage succeeds (no `PostOrderLiveAlias` UPDATE_FAILED)
- [ ] No `Runtime.OutOfMemory` in `PostOrderGoudaServiceLam-c8Lpr0OH6M6Q` logs after deploy
- [ ] Prod deploy stage still succeeds (prod untouched)
- [ ] PostOrder API responding in beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)