### PR TITLE
fix: grant IntegTests CodeBuild role kms:Decrypt for RPC secret

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -5,6 +5,7 @@ import { BuildEnvironmentVariableType, BuildSpec, ComputeType } from 'aws-cdk-li
 import * as sm from 'aws-cdk-lib/aws-secretsmanager'
 
 import { PipelineNotificationEvents } from 'aws-cdk-lib/aws-codepipeline'
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam'
 import { CodeBuildStep, CodePipeline, CodePipelineSource } from 'aws-cdk-lib/pipelines'
 import { Construct } from 'constructs'
 import dotenv from 'dotenv'
@@ -272,6 +273,18 @@ export class APIPipeline extends Stack {
     const testAction = new CodeBuildStep(`${SERVICE_NAME}-IntegTests-${apiStage.stageName}`, {
       projectName: `${SERVICE_NAME}-IntegTests-${apiStage.stageName}`,
       input: sourceArtifact,
+      // RPC_PREFIX_URL / RPC_HEADER_SECRET are read from gouda-service-rpc-urls-2,
+      // which is encrypted with a customer-managed KMS key. Allow this build's role
+      // to decrypt Secrets Manager values so the SECRETS_MANAGER env vars resolve.
+      rolePolicyStatements: [
+        new PolicyStatement({
+          actions: ['kms:Decrypt'],
+          resources: ['*'],
+          conditions: {
+            StringEquals: { 'kms:ViaService': `secretsmanager.${this.region}.amazonaws.com` },
+          },
+        }),
+      ],
       envFromCfnOutputs: {
         UNISWAP_API: apiStage.url,
       },


### PR DESCRIPTION
## Summary

Fixes the beta `IntegTests` stage failing with:

```
Secrets Manager Error Message: AccessDeniedException: Access to KMS is not allowed
```

## Root cause

#674 moved the integ-test `RPC_PREFIX_URL` / `RPC_HEADER_SECRET` to resolve from the `gouda-service-rpc-urls-2` secret. That secret is encrypted with a **customer-managed KMS key**, and the IntegTests CodeBuild service role has no `kms:Decrypt` on it, so CodeBuild can't resolve those `SECRETS_MANAGER` env vars. The previous `all/gouda-service/integ-test/*` secrets were on a key the role could already use.

(The beta/prod deploy stages are unaffected — they resolve the secret at CloudFormation time in the target accounts via the secret's resource policy, a different path than the CodeBuild role.)

## Fix

Add a `rolePolicyStatement` to the IntegTests `CodeBuildStep` granting `kms:Decrypt`, scoped to Secrets Manager via a `kms:ViaService` condition (so it can only decrypt when used through Secrets Manager, not arbitrarily):

```ts
new PolicyStatement({
  actions: ['kms:Decrypt'],
  resources: ['*'],
  conditions: { StringEquals: { 'kms:ViaService': `secretsmanager.${this.region}.amazonaws.com` } },
})
```

## Caveat — KMS key policy

This grants the IAM side. If the CMK's **key policy** delegates to IAM (the standard "Enable IAM policies" / root statement), this is sufficient. If the key policy is locked down, the IntegTests CodeBuild **service role** must also be added as a principal there — use the role ARN (`arn:aws:iam::644039819003:role/<generated-name>`), found via `aws codebuild batch-get-projects --names GoudaService-IntegTests-beta-us-east-2 --query 'projects[0].serviceRole'`, not the build-run ARN.

## Testing

- `yarn build` ✅ (CDK synth-level change; no unit-test surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)