### PR TITLE
fix: grant IntegTests CodeBuild role kms:Decrypt for beta/prod secrets

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -5,6 +5,7 @@ import { BuildEnvironmentVariableType, BuildSpec, ComputeType } from 'aws-cdk-li
 import * as sm from 'aws-cdk-lib/aws-secretsmanager'
 
 import { PipelineNotificationEvents } from 'aws-cdk-lib/aws-codepipeline'
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam'
 import { CodeBuildStep, CodePipeline, CodePipelineSource } from 'aws-cdk-lib/pipelines'
 import { Construct } from 'constructs'
 import dotenv from 'dotenv'
@@ -272,6 +273,18 @@ export class APIPipeline extends Stack {
     const testAction = new CodeBuildStep(`${SERVICE_NAME}-IntegTests-${apiStage.stageName}`, {
       projectName: `${SERVICE_NAME}-IntegTests-${apiStage.stageName}`,
       input: sourceArtifact,
+      // Several beta/prod integ-test secrets (gpa_url, tapi_api_key, tapi_url,
+      // cosigner) are encrypted with a shared customer-managed KMS key. CDK
+      // auto-grants secretsmanager:GetSecretValue for the env-var secrets but
+      // not kms:Decrypt, so without this the build fails resolving them with
+      // "AccessDeniedException: Access to KMS is not allowed". The key policy
+      // delegates to IAM, so this IAM grant is sufficient (no key-policy edit).
+      rolePolicyStatements: [
+        new PolicyStatement({
+          actions: ['kms:Decrypt'],
+          resources: ['arn:aws:kms:us-east-2:644039819003:key/2df28f63-7535-49e9-892a-8ea0471366bf'],
+        }),
+      ],
       envFromCfnOutputs: {
         UNISWAP_API: apiStage.url,
       },


### PR DESCRIPTION
## Summary

Fixes the `IntegTests` (beta + prod) stage failing with:

```
Secrets Manager Error Message: AccessDeniedException: Access to KMS is not allowed
```

## Root cause (diagnosed against the live account)

Four of the integ-test secrets the build resolves are encrypted with a **shared customer-managed KMS key** (`arn:aws:kms:us-east-2:644039819003:key/2df28f63-7535-49e9-892a-8ea0471366bf`):

- `{beta,prod}/gouda-service/integ-test/gpa_url`
- `{beta,prod}/gouda-service/integ-test/tapi_api_key`
- `{beta,prod}/gouda-service/integ-test/tapi_url`
- `{beta,prod}/gouda-service/integ-test/cosigner`

The IntegTests CodeBuild role's auto-generated policy grants `secretsmanager:GetSecretValue` on these secrets, but **no `kms:Decrypt`** — CDK doesn't infer KMS grants for CMK-encrypted secrets. So the build can fetch but not decrypt them.

This is a **pre-existing** gap (those secrets live on a shared org CMK); it was surfaced by the first pipeline run in a while. It is **not** caused by the `gouda-service-rpc-urls-2` change — that was a separate breakage already reverted in #676 (the `all/...` and `RPC_PREFIX_URL` secrets are all on the default key).

## Fix

Add a `rolePolicyStatement` to the IntegTests `CodeBuildStep` granting `kms:Decrypt` on that key. `addIntegTests` runs for both beta and prod (both use the same key), so one rule covers both.

No key-policy change is required: the key's policy has the standard `Enable IAM User Permissions` statement for `644039819003:root`, so it delegates authorization to IAM — an IAM grant on the role is sufficient. (Precedent: the `GoudaParameterizationPipe-…` CodeBuild role is already wired to this same key.)

## Verification

- `yarn build` ✅
- Confirmed in-account: role `…GoudaServicePipelinebeta-KK13G9DALNDI` has `GetSecretValue` but no `kms:Decrypt`; key policy delegates to IAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)