### PR TITLE
feat, test: chain-based fill lookups to avoid false cancel tags

### DIFF
--- a/lib/handlers/check-order-status/service.ts
+++ b/lib/handlers/check-order-status/service.ts
@@ -21,13 +21,16 @@ import { ChainId } from '../../util/chain'
 import { metrics } from '../../util/metrics'
 import { SfnStateInputOutput } from '../base'
 import { FillEventLogger } from './fill-event-logger'
-import { getSettledAmounts, IS_TERMINAL_STATE, timestampToBlockNumber } from './util'
+import {
+  FILL_CHECK_OVERLAP_BLOCKS_ON,
+  getSettledAmounts,
+  IS_TERMINAL_STATE,
+  timestampToBlockNumber,
+} from './util'
 import { parseOrder } from '../OrderParser'
 import { PRIORITY_ORDER_TARGET_BLOCK_BUFFER } from '../constants'
 import { PermissionedTokenValidator } from '@uniswap/uniswapx-sdk'
 import { Permit2Validator } from '../../util/Permit2Validator'
-
-const FILL_CHECK_OVERLAP_BLOCK = 20
 
 // Type for legacy orders that have input at the info level
 type LegacyUniswapXOrder = DutchOrder | CosignedV2DutchOrder | CosignedV3DutchOrder | CosignedPriorityOrder
