### PR TITLE
fix: source integ-test RPC_PREFIX_URL from integ secret, drop header

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -308,11 +308,7 @@ export class APIPipeline extends Stack {
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
           RPC_PREFIX_URL: {
-            value: 'gouda-service-rpc-urls-2:RPC_PREFIX_URL',
-            type: BuildEnvironmentVariableType.SECRETS_MANAGER,
-          },
-          RPC_HEADER_SECRET: {
-            value: 'gouda-service-rpc-urls-2:RPC_HEADER_SECRET',
+            value: 'all/gouda-service/integ-test/rpc',
             type: BuildEnvironmentVariableType.SECRETS_MANAGER,
           },
           TEST_WALLET_PK: {
@@ -334,7 +330,6 @@ export class APIPipeline extends Stack {
         'echo "GPA_SERVICE_URL=${GPA_SERVICE_URL}" >> .env',
         'echo "COSIGNER_ADDRESS=${COSIGNER_ADDRESS}" >> .env',
         'echo "RPC_PREFIX_URL=${RPC_PREFIX_URL}" >> .env',
-        'echo "RPC_HEADER_SECRET=${RPC_HEADER_SECRET}" >> .env',
         'echo "TEST_WALLET_PK=${TEST_WALLET_PK}" >> .env',
         'echo "TEST_FILLER_PK=${TEST_FILLER_PK}" >> .env',
         'yarn install --network-concurrency 1 --skip-integrity-check',


### PR DESCRIPTION
## Summary

Fixes the beta `IntegTests` stage failing with `AccessDeniedException: Access to KMS is not allowed`, by reverting the integ-test build's RPC secret references to the integ-test namespace.

Supersedes #675 (the `kms:Decrypt` grant approach).

## Why

The e2e suite (`test/e2e/order.test.ts`, run by `test:e2e`):
- **requires `RPC_PREFIX_URL`** — `beforeAll` throws if unset, and it builds the provider URL `${RPC_PREFIX_URL}/1`.
- **does not need `RPC_HEADER_SECRET`** — it's never referenced in `test/e2e/`; it's only applied via `RPC_HEADERS` if present in the env, and the test passes without it.

#674 moved both integ-test vars to `gouda-service-rpc-urls-2`, which is encrypted with a customer-managed KMS key the IntegTests CodeBuild role can't decrypt — breaking the build. Since the integ build doesn't actually need the production secret, the simplest fix is to stop using it there.

## Change

- `RPC_PREFIX_URL` (integ build) → back to `all/gouda-service/integ-test/rpc` (a key the role can already decrypt).
- Remove `RPC_HEADER_SECRET` from the integ build env + `.env` echo.

No KMS grant or key-policy change required. Beta/prod **Lambda** wiring (which reads both from `gouda-service-rpc-urls-2` at deploy time via the secret's resource policy) is unchanged and was never broken. Local-dev wiring unchanged.

## Trade-off

e2e RPC calls no longer carry the `x-internal-service-secret` header — same as before #674, and the integ-test RPC endpoint doesn't require it.

## Testing

- `yarn build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)