### PR TITLE
fix, test: stop writing client IPs to CloudWatch logs

### DIFF
--- a/lib/handlers/base/api-handler.ts
+++ b/lib/handlers/base/api-handler.ts
@@ -23,6 +23,32 @@ export const INTERNAL_ERROR = (id?: string) => {
 
 export type APIGatewayProxyHandler = (event: APIGatewayProxyEvent, context: Context) => Promise<APIGatewayProxyResult>
 
+/*
+ * The raw APIGatewayProxyEvent carries the client IP in several places: requestContext.identity.sourceIp
+ * and any of the forwarding headers (X-Forwarded-For, X-Real-IP, CF-Connecting-IP, ...). IP addresses are
+ * personal data, and our log groups retain for up to three months, so never log the raw event.
+ * This is an allowlist rather than a denylist so a new IP-bearing header can't leak in by default.
+ */
+export function redactEvent(event: APIGatewayProxyEvent) {
+  return {
+    resource: event.resource,
+    path: event.path,
+    httpMethod: event.httpMethod,
+    pathParameters: event.pathParameters,
+    queryStringParameters: event.queryStringParameters,
+    body: event.body,
+    isBase64Encoded: event.isBase64Encoded,
+    requestContext: {
+      requestId: event.requestContext?.requestId,
+      path: event.requestContext?.path,
+      stage: event.requestContext?.stage,
+      resourcePath: event.requestContext?.resourcePath,
+      httpMethod: event.requestContext?.httpMethod,
+      requestTimeEpoch: event.requestContext?.requestTimeEpoch,
+    },
+  }
+}
+
 export type ApiRInj = {
   log: Logger
   requestId: string
@@ -115,7 +141,7 @@ export abstract class APIGLambdaHandler<CInj, RInj extends ApiRInj, ReqBody, Req
           requestId: context.awsRequestId,
         })
 
-        log.debug({ event, context }, 'Request started.')
+        log.debug({ event: redactEvent(event), context }, 'Request started.')
 
         let requestBody: ReqBody
         let requestQueryParams: ReqQueryParams
@@ -149,7 +175,7 @@ export abstract class APIGLambdaHandler<CInj, RInj extends ApiRInj, ReqBody, Req
             metrics
           )
         } catch (err) {
-          log.error({ err, event }, 'Unexpected error building request injected.')
+          log.error({ err, event: redactEvent(event) }, 'Unexpected error building request injected.')
           return INTERNAL_ERROR()
         }
 

--- a/test/unit/handlers/base/redact-event.test.ts
+++ b/test/unit/handlers/base/redact-event.test.ts
@@ -1,0 +1,78 @@
+import { APIGatewayProxyEvent } from 'aws-lambda'
+import { redactEvent } from '../../../../lib/handlers/base/api-handler'
+
+describe('redactEvent', () => {
+  const SOURCE_IP = '203.0.113.42'
+  const FORWARDED_IP = '198.51.100.7'
+
+  const event = {
+    resource: '/dutch-auction/order',
+    path: '/dutch-auction/order',
+    httpMethod: 'POST',
+    pathParameters: null,
+    queryStringParameters: { chainId: '1' },
+    body: '{"encodedOrder":"0xabc","signature":"0xdef","chainId":1}',
+    isBase64Encoded: false,
+    headers: {
+      'X-Forwarded-For': FORWARDED_IP,
+      'x-real-ip': FORWARDED_IP,
+      'CF-Connecting-IP': FORWARDED_IP,
+      'User-Agent': 'Mozilla/5.0',
+      'x-api-key': 'super-secret-key',
+    },
+    multiValueHeaders: {
+      'X-Forwarded-For': [FORWARDED_IP],
+    },
+    requestContext: {
+      requestId: 'request-id-1',
+      path: '/prod/dutch-auction/order',
+      stage: 'prod',
+      resourcePath: '/dutch-auction/order',
+      httpMethod: 'POST',
+      requestTimeEpoch: 1700000000000,
+      identity: {
+        sourceIp: SOURCE_IP,
+        userAgent: 'Mozilla/5.0',
+        caller: 'caller-id',
+        user: 'user-id',
+      },
+    },
+  } as unknown as APIGatewayProxyEvent
+
+  it('keeps the fields needed to debug a request', () => {
+    expect(redactEvent(event)).toEqual({
+      resource: '/dutch-auction/order',
+      path: '/dutch-auction/order',
+      httpMethod: 'POST',
+      pathParameters: null,
+      queryStringParameters: { chainId: '1' },
+      body: '{"encodedOrder":"0xabc","signature":"0xdef","chainId":1}',
+      isBase64Encoded: false,
+      requestContext: {
+        requestId: 'request-id-1',
+        path: '/prod/dutch-auction/order',
+        stage: 'prod',
+        resourcePath: '/dutch-auction/order',
+        httpMethod: 'POST',
+        requestTimeEpoch: 1700000000000,
+      },
+    })
+  })
+
+  it('drops every client IP, headers, and requestContext.identity', () => {
+    const serialized = JSON.stringify(redactEvent(event))
+
+    expect(serialized).not.toContain(SOURCE_IP)
+    expect(serialized).not.toContain(FORWARDED_IP)
+    expect(serialized).not.toContain('super-secret-key')
+
+    const redacted = redactEvent(event) as Record<string, unknown>
+    expect(redacted.headers).toBeUndefined()
+    expect(redacted.multiValueHeaders).toBeUndefined()
+    expect((redacted.requestContext as Record<string, unknown>).identity).toBeUndefined()
+  })
+
+  it('tolerates a missing requestContext', () => {
+    expect(() => redactEvent({} as APIGatewayProxyEvent)).not.toThrow()
+  })
+})

