### PR TITLE
fix(deps): pin elliptic to 6.6.1 (GHSA-vjh7-7g9h-fjfh)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "license": "GPL",
   "type": "commonjs",
   "repository": "https://github.com/Uniswap/uniswapx-service",
+  "resolutions": {
+    "elliptic": "6.6.1"
+  },
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist cdk.out",


### PR DESCRIPTION
## Summary

Pin transitive dependency \`elliptic\` to \`6.6.1\` via Yarn \`resolutions\` to close [GHSA-vjh7-7g9h-fjfh](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh) (**CRITICAL**: *Elliptic's private key extraction in ECDSA upon signing a malformed input*).

\`elliptic\` lands here transitively via \`@uniswap/uniswapx-sdk\` → \`ethers@5\` → \`@ethersproject/signing-key\` → \`elliptic\`. The pin is mirrored from what's already in place on \`Uniswap/universe\`, \`Uniswap/interface\`, and \`Uniswap/backend\`.

## Threat model in context

The advisory's exploit path is: ECDSA signing of an attacker-influenced malformed input (a string instead of a Buffer) → private-key extraction → key reuse on a subsequent normal signing. For a signed-order propagation service, the exposure surface is the signing-key handling on the validation/cosigner path. The pin removes the underlying primitive's vulnerability regardless of input-shape discipline elsewhere in the codebase.

## What this does

- Adds \`resolutions.elliptic: \"6.6.1\"\` to root \`package.json\`.
- Forces every dependent (today: \`@ethersproject/signing-key\` via \`ethers@5\`) to resolve \`elliptic\` to \`6.6.1\` instead of the v5-pinned-vulnerable \`6.5.x\`.
- Same pattern Yarn's \`resolutions\` field is designed for; mirrors the resolution-block convention already present in 3 other Uniswap repos.

## Lockfile

The \`yarn.lock\` is not updated in this PR — couldn't run \`yarn install\` locally on the authoring machine. Two options for handling that:

1. **Before merge:** a reviewer (or you) runs \`yarn install\` locally, which will refresh \`yarn.lock\` to honor the new resolution. Push the regenerated lockfile to this branch. (Recommended — keeps merge clean.)
2. **On merge:** CI (or whoever runs \`yarn install\` against \`main\`) regenerates \`yarn.lock\` afterwards. Works, but produces a follow-up commit on \`main\` solely to update the lockfile.

After install, verify with: \`yarn why elliptic\` — should show \`6.6.1\` everywhere it resolves.

## Why \`6.6.1\` specifically

That's the first patched version per the advisory. Pinning to an exact version (rather than \`^6.6.1\` or \`>=6.6.1\`) matches Uniswap's convention for security-driven pins and avoids accidental future drift on the resolution.

## Related

- This PR addresses one of four high-priority unprotected consumers of \`@uniswap/uniswapx-sdk\` identified in a security review of the broader fleet.
- Other repos still needing the same one-line fix: \`Uniswap/fee-collector\`, \`Uniswap/uniswapx-parameterization-api\`, \`Uniswap/data-api-graphql\` (plus several lower-priority tools).
- The durable upstream fix is bumping \`ethers\` past v5 (which still pins old \`elliptic\` in its maintenance branch), or migrating to \`ethers\` v6 (which removes the \`elliptic\` dependency). Tracked separately.

## Test plan

- [ ] Reviewer runs \`yarn install\` locally; \`yarn.lock\` updates to reflect \`elliptic@6.6.1\` resolution
- [ ] \`yarn why elliptic\` shows \`6.6.1\`
- [ ] CI green (build, lint, unit tests, integ tests unchanged — no API surface affected)