### PR TITLE
gate getOrder logs behind debug env

### DIFF
--- a/lib/handlers/base/api-handler.ts
+++ b/lib/handlers/base/api-handler.ts
@@ -110,11 +110,12 @@ export abstract class APIGLambdaHandler<CInj, RInj extends ApiRInj, ReqBody, Req
         let log: Logger = bunyan.createLogger({
           name: this.handlerName,
           serializers: bunyan.stdSerializers,
-          level: process.env.NODE_ENV == 'test' ? bunyan.FATAL + 1 : bunyan.INFO,
+          level: process.env.NODE_ENV == 'test' ? bunyan.FATAL + 1 :
+            process.env.NODE_ENV == 'debug' ? bunyan.DEBUG : bunyan.INFO,
           requestId: context.awsRequestId,
         })
 
-        log.info({ event, context }, 'Request started.')
+        log.debug({ event, context }, 'Request started.')
 
         let requestBody: ReqBody
         let requestQueryParams: ReqQueryParams
@@ -180,7 +181,7 @@ export abstract class APIGLambdaHandler<CInj, RInj extends ApiRInj, ReqBody, Req
               body: response,
             }
           } else {
-            log.info({ requestBody, requestQueryParams }, 'Handler returned 200')
+            log.debug({ requestBody, requestQueryParams }, 'Handler returned 200')
             ;({ headers, body, statusCode } = handleRequestResult)
           }
         } catch (err) {
@@ -202,7 +203,7 @@ export abstract class APIGLambdaHandler<CInj, RInj extends ApiRInj, ReqBody, Req
           return INTERNAL_ERROR(id)
         }
 
-        log.info({ statusCode, response }, `Request ended. ${statusCode}`)
+        log.debug({ statusCode, response }, `Request ended. ${statusCode}`)
         const responseBody =
           headers && Object.keys(headers).includes('Content-Type') && headers['Content-Type'] == 'text/html'
             ? (response as string)

--- a/test/unit/handlers/get-docs.test.ts
+++ b/test/unit/handlers/get-docs.test.ts
@@ -5,7 +5,7 @@ import { HeaderExpectation } from '../../HeaderExpectation'
 describe('Testing get api docs json handler.', () => {
   // Creating mocks for all the handler dependencies.
   const requestInjectedMock = {
-    log: { info: () => jest.fn(), error: () => jest.fn() },
+    log: { info: () => jest.fn(), error: () => jest.fn(), debug: () => jest.fn() },
   }
   const injectorPromiseMock: any = {
     getContainerInjected: () => {

--- a/test/unit/handlers/get-nonce.test.ts
+++ b/test/unit/handlers/get-nonce.test.ts
@@ -12,7 +12,7 @@ describe('Testing get nonce handler.', () => {
   const requestInjectedMock = {
     address: MOCK_ADDRESS,
     chainId: 1,
-    log: { info: () => jest.fn(), error: () => jest.fn() },
+    log: { info: () => jest.fn(), error: () => jest.fn(), debug: () => jest.fn() },
   }
   const injectorPromiseMock: any = {
     getContainerInjected: () => {


### PR DESCRIPTION
# Reduce verbose logging in API handlers

## Summary

Demotes three high-volume log lines in the base API handler from `info` to `debug`, and adds a `NODE_ENV=debug` gate so they only emit when explicitly enabled.

## Changes

**`lib/handlers/base/api-handler.ts`**

- Added a three-state log level:
  - `test` → `FATAL+1` (fully suppressed, existing behavior)
  - `debug` → `DEBUG` (verbose)
  - anything else → `INFO` (default production behavior, unchanged)
- Demoted `'Request started.'` from `log.info` → `log.debug`
- Demoted `'Handler returned 200'` from `log.info` → `log.debug` — this was the log that included the full `containerInjected` DynamoDB table schema on every request
- Demoted `'Request ended. 2xx'` from `log.info` → `log.debug`

## Motivation

The `'Handler returned 200'` log was attaching the full DynamoDB table schema (via `containerInjected` on the child logger) to every successful API response log line, producing very large and noisy log entries in production. These logs are not actionable under normal conditions and are better suited to a debug/troubleshooting mode.

