### PR TITLE
fix: guard REACTOR_ADDRESS_MAPPING[chainId] against undefined

### DIFF
--- a/lib/crons/gs-reaper/gs-reaper.ts
+++ b/lib/crons/gs-reaper/gs-reaper.ts
@@ -266,8 +266,13 @@ async function processBlockRange(
 ): Promise<{ updates: Record<string, OrderUpdate>, remainingHashes: Set<string> }> {
   const orderUpdates = { ...existingUpdates }
   
-  for (const orderType of Object.keys(REACTOR_ADDRESS_MAPPING[chainId])) {
-    const reactorAddress = REACTOR_ADDRESS_MAPPING[chainId][orderType as OrderType]
+  const reactorMap = REACTOR_ADDRESS_MAPPING[chainId]
+  if (!reactorMap) {
+    log.info(`No reactor mapping for chainId ${chainId}, skipping block range`)
+    return { updates: orderUpdates, remainingHashes: orderHashSet }
+  }
+  for (const orderType of Object.keys(reactorMap)) {
+    const reactorAddress = reactorMap[orderType as OrderType]
     if (!reactorAddress || reactorAddress === "0x0000000000000000000000000000000000000000") continue
     log.info(`Processing block range ${fromBlock} to ${toBlock} for chainId ${chainId} orderType ${orderType}`)
     

--- a/lib/handlers/EventWatcherMap.ts
+++ b/lib/handlers/EventWatcherMap.ts
@@ -29,9 +29,9 @@ export class EventWatcherMap<T extends UniswapXEventWatcher | RelayEventWatcher>
   public static createRelayEventWatcherMap() {
     const map = new EventWatcherMap<RelayEventWatcher>()
     for (const chainId of SUPPORTED_CHAINS) {
-      const address = REACTOR_ADDRESS_MAPPING[chainId][OrderType.Relay]
+      const address = REACTOR_ADDRESS_MAPPING[chainId]?.[OrderType.Relay]
       if (!address) {
-        throw new Error(`No Reactor Address Configured for ${chainId}, ${OrderType.Relay}`)
+        continue
       }
       map.set(
         chainId,

--- a/lib/handlers/check-order-status/util.ts
+++ b/lib/handlers/check-order-status/util.ts
@@ -284,7 +284,7 @@ export function getWatcher(
   orderType: OrderType
 ): UniswapXEventWatcher {
   const reactorType = orderType === OrderType.Limit ? OrderType.Dutch : orderType
-  const address = REACTOR_ADDRESS_MAPPING[chainId][reactorType]
+  const address = REACTOR_ADDRESS_MAPPING[chainId]?.[reactorType]
   if (!address) {
     throw new Error(`No Reactor Address Defined in UniswapX SDK for chainId:${chainId}, orderType:${reactorType}`)
   }

--- a/lib/util/OffChainRelayOrderValidator.ts
+++ b/lib/util/OffChainRelayOrderValidator.ts
@@ -72,7 +72,8 @@ export class OffChainRelayOrderValidator {
   }
 
   private validateReactorAddress(reactor: string, chainId: number): OrderValidationResponse {
-    if (reactor.toLowerCase() != REACTOR_ADDRESS_MAPPING[chainId][OrderType.Relay]!.toLowerCase()) {
+    const expected = REACTOR_ADDRESS_MAPPING[chainId]?.[OrderType.Relay]
+    if (!expected || reactor.toLowerCase() != expected.toLowerCase()) {
       return {
         valid: false,
         errorString: `Invalid reactor address`,

--- a/lib/util/OffChainUniswapXOrderValidator.ts
+++ b/lib/util/OffChainUniswapXOrderValidator.ts
@@ -254,7 +254,8 @@ export class OffChainUniswapXOrderValidator {
     chainId: number,
     orderType: OrderType | undefined
   ): OrderValidationResponse {
-    if (!orderType || reactor.toLowerCase() != REACTOR_ADDRESS_MAPPING[chainId][orderType]!.toLowerCase()) {
+    const expected = orderType ? REACTOR_ADDRESS_MAPPING[chainId]?.[orderType] : undefined
+    if (!expected || reactor.toLowerCase() != expected.toLowerCase()) {
       return {
         valid: false,
         errorString: `Invalid reactor address`,


### PR DESCRIPTION
## Summary
- PR #654 expanded `SUPPORTED_CHAINS` 7→18 but not every new chain has an entry in the SDK's `REACTOR_ADDRESS_MAPPING`. Five call sites indexed `REACTOR_ADDRESS_MAPPING[chainId][orderType]` without guarding the parent, producing `TypeError: Cannot read properties of undefined (reading 'Relay')`.
- The most visible failure: `EventWatcherMap.createRelayEventWatcherMap()` runs at module load of `lib/handlers/get-orders/index.ts`. With beta provisioned concurrency reset to 0 in #666, every cold start re-evaluated the module, the TypeError aborted Lambda init, and API Gateway returned 502 for requests that should have been 4xx — surfaced by the failing e2e test `GET /dutch-auction/orders Stability Tests › Error Handling › should handle invalid parameters`.
- Optional-chain the lookups so unmapped chains fall through to each site's existing guard branch (skip, return validation error, or throw with the intended message).

## Sites fixed
| File | Behavior on unmapped chain |
|---|---|
| `lib/handlers/EventWatcherMap.ts` | Skip chain at module load (was: throw, aborts Lambda init → 502) |
| `lib/util/OffChainRelayOrderValidator.ts` | Return `Invalid reactor address` (400) (was: TypeError → 500) |
| `lib/util/OffChainUniswapXOrderValidator.ts` | Return `Invalid reactor address` (400) (was: TypeError → 500) |
| `lib/handlers/check-order-status/util.ts` | Existing `throw new Error(...)` fires with intended message (was: TypeError) |
| `lib/crons/gs-reaper/gs-reaper.ts` | Skip chain in this block range, cron continues for other chains |

Test fixtures all pin `chainId=1`, so no test changes were needed.

## Test plan
- [ ] `yarn build` / `yarn tsc --noEmit` — already verified locally
- [ ] `yarn test` — unit tests pass
- [ ] After deploy to beta, re-run the e2e `should handle invalid parameters` test and confirm 4xx (not 502)
- [ ] Confirm GetOrders Lambda init no longer logs `Cannot read properties of undefined (reading 'Relay')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)