--- a/test/unit/handlers/base/redact-event.test.ts
+++ b/test/unit/handlers/base/redact-event.test.ts
@@ -39,8 +39,10 @@ describe('redactEvent', () => {
     },
   } as unknown as APIGatewayProxyEvent
 
+  // toStrictEqual, not toEqual: toEqual ignores keys whose value is undefined, so a field
+  // added back to the allowlist but absent from this fixture would slip through.
   it('keeps the fields needed to debug a request', () => {
-    expect(redactEvent(event)).toEqual({
+    expect(redactEvent(event)).toStrictEqual({
       resource: '/dutch-auction/order',
       path: '/dutch-auction/order',
       httpMethod: 'POST',


### PR DESCRIPTION
## What

The API handler logged the raw `APIGatewayProxyEvent` in two places. That event carries the client IP in several fields — `requestContext.identity.sourceIp` and the forwarding headers (`X-Forwarded-For`, `X-Real-IP`, `CF-Connecting-IP`) — so every hit of the error path wrote an IP into CloudWatch, where prod log groups retain for **three months** (`logRetentionDays`, `lib/util/stage.ts`).

The error-level call is the notable one: it runs in prod regardless of `NODE_ENV`, unlike the debug call that only fires under `NODE_ENV=debug` (which nothing in `bin/` sets).

```
lib/handlers/base/api-handler.ts:118  log.debug({ event, context }, 'Request started.')
lib/handlers/base/api-handler.ts:152  log.error({ err, event }, 'Unexpected error building request injected.')
```

## How

Added `redactEvent()` and applied it at both sites. It's an **allowlist rather than a denylist**, so a new IP-bearing header can't leak in by default.

- **Kept:** `resource`, `path`, `httpMethod`, `pathParameters`, `queryStringParameters`, `body`, `isBase64Encoded`, and exactly six `requestContext` fields — `requestId`, `path`, `stage`, `resourcePath`, `httpMethod`, `requestTimeEpoch`.
- **Dropped:** `headers`, `multiValueHeaders`, and every other `requestContext` field. That includes `identity` (which carries `sourceIp`, `userAgent`, `caller`, `user`) and also `authorizer`, `apiId`, `extendedRequestId` and the domain fields. Dropping `authorizer` matters independently of IPs, since it can carry claims.

This brings the Lambda logs in line with the API Gateway access logs, which already set `ip: false` in the access log format (`bin/stacks/api-stack.ts:88`).

## Context

Came out of a review of the WAF IP rate limiting in `bin/stacks/api-stack.ts`. IP addresses are personal data under GDPR (Recital 30; CJEU *Breyer*, C-582/14), and the WAF rate limiting itself is a standard legitimate-interest use for abuse prevention. But months-long IP retention in application logs is harder to justify as necessary, and it was inadvertent rather than deliberate.

Two related surfaces were left alone deliberately, as they're judgment calls rather than clear bugs:

- `sampledRequestsEnabled: true` (7×) — retains sampled requests including Source IP for 3 hours. Genuinely useful when debugging a misfiring WAF rule.
- **Request bodies are still logged**, which for order posts means a signed order. Note this error path fires inside `getRequestInjected`, i.e. *before* the order is persisted, so the log entry can be the only copy — the "it's in DynamoDB anyway" argument doesn't actually cover this call site. Keeping the body still looks right for debuggability, since the signature only authorizes the order the client already intended to submit, but it's a deliberate call rather than a free one.

## Testing

New `test/unit/handlers/base/redact-event.test.ts` asserts the exact output shape and serializes the result to confirm no IP (or `x-api-key`) survives — so it fails loudly if someone re-adds a field later.

Uses `toStrictEqual` rather than `toEqual`, since `toEqual` ignores keys whose value is `undefined` and would miss a re-added field absent from the fixture. Verified both ways: adding `multiValueQueryStringParameters` to `redactEvent` fails under `toStrictEqual` and passes under `toEqual`.

- `npx jest test/unit` — 43 suites / 508 tests pass
- `npx tsc --noEmit` — clean
- `npx eslint` on both files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
