### PR TITLE
fix: don't fail accepted orders and cut post-order tail latency (SWAP-2839)

### DIFF
--- a/lib/handlers/shared/index.ts
+++ b/lib/handlers/shared/index.ts
@@ -2,7 +2,7 @@ import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { ethers } from 'ethers'
 import { CONFIG } from '../../Config'
 import { ChainId } from '../../util/chain'
-import { RPC_HEADERS } from '../../util/constants'
+import { RPC_HEADERS, RPC_PROVIDER_TIMEOUT_MS } from '../../util/constants'
 
 export interface ProviderMap {
   get(chainId: ChainId): StaticJsonRpcProvider | undefined
@@ -15,7 +15,7 @@ export class LazyProviderMap implements ProviderMap {
     let provider = this.providers.get(chainId)
     if (!provider) {
       provider = new ethers.providers.StaticJsonRpcProvider(
-        { url: CONFIG.rpcUrls.get(chainId), headers: RPC_HEADERS },
+        { url: CONFIG.rpcUrls.get(chainId), headers: RPC_HEADERS, timeout: RPC_PROVIDER_TIMEOUT_MS },
         chainId
       )
       this.providers.set(chainId, provider)

--- a/lib/handlers/shared/sfn.ts
+++ b/lib/handlers/shared/sfn.ts
@@ -14,14 +14,18 @@ export type OrderTrackingSfnInput = {
   runIndex?: number
 }
 
+// Reuse a single client across invocations: constructing an SFNClient per
+// order pays a fresh TLS handshake on the post-order latency-critical path.
+let sfnClient: SFNClient | undefined
+
 export async function kickoffOrderTrackingSfn(
   sfnInput: OrderTrackingSfnInput,
   stateMachineArn: string
 ) {
   log.info('starting state machine')
   const region = checkDefined(process.env['REGION'], 'REGION is undefined')
-  const sfnClient = new SFNClient({ region: region })
-  
+  sfnClient = sfnClient ?? new SFNClient({ region: region })
+
   // Use runIndex if provided, otherwise fall back to random number
   const BIG_NUMBER = 1000000000000
   const rand = Math.floor(Math.random() * BIG_NUMBER)

--- a/lib/services/UniswapXOrderService.ts
+++ b/lib/services/UniswapXOrderService.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@aws-lambda-powertools/logger'
 import { KMSClient } from '@aws-sdk/client-kms'
+import { Unit } from 'aws-embedded-metrics'
 import { KmsSigner } from '@uniswap/signer'
 import {
   CosignedHybridOrder,
@@ -41,6 +42,7 @@ import { WebhookProvider } from '../providers/base'
 import { BaseOrdersRepository } from '../repositories/base'
 import { QuoteMetadata, QuoteMetadataRepository } from '../repositories/quote-metadata-repository'
 import { hasExclusiveFiller } from '../util/address'
+import { metrics } from '../util/metrics'
 import { OffChainUniswapXOrderValidator } from '../util/OffChainUniswapXOrderValidator'
 import { DUTCH_LIMIT, formatOrderEntity } from '../util/order'
 import { AnalyticsServiceInterface } from './analytics-service'
@@ -65,6 +67,14 @@ export class UniswapXOrderService {
   async createOrder(
     order: DutchV1Order | LimitOrder | DutchV2Order | PriorityOrder | DutchV3Order | HybridOrder
   ): Promise<string> {
+    // Start the open-order count alongside validation; both must pass before the
+    // order is accepted but neither depends on the other. All order entities
+    // store offerer as the lowercased swapper address.
+    const canPlaceNewOrderPromise = this.userCanPlaceNewOrder(order.inner.info.swapper.toLowerCase())
+    // If validation throws first, keep the still-pending count from surfacing as
+    // an unhandled rejection; the real result is awaited below.
+    canPlaceNewOrderPromise.catch(() => undefined)
+
     let orderEntity: UniswapXOrderEntity
     if (order instanceof DutchV1Order || order instanceof LimitOrder) {
       await this.validateOrder(order.inner, order.signature, order.chainId)
@@ -118,50 +128,61 @@ export class UniswapXOrderService {
       throw new Error('unsupported OrderType')
     }
 
-    const canPlaceNewOrder = await this.userCanPlaceNewOrder(orderEntity.offerer)
+    const canPlaceNewOrder = await canPlaceNewOrderPromise
     if (!canPlaceNewOrder) {
       throw new TooManyOpenOrdersError()
     }
 
     await this.persistOrder(orderEntity)
 
-    const realOrderType = order.orderType
-    await this.logOrderCreatedEvent(orderEntity, realOrderType)
+    // From here on the signed order is durably stored and fillable, so a thrown
+    // error would make the caller report an accepted order as rejected
+    // (SWAP-2839). Log and alarm instead of throwing.
+    try {
+      const realOrderType = order.orderType
+      await this.logOrderCreatedEvent(orderEntity, realOrderType)
 
-    // Send immediate notification to exclusive filler if present
-    if (this.webhookProvider && hasExclusiveFiller(orderEntity.filler)) {
-      // Create properly typed webhook order data
-      const exclusiveFillerOrder: ExclusiveFillerWebhookOrder = {
-        orderHash: orderEntity.orderHash,
-        createdAt: orderEntity.createdAt ?? Date.now(),
-        signature: orderEntity.signature,
-        offerer: orderEntity.offerer,
-        orderStatus: orderEntity.orderStatus,
-        encodedOrder: orderEntity.encodedOrder,
-        chainId: orderEntity.chainId,
-        quoteId: orderEntity.quoteId,
-        filler: orderEntity.filler,
-        orderType: realOrderType,
+      // Send immediate notification to exclusive filler if present
+      if (this.webhookProvider && hasExclusiveFiller(orderEntity.filler)) {
+        // Create properly typed webhook order data
+        const exclusiveFillerOrder: ExclusiveFillerWebhookOrder = {
+          orderHash: orderEntity.orderHash,
+          createdAt: orderEntity.createdAt ?? Date.now(),
+          signature: orderEntity.signature,
+          offerer: orderEntity.offerer,
+          orderStatus: orderEntity.orderStatus,
+          encodedOrder: orderEntity.encodedOrder,
+          chainId: orderEntity.chainId,
+          quoteId: orderEntity.quoteId,
+          filler: orderEntity.filler,
+          orderType: realOrderType,
+        }
+
+        // Don't await to minimize latency-add to order posting flow
+        sendImmediateExclusiveFillerNotification(
+          exclusiveFillerOrder,
+          realOrderType,
+          this.webhookProvider,
+          this.logger
+        ).catch((error) => {
+          this.logger.warn({
+            orderHash: orderEntity.orderHash,
+            error: error.message || error,
+            message: 'Immediate webhook notification failed, will rely on DynamoDB stream',
+          })
+        })
       }
 
-      // Don't await to minimize latency-add to order posting flow
-      sendImmediateExclusiveFillerNotification(
-        exclusiveFillerOrder,
-        realOrderType,
-        this.webhookProvider,
-        this.logger
-      ).catch((error) => {
-        this.logger.warn({
-          orderHash: orderEntity.orderHash,
-          error: error.message || error,
-          message: 'Immediate webhook notification failed, will rely on DynamoDB stream',
-        })
+      // TODO: cleanup with generic order model
+      const quoteId = 'quoteId' in order ? order.quoteId : undefined
+      await this.startOrderTracker(orderEntity.orderHash, order.chainId, quoteId, realOrderType)
+    } catch (err) {
+      this.logger.error('Post-persist processing failed for accepted order', {
+        orderHash: orderEntity.orderHash,
+        err,
       })
+      metrics.putMetric('PostOrderPostPersistFailure', 1, Unit.Count)
     }
-
-    // TODO: cleanup with generic order model
-    const quoteId = 'quoteId' in order ? order.quoteId : undefined
-    await this.startOrderTracker(orderEntity.orderHash, order.chainId, quoteId, realOrderType)
 
     return orderEntity.orderHash
   }

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -95,6 +95,11 @@ export const USE_CLASSIC_PARAMETERS = {
   // batchNumber and algorithmVersion are added dynamically
 }
 
+// Bound RPC calls well below the post-order Lambda's 29s budget so a hung
+// provider fails the request before the order is accepted, instead of the
+// ethers default of 120s.
+export const RPC_PROVIDER_TIMEOUT_MS = 5_000
+
 export const RPC_HEADERS: { [key: string]: string } = {
   'x-uni-service-id': 'x_order_service',
   // Authenticate RPC requests against internal providers. The value is provided

--- a/test/unit/services/UniswapXOrderService.test.ts
+++ b/test/unit/services/UniswapXOrderService.test.ts
@@ -5,6 +5,7 @@ import { BigNumber } from 'ethers'
 import { mock } from 'jest-mock-extended'
 import { ORDER_STATUS, UniswapXOrderEntity } from '../../../lib/entities'
 import { OrderValidationFailedError } from '../../../lib/errors/OrderValidationFailedError'
+import { TooManyOpenOrdersError } from '../../../lib/errors/TooManyOpenOrdersError'
 import { OnChainValidatorMap } from '../../../lib/handlers/OnChainValidatorMap'
 import { kickoffOrderTrackingSfn } from '../../../lib/handlers/shared/sfn'
 import { DutchV1Order, DutchV2Order } from '../../../lib/models'
@@ -90,6 +91,84 @@ describe('UniswapXOrderService', () => {
       },
       undefined
     )
+  })
+
+  test('createOrder returns the order hash when post-persist tracking kickoff fails', async () => {
+    const mockOrderValidator = mock<OffChainUniswapXOrderValidator>()
+    mockOrderValidator.validate.mockReturnValue({ valid: true })
+
+    const onChainValidator = mock<OrderValidator>()
+    onChainValidator.validate.mockResolvedValue(OrderValidation.OK)
+
+    const onChainValidatorMap = mock<OnChainValidatorMap<OrderValidator>>()
+    onChainValidatorMap.get.mockReturnValue(onChainValidator)
+
+    const repository = mock<BaseOrdersRepository<UniswapXOrderEntity>>()
+    const logger = mock<Logger>()
+    const analyticsService = mock<AnalyticsService>()
+
+    const service = new UniswapXOrderService(
+      mockOrderValidator,
+      onChainValidatorMap,
+      repository as unknown as BaseOrdersRepository<UniswapXOrderEntity>,
+      mock<BaseOrdersRepository<UniswapXOrderEntity>>(),
+      mock<QuoteMetadataRepository>(),
+      logger,
+      () => {
+        return 10
+      },
+      analyticsService,
+      MOCK_PROVIDER_MAP
+    )
+
+    const order = SDKDutchOrderFactory.buildLimitOrder()
+    ;(kickoffOrderTrackingSfn as jest.Mock).mockRejectedValueOnce(new Error('sfn unavailable'))
+
+    // The order is persisted before tracking starts; the caller must still
+    // receive the hash or an accepted order is misreported as rejected.
+    const response = await service.createOrder(new LimitOrder(order, '0x00', 1))
+
+    expect(response).not.toBeNull()
+    expect(repository.putOrderAndUpdateNonceTransaction).toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith(
+      'Post-persist processing failed for accepted order',
+      expect.objectContaining({ orderHash: response })
+    )
+  })
+
+  test('createOrder throws TooManyOpenOrdersError and does not persist when open order limit is reached', async () => {
+    const mockOrderValidator = mock<OffChainUniswapXOrderValidator>()
+    mockOrderValidator.validate.mockReturnValue({ valid: true })
+
+    const onChainValidator = mock<OrderValidator>()
+    onChainValidator.validate.mockResolvedValue(OrderValidation.OK)
+
+    const onChainValidatorMap = mock<OnChainValidatorMap<OrderValidator>>()
+    onChainValidatorMap.get.mockReturnValue(onChainValidator)
+
+    const repository = mock<BaseOrdersRepository<UniswapXOrderEntity>>()
+    repository.countOrdersByOffererAndStatus.mockResolvedValue(11)
+    const logger = mock<Logger>()
+    const analyticsService = mock<AnalyticsService>()
+
+    const service = new UniswapXOrderService(
+      mockOrderValidator,
+      onChainValidatorMap,
+      repository as unknown as BaseOrdersRepository<UniswapXOrderEntity>,
+      mock<BaseOrdersRepository<UniswapXOrderEntity>>(),
+      mock<QuoteMetadataRepository>(),
+      logger,
+      () => {
+        return 10
+      },
+      analyticsService,
+      MOCK_PROVIDER_MAP
+    )
+
+    const order = SDKDutchOrderFactory.buildLimitOrder()
+
+    await expect(service.createOrder(new LimitOrder(order, '0x00', 1))).rejects.toThrow(TooManyOpenOrdersError)
+    expect(repository.putOrderAndUpdateNonceTransaction).not.toHaveBeenCalled()
   })
 
   test('createOrder with PriorityOrder, propagates correct type', async () => {


### PR DESCRIPTION
## Context

[SWAP-2839](https://linear.app/uniswap/issue/SWAP-2839/uniswapx-order-timeouts-can-still-create-filled-orders): `POST /v1/order` callers intermittently see `400 InputValidationError` / `timeout of 2000ms exceeded` while the order is actually accepted and later filled.

Root cause (confirmed via Datadog trace `2119114652437636364`): the 2s timeout lives in **uniswapx-parameterization-api**'s order-post client (`ORDER_SERVICE_TIMEOUT_MS = 2000`). When this service's post path exceeds 2s, the caller hangs up, but the Lambda (29s budget) finishes — persists the order, notifies fillers — and the order fills. The hard-quote handler then rewrites the timeout into a 400, which TAPI surfaces as `InputValidationError`. Companion fixes: parameterization-api (reconcile-on-timeout, status mapping) and TAPI (timeout headroom, error mapping).

## Changes in this service

1. **Never return an error after the order is persisted.** `logOrderCreatedEvent` / `startOrderTracker` failures now log + emit `PostOrderPostPersistFailure` (alarmable) and still return `201 { hash }` — the signed order is already live and fillable, so erroring just misinforms the caller.
2. **Reuse the `SFNClient`** across invocations in `kickoffOrderTrackingSfn` (was a new client + TLS handshake per order, awaited after persist).
3. **Run the open-order count concurrently with validation** (was a serial DynamoDB query after the on-chain `eth_call`).
4. **Bound RPC calls at 5s** (`RPC_PROVIDER_TIMEOUT_MS`) so a hung provider fails the request *before* the order is accepted, instead of the ethers default of 120s.

## Testing

- `yarn test`: 513/513 pass, including new tests:
  - post-persist SFN kickoff failure still returns the order hash (and logs/alarms)
  - open-order limit still rejects before persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)