@@ -145,10 +148,21 @@ export class CheckOrderStatusService {
     // if validation is NonceUsed or Expired it might be filled or unfilled
     // so check for a fillEvent
     // if no fill event, process in the unfilled path
+    const overlapBlocks = FILL_CHECK_OVERLAP_BLOCKS_ON(chainId as ChainId)
+    let fillSearchFromBlock = Math.max(0, fromBlock - overlapBlocks)
+    if (
+      getFillLogAttempts > 0 &&
+      (validation === OrderValidation.NonceUsed || validation === OrderValidation.Expired) &&
+      order.type === OrderType.Dutch_V3
+    ) {
+      // Minimal reconciliation: avoid false terminal states for V3 by looking
+      // back to the auction start block before concluding cancelled/expired.
+      fillSearchFromBlock = Math.max(0, Math.min(fillSearchFromBlock, order.cosignerData.decayStartBlock))
+    }
     if (validation === OrderValidation.NonceUsed || validation === OrderValidation.Expired) {
       const fillEvent = await this.getFillEventForOrder(
         orderHash,
-        fromBlock - FILL_CHECK_OVERLAP_BLOCK,
+        fillSearchFromBlock,
         curBlockNumber,
         orderWatcher
       )

--- a/lib/handlers/check-order-status/util.ts
+++ b/lib/handlers/check-order-status/util.ts
@@ -277,6 +277,19 @@ export const FILL_EVENT_LOOKBACK_BLOCKS_ON = (chainId: ChainId): number => {
   }
 }
 
+export const FILL_CHECK_OVERLAP_BLOCKS_ON = (chainId: ChainId): number => {
+  switch (chainId) {
+    case ChainId.MAINNET:
+      return 20
+    case ChainId.BASE:
+      return 20
+    case ChainId.ARBITRUM_ONE:
+      return 50
+    default:
+      return 20
+  }
+}
+
 const watcherMap = new Map<string, UniswapXEventWatcher>()
 export function getWatcher(
   provider: ethers.providers.StaticJsonRpcProvider,

--- a/test/integ/handlers/check-order-status-service.test.ts
+++ b/test/integ/handlers/check-order-status-service.test.ts
@@ -309,8 +309,8 @@ describe('checkOrderStatusService', () => {
                 swapper: '0x123',
                 blockNumber: fillBlock,
                 txHash: '0x1244345323',
-                inputs: [{ token: v3OrderEntity.input.token, amount: BigNumber.from(v3OrderEntity.input.startAmount) }],
-                outputs: [{ token: v3OrderEntity.outputs[0].token, amount: BigNumber.from(v3OrderEntity.outputs[0].startAmount) }],
+                inputs: [{ token: v3Order.inner.info.input.token, amount: v3Order.inner.info.input.startAmount }],
+                outputs: [{ token: v3Order.inner.info.outputs[0].token, amount: v3Order.inner.info.outputs[0].startAmount }],
               },
             ]
           }

--- a/test/integ/handlers/check-order-status-service.test.ts
+++ b/test/integ/handlers/check-order-status-service.test.ts
@@ -13,7 +13,10 @@ import {
   FILL_EVENT_LOOKBACK_BLOCKS_ON,
 } from '../../../lib/handlers/check-order-status/util'
 import { log } from '../../../lib/Logging'
-import { MOCK_ORDER_ENTITY, MOCK_ORDER_HASH, MOCK_V2_ORDER_ENTITY } from '../../test-data'
+import { DutchV3Order } from '../../../lib/models/DutchV3Order'
+import { ChainId } from '../../../lib/util/chain'
+import { SDKDutchOrderV3Factory } from '../../factories/SDKDutchOrderV3Factory'
+import { MOCK_ORDER_ENTITY, MOCK_ORDER_HASH, MOCK_SIGNATURE, MOCK_V2_ORDER_ENTITY } from '../../test-data'
 
 jest.mock('../../../lib/handlers/check-order-status/util', () => {
   const original = jest.requireActual('../../../lib/handlers/check-order-status/util')
@@ -275,6 +278,62 @@ describe('checkOrderStatusService', () => {
         expect(result).toEqual(
           expect.objectContaining({
             orderStatus: 'cancelled',
+          })
+        )
+      })
+
+      it('backfills from decayStartBlock before terminalizing Dutch_V3 orders', async () => {
+        const v3Order = new DutchV3Order(
+          SDKDutchOrderV3Factory.buildDutchV3Order(ChainId.ARBITRUM_ONE, {
+            cosignerData: {
+              decayStartBlock: 420,
+            },
+          }),
+          MOCK_SIGNATURE,
+          ChainId.ARBITRUM_ONE
+        )
+        const v3OrderEntity = v3Order.toEntity(ORDER_STATUS.OPEN)
+        ordersRepositoryMock.getByHash.mockResolvedValue(v3OrderEntity)
+
+        providerMock.getBlockNumber.mockResolvedValue(500)
+        const fillBlock = 450
+        getFillInfoMock.mockImplementation((fromBlock: number, toBlock: number) => {
+          // Simulates a case where the normal window misses the fill but a
+          // one-time reconciliation from decayStartBlock can still recover it.
+          if (fromBlock <= fillBlock && toBlock >= fillBlock) {
+            return [
+              {
+                orderHash: v3OrderEntity.orderHash,
+                filler: '0x123',
+                nonce: BigNumber.from(1),
+                swapper: '0x123',
+                blockNumber: fillBlock,
+                txHash: '0x1244345323',
+                inputs: [{ token: v3OrderEntity.input.token, amount: BigNumber.from(v3OrderEntity.input.startAmount) }],
+                outputs: [{ token: v3OrderEntity.outputs[0].token, amount: BigNumber.from(v3OrderEntity.outputs[0].startAmount) }],
+              },
+            ]
+          }
+          return []
+        })
+
+        const result = await checkOrderStatusService.handleRequest({
+          ...openOrderRequest,
+          chainId: ChainId.ARBITRUM_ONE,
+          orderHash: v3OrderEntity.orderHash,
+          getFillLogAttempts: 1,
+          startingBlockNumber: 490,
+          orderType: OrderType.Dutch_V3,
+        })
+
+        expect(getFillInfoMock).toHaveBeenCalledTimes(1)
+        expect(getFillInfoMock).toHaveBeenNthCalledWith(1, 420, 500)
+        expect(ordersRepositoryMock.updateOrderStatus).toHaveBeenCalled()
+        expect(result).toEqual(
+          expect.objectContaining({
+            orderStatus: 'filled',
+            txHash: '0x1244345323',
+            fillBlock,
           })
         )
       })

--- a/test/unit/handlers/check-order-status/util.test.ts
+++ b/test/unit/handlers/check-order-status/util.test.ts
@@ -1,7 +1,8 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { OrderType } from '@uniswap/uniswapx-sdk'
 import { mock } from 'jest-mock-extended'
-import { getWatcher } from '../../../../lib/handlers/check-order-status/util'
+import { ChainId } from '../../../../lib/util/chain'
+import { FILL_CHECK_OVERLAP_BLOCKS_ON, getWatcher } from '../../../../lib/handlers/check-order-status/util'
 
 describe('getWatcher', () => {
   test('works with OrderType.Dutch', () => {
@@ -56,5 +57,23 @@ describe('getWatcher', () => {
     expect(() => {
       getWatcher(mock<StaticJsonRpcProvider>(), 1, 'someOtherType' as OrderType)
     }).toThrow(`No Reactor Address Defined in UniswapX SDK for chainId:1, orderType:someOtherType`)
+  })
+})
+
+describe('FILL_CHECK_OVERLAP_BLOCKS_ON', () => {
+  test('returns prioritized overlap for mainnet', () => {
+    expect(FILL_CHECK_OVERLAP_BLOCKS_ON(ChainId.MAINNET)).toEqual(20)
+  })
+
+  test('returns prioritized overlap for base', () => {
+    expect(FILL_CHECK_OVERLAP_BLOCKS_ON(ChainId.BASE)).toEqual(20)
+  })
+
+  test('returns prioritized overlap for arbitrum one', () => {
+    expect(FILL_CHECK_OVERLAP_BLOCKS_ON(ChainId.ARBITRUM_ONE)).toEqual(50)
+  })
+
+  test('returns default overlap for non-priority chains', () => {
+    expect(FILL_CHECK_OVERLAP_BLOCKS_ON(ChainId.POLYGON)).toEqual(20)
   })
 })


### PR DESCRIPTION
Fixes false cancelled classification for filled Dutch V3 orders by widening terminal fill lookup to decayStartBlock when needed, and adds chain-based overlap constants (mainnet=20, base=20, arbitrum=50) with test coverage.