### PR TITLE
fix(check-order-status): fall back to 12s block time for chains unsupported by sdk-core

### DIFF
--- a/lib/handlers/check-order-status/util.ts
+++ b/lib/handlers/check-order-status/util.ts
@@ -248,7 +248,16 @@ export function getRelaySettledAmounts(fill: FillInfo, parsedOrder: RelayOrder):
 // `calculateDutchRetryWaitSeconds` floor stay correct as chain cadence
 // changes. Sub-second values are intentional for accurate block-number
 // arithmetic in `timestampToBlockNumber`.
-export const AVERAGE_BLOCK_TIME = (chainId: ChainId): number => getAverageBlockTimeSecs(chainId)
+// Falls back to 12 s (Ethereum PoS slot time) for chains not yet registered
+// in sdk-core (e.g. Sepolia, new L2s added via SUPPORTED_CHAINS before the
+// SDK is updated).
+export const AVERAGE_BLOCK_TIME = (chainId: ChainId): number => {
+  try {
+    return getAverageBlockTimeSecs(chainId)
+  } catch {
+    return 12
+  }
+}
 
 // Approximate block number from timestamp
 export function timestampToBlockNumber(


### PR DESCRIPTION
## Problem

`check-order-status` is crashing on every retry for orders on **Sepolia (chainId 11155111)** — and potentially any other chain in `SUPPORTED_CHAINS` not yet registered in `@uniswap/sdk-core`:

\`\`\`
Error: getAverageBlockTimeSecs: unsupported chainId 11155111;
register it in chains.ts before use
  at AVERAGE_BLOCK_TIME (check-order-status/util.ts:251)
\`\`\`

This was observed in beta CloudWatch logs (`GoudaServicebetaCheckOrd`) hitting repeatedly today (June 3), triggered by the order posted at 22:25 UTC. The step function retries indefinitely, never reaching a terminal state.

## Fix

Wrap `AVERAGE_BLOCK_TIME` in a try/catch. Falls back to **12 seconds** (Ethereum PoS slot time) for any chain the SDK doesn't know about yet, so status tracking degrades gracefully instead of looping forever.

```ts
export const AVERAGE_BLOCK_TIME = (chainId: ChainId): number => {
  try {
    return getAverageBlockTimeSecs(chainId)
  } catch {
    return 12
  }
}
```

## Why 12s?

Sepolia uses the same 12s PoS slot time as Ethereum mainnet. It's also a safe conservative default for any other unknown chain — block-number arithmetic will be slightly off but won't crash.

## Test plan
- [ ] No more `getAverageBlockTimeSecs: unsupported chainId 11155111` errors in `GoudaServicebetaCheckOrd` logs after deploy
- [ ] Existing unit tests pass (`yarn test`)
- [ ] Order posted on Sepolia reaches a terminal state (filled / expired) rather than looping forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)