### PR TITLE
fix: enforce single-token outputs and report cosigner-adjusted amounts to fillers

### DIFF
--- a/lib/handlers/get-orders/schema/GetDutchV2OrderResponse.ts
+++ b/lib/handlers/get-orders/schema/GetDutchV2OrderResponse.ts
@@ -29,6 +29,29 @@ export type GetDutchV2OrderResponse = {
     endAmount: string
     recipient: string
   }[]
+  /**
+   * `input`/`outputs` are the amounts the swapper signed. The cosigner can improve them,
+   * and the reactor uses the override in place of `startAmount` whenever it is non-zero,
+   * so neither field on its own is what a fill actually moves. `effectiveInput` and
+   * `effectiveOutputs` are those same amounts with `cosignerData.inputOverride` and
+   * `cosignerData.outputOverrides` already applied: what the filler receives and pays.
+   *
+   * Always populated for Dutch V2 orders. Optional so older clients and the legacy
+   * untyped `GET /orders` response stay valid. Amounts still decay to `endAmount` over
+   * the cosigner's decay window, and a non-exclusive filler pays
+   * `cosignerData.exclusivityOverrideBps` on top of every output.
+   */
+  effectiveInput?: {
+    token: string
+    startAmount: string
+    endAmount: string
+  }
+  effectiveOutputs?: {
+    token: string
+    startAmount: string
+    endAmount: string
+    recipient: string
+  }[]
   settledAmounts: {
     tokenOut: string
     amountOut: string
@@ -58,21 +81,25 @@ export const CosignerDataJoi = Joi.object({
   outputOverrides: Joi.array().items(FieldValidator.isValidAmount()),
 })
 
+const InputJoi = Joi.object({
+  token: FieldValidator.isValidEthAddress().required(),
+  startAmount: FieldValidator.isValidAmount().required(),
+  endAmount: FieldValidator.isValidAmount().required(),
+})
+
+const OutputJoi = Joi.object({
+  token: FieldValidator.isValidEthAddress().required(),
+  startAmount: FieldValidator.isValidAmount().required(),
+  endAmount: FieldValidator.isValidAmount().required(),
+  recipient: FieldValidator.isValidEthAddress().required(),
+})
+
 export const GetDutchV2OrderResponseEntryJoi = Joi.object({
   ...CommonOrderValidationFields,
   type: Joi.string().valid(OrderType.Dutch_V2).required(),
-  input: Joi.object({
-    token: FieldValidator.isValidEthAddress().required(),
-    startAmount: FieldValidator.isValidAmount().required(),
-    endAmount: FieldValidator.isValidAmount().required(),
-  }),
-  outputs: Joi.array().items(
-    Joi.object({
-      token: FieldValidator.isValidEthAddress().required(),
-      startAmount: FieldValidator.isValidAmount().required(),
-      endAmount: FieldValidator.isValidAmount().required(),
-      recipient: FieldValidator.isValidEthAddress().required(),
-    })
-  ),
+  input: InputJoi,
+  outputs: Joi.array().items(OutputJoi),
+  effectiveInput: InputJoi,
+  effectiveOutputs: Joi.array().items(OutputJoi),
   cosignerData: CosignerDataJoi,
 })

--- a/lib/handlers/get-orders/schema/GetDutchV3OrderResponse.ts
+++ b/lib/handlers/get-orders/schema/GetDutchV3OrderResponse.ts
@@ -40,6 +40,39 @@ export type GetDutchV3OrderResponse = {
     minAmount: string
     adjustmentPerGweiBaseFee: string
   }[]
+  /**
+   * `input`/`outputs` are the amounts the swapper signed. The cosigner can improve them,
+   * and the reactor uses the override in place of `startAmount` whenever it is non-zero,
+   * so neither field on its own is what a fill actually moves. `effectiveInput` and
+   * `effectiveOutputs` are those same amounts with `cosignerData.inputOverride` and
+   * `cosignerData.outputOverrides` already applied: what the filler receives and pays.
+   *
+   * Always populated for Dutch V3 orders. Optional so older clients and the legacy
+   * untyped `GET /orders` response stay valid. Amounts still decay along `curve` from
+   * `decayStartBlock`, are adjusted by `adjustmentPerGweiBaseFee`, and a non-exclusive
+   * filler pays `exclusivityOverrideBps` on top of every output.
+   */
+  effectiveInput?: {
+    token: string
+    startAmount: string
+    curve: {
+      relativeBlocks: number[]
+      relativeAmounts: string[]
+    }
+    maxAmount: string
+    adjustmentPerGweiBaseFee: string
+  }
+  effectiveOutputs?: {
+    token: string
+    startAmount: string
+    curve: {
+      relativeBlocks: number[]
+      relativeAmounts: string[]
+    }
+    recipient: string
+    minAmount: string
+    adjustmentPerGweiBaseFee: string
+  }[]
   settledAmounts: {
     tokenOut: string
     amountOut: string
@@ -68,34 +101,37 @@ export const CosignerDataJoi = Joi.object({
   outputOverrides: Joi.array().items(FieldValidator.isValidAmount()),
 })
 
+const CurveJoi = Joi.object({
+  relativeBlocks: Joi.array().items(FieldValidator.isValidNumber()),
+  relativeAmounts: Joi.array().items(FieldValidator.isValidBigIntString()),
+})
+
+const InputJoi = Joi.object({
+  token: FieldValidator.isValidEthAddress().required(),
+  startAmount: FieldValidator.isValidAmount().required(),
+  curve: CurveJoi,
+  maxAmount: FieldValidator.isValidAmount(),
+  adjustmentPerGweiBaseFee: FieldValidator.isValidAmount(),
+})
+
+const OutputJoi = Joi.object({
+  token: FieldValidator.isValidEthAddress().required(),
+  startAmount: FieldValidator.isValidAmount().required(),
+  curve: CurveJoi,
+  recipient: FieldValidator.isValidEthAddress().required(),
+  minAmount: FieldValidator.isValidAmount(),
+  adjustmentPerGweiBaseFee: FieldValidator.isValidAmount(),
+})
+
 export const GetDutchV3OrderResponseEntryJoi = Joi.object({
   ...CommonOrderValidationFields,
   //only Dutch_V3
   type: Joi.string().valid(OrderType.Dutch_V3).required(),
   startingBaseFee: FieldValidator.isValidAmount(),
   fillBlock: FieldValidator.isValidNumber(),
-  input: Joi.object({
-    token: FieldValidator.isValidEthAddress().required(),
-    startAmount: FieldValidator.isValidAmount().required(),
-    curve: Joi.object({
-      relativeBlocks: Joi.array().items(FieldValidator.isValidNumber()),
-      relativeAmounts: Joi.array().items(FieldValidator.isValidBigIntString()),
-    }),
-    maxAmount: FieldValidator.isValidAmount(),
-    adjustmentPerGweiBaseFee: FieldValidator.isValidAmount(),
-  }),
-  outputs: Joi.array().items(
-    Joi.object({
-      token: FieldValidator.isValidEthAddress().required(),
-      startAmount: FieldValidator.isValidAmount().required(),
-      curve: Joi.object({
-        relativeBlocks: Joi.array().items(FieldValidator.isValidNumber()),
-        relativeAmounts: Joi.array().items(FieldValidator.isValidBigIntString()),
-      }),
-      recipient: FieldValidator.isValidEthAddress().required(),
-      minAmount: FieldValidator.isValidAmount(),
-      adjustmentPerGweiBaseFee: FieldValidator.isValidAmount(),
-    })
-  ),
+  input: InputJoi,
+  outputs: Joi.array().items(OutputJoi),
+  effectiveInput: InputJoi,
+  effectiveOutputs: Joi.array().items(OutputJoi),
   cosignerData: CosignerDataJoi,
 })

--- a/lib/models/DutchV2Order.ts
+++ b/lib/models/DutchV2Order.ts
@@ -107,6 +107,25 @@ export class DutchV2Order extends Order {
   }
 
   public toGetResponse(): GetDutchV2OrderResponse {
+    const { input, outputs, cosignerData } = this.inner.info
+    // The reactor substitutes a non-zero override for the signed startAmount
+    // (V2DutchOrderReactor._updateWithCosignerAmounts), so these are the amounts a fill
+    // actually moves. endAmount is not overridable and carries through unchanged.
+    const effectiveInput = {
+      token: input.token,
+      startAmount: (cosignerData.inputOverride.isZero() ? input.startAmount : cosignerData.inputOverride).toString(),
+      endAmount: input.endAmount.toString(),
+    }
+    const effectiveOutputs = outputs.map((o, i) => {
+      const override = cosignerData.outputOverrides[i]
+      return {
+        token: o.token,
+        startAmount: (override && !override.isZero() ? override : o.startAmount).toString(),
+        endAmount: o.endAmount.toString(),
+        recipient: o.recipient,
+      }
+    })
+
     return {
       type: OrderType.Dutch_V2,
       orderStatus: this.orderStatus as ORDER_STATUS,
@@ -132,6 +151,8 @@ export class DutchV2Order extends Order {
           recipient: o.recipient,
         }
       }),
+      effectiveInput,
+      effectiveOutputs,
       settledAmounts: this.settledAmounts,
       cosignerData: {
         decayStartTime: this.inner.info.cosignerData.decayStartTime,

--- a/lib/models/DutchV3Order.ts
+++ b/lib/models/DutchV3Order.ts
@@ -122,6 +122,35 @@ export class DutchV3Order extends Order {
   }
 
   public toGetResponse(): GetDutchV3OrderResponse {
+    const { input, outputs, cosignerData } = this.inner.info
+    // The reactor substitutes a non-zero override for the signed startAmount
+    // (V3DutchOrderReactor._updateWithCosignerAmounts), so these are the amounts a fill
+    // actually moves. The curve and min/max bounds are not overridable.
+    const effectiveInput = {
+      token: input.token,
+      startAmount: (cosignerData.inputOverride.isZero() ? input.startAmount : cosignerData.inputOverride).toString(),
+      curve: {
+        relativeBlocks: input.curve.relativeBlocks,
+        relativeAmounts: input.curve.relativeAmounts.map((a) => a.toString()),
+      },
+      maxAmount: input.maxAmount.toString(),
+      adjustmentPerGweiBaseFee: input.adjustmentPerGweiBaseFee.toString(),
+    }
+    const effectiveOutputs = outputs.map((o, i) => {
+      const override = cosignerData.outputOverrides[i]
+      return {
+        token: o.token,
+        startAmount: (override && !override.isZero() ? override : o.startAmount).toString(),
+        curve: {
+          relativeBlocks: o.curve.relativeBlocks,
+          relativeAmounts: o.curve.relativeAmounts.map((a) => a.toString()),
+        },
+        minAmount: o.minAmount.toString(),
+        recipient: o.recipient,
+        adjustmentPerGweiBaseFee: o.adjustmentPerGweiBaseFee.toString(),
+      }
+    })
+
     return {
       type: OrderType.Dutch_V3,
       orderStatus: this.orderStatus as ORDER_STATUS,
@@ -159,6 +188,8 @@ export class DutchV3Order extends Order {
           adjustmentPerGweiBaseFee: o.adjustmentPerGweiBaseFee.toString(),
         }
       }),
+      effectiveInput,
+      effectiveOutputs,
       settledAmounts: this.settledAmounts,
       cosignerData: {
         decayStartBlock: this.inner.info.cosignerData.decayStartBlock,

--- a/lib/services/UniswapXOrderService.ts
+++ b/lib/services/UniswapXOrderService.ts
@@ -194,6 +194,15 @@ export class UniswapXOrderService {
   ): Promise<void> {
     const offChainValidationResult = this.orderValidator.validate(order)
     if (!offChainValidationResult.valid) {
+      // The 400 this becomes carries the reason to the caller but leaves no trace on our
+      // side, so a validation rule that starts rejecting real traffic is invisible.
+      metrics.putMetric('OffchainValidationFailure', 1, Unit.Count)
+      this.logger.info('offchain validation failed', {
+        chainId,
+        orderHash: order.hash(),
+        swapper: order.info.swapper,
+        reason: offChainValidationResult.errorString,
+      })
       throw new OrderValidationFailedError(offChainValidationResult.errorString)
     }
     const token = order.info.input.token

--- a/lib/util/OffChainUniswapXOrderValidator.ts
+++ b/lib/util/OffChainUniswapXOrderValidator.ts
@@ -209,7 +209,14 @@ export class OffChainUniswapXOrderValidator {
       if (!outputsValidation.valid) {
         return outputsValidation
       }
-    } else if (orderType == OrderType.Dutch && (order instanceof DutchOrder || order instanceof CosignedV2DutchOrder)) {
+    } else if (
+      // Dutch_V2 shares the DutchInput/DutchOutput shape with V1, so it validates here too.
+      // The V2 case used to be unreachable: a CosignedV2DutchOrder is classified as
+      // Dutch_V2 above, so `orderType == OrderType.Dutch` was never true for it and V2
+      // orders reached the repository with no output validation at all.
+      (orderType == OrderType.Dutch || orderType == OrderType.Dutch_V2) &&
+      (order instanceof DutchOrder || order instanceof CosignedV2DutchOrder)
+    ) {
       const input = order.info.input as DutchInput
       const inputStartAmountValidation = this.validateInputAmount(input.startAmount)
       if (!inputStartAmountValidation.valid) {
@@ -224,6 +231,16 @@ export class OffChainUniswapXOrderValidator {
       const outputsValidation = this.validateDutchOutputs(order.info.outputs as DutchOutput[])
       if (!outputsValidation.valid) {
         return outputsValidation
+      }
+
+      if (order instanceof CosignedV2DutchOrder) {
+        const outputOverridesValidation = this.validateV2OutputOverrides(
+          order.info.outputs as DutchOutput[],
+          order.info.cosignerData.outputOverrides
+        )
+        if (!outputOverridesValidation.valid) {
+          return outputOverridesValidation
+        }
       }
     }
 
@@ -397,6 +414,10 @@ export class OffChainUniswapXOrderValidator {
         errorString: `Invalid number of outputs: 0`,
       }
     }
+    const outputTokensValidation = this.validateOutputTokensMatch(outputs)
+    if (!outputTokensValidation.valid) {
+      return outputTokensValidation
+    }
     for (const output of outputs) {
       const { token, recipient, startAmount, endAmount } = output
       if (FieldValidator.isValidEthAddress().validate(token).error) {
@@ -444,6 +465,16 @@ export class OffChainUniswapXOrderValidator {
       return {
         valid: false,
         errorString: `Invalid number of outputs: 0`,
+      }
+    }
+    const outputTokensValidation = this.validateOutputTokensMatch(outputs)
+    if (!outputTokensValidation.valid) {
+      return outputTokensValidation
+    }
+    if (outputOverrides.length != outputs.length) {
+      return {
+        valid: false,
+        errorString: `Invalid outputOverrides length ${outputOverrides.length}: expected ${outputs.length}`,
       }
     }
     for (let i = 0; i < outputs.length; i++) {
@@ -521,6 +552,10 @@ export class OffChainUniswapXOrderValidator {
         errorString: `Invalid number of outputs: 0`,
       }
     }
+    const outputTokensValidation = this.validateOutputTokensMatch(priorityOutputs)
+    if (!outputTokensValidation.valid) {
+      return outputTokensValidation
+    }
     for (const output of priorityOutputs) {
       const { token, recipient, amount, mpsPerPriorityFeeWei } = output
       if (FieldValidator.isValidEthAddress().validate(token).error) {
@@ -563,6 +598,56 @@ export class OffChainUniswapXOrderValidator {
       return {
         valid: false,
         errorString: `Invalid orderHash: ${error}`,
+      }
+    }
+    return {
+      valid: true,
+    }
+  }
+
+  /**
+   * Every output of an order must pay the same token.
+   *
+   * RFQ quotes an order as a single (tokenIn, tokenOut, amount) tuple where tokenOut is
+   * outputs[0].token, and the cosigner sums the output start amounts into one scalar to
+   * compare against the quote. An order whose outputs span multiple tokens is therefore
+   * priced against a total that mixes assets, and the filler is obligated to pay a token
+   * that was never quoted. Multi-output orders are still fine: fee outputs use the same
+   * token as the swapper output.
+   */
+  private validateOutputTokensMatch(outputs: { token: string }[]): OrderValidationResponse {
+    const expectedToken = outputs[0].token
+    for (const output of outputs) {
+      if (output.token.toLowerCase() != expectedToken.toLowerCase()) {
+        return {
+          valid: false,
+          errorString: `Invalid output token ${output.token}: all outputs must use ${expectedToken}`,
+        }
+      }
+    }
+    return {
+      valid: true,
+    }
+  }
+
+  /**
+   * V2DutchOrderReactor._updateWithCosignerAmounts reverts with InvalidCosignerOutput when
+   * the override array length disagrees with the outputs, or when a non-zero override is
+   * below the signed startAmount. Reject here rather than storing an unfillable order.
+   */
+  private validateV2OutputOverrides(outputs: DutchOutput[], outputOverrides: BigNumber[]): OrderValidationResponse {
+    if (outputOverrides.length != outputs.length) {
+      return {
+        valid: false,
+        errorString: `Invalid outputOverrides length ${outputOverrides.length}: expected ${outputs.length}`,
+      }
+    }
+    for (let i = 0; i < outputs.length; i++) {
+      if (!outputOverrides[i].isZero() && outputOverrides[i].lt(outputs[i].startAmount)) {
+        return {
+          valid: false,
+          errorString: `Invalid outputOverride < startAmount`,
+        }
       }
     }
     return {
@@ -653,6 +738,10 @@ export class OffChainUniswapXOrderValidator {
         valid: false,
         errorString: `Invalid number of outputs: 0`,
       }
+    }
+    const outputTokensValidation = this.validateOutputTokensMatch(outputs)
+    if (!outputTokensValidation.valid) {
+      return outputTokensValidation
     }
     for (const output of outputs) {
       const { token, recipient, minAmount } = output

--- a/lib/util/OffChainUniswapXOrderValidator.ts
+++ b/lib/util/OffChainUniswapXOrderValidator.ts
@@ -225,7 +225,9 @@ export class OffChainUniswapXOrderValidator {
 
       const inputEndAmountValidation = this.validateInputAmount(input.endAmount)
       if (!inputEndAmountValidation.valid) {
-        return inputStartAmountValidation
+        // Returning inputStartAmountValidation here (known valid at this point) reported
+        // the whole order as valid and skipped every check below it.
+        return inputEndAmountValidation
       }
 
       const outputsValidation = this.validateDutchOutputs(order.info.outputs as DutchOutput[])
@@ -414,10 +416,6 @@ export class OffChainUniswapXOrderValidator {
         errorString: `Invalid number of outputs: 0`,
       }
     }
-    const outputTokensValidation = this.validateOutputTokensMatch(outputs)
-    if (!outputTokensValidation.valid) {
-      return outputTokensValidation
-    }
     for (const output of outputs) {
       const { token, recipient, startAmount, endAmount } = output
       if (FieldValidator.isValidEthAddress().validate(token).error) {
@@ -455,9 +453,7 @@ export class OffChainUniswapXOrderValidator {
         }
       }
     }
-    return {
-      valid: true,
-    }
+    return this.validateOutputTokensMatch(outputs)
   }
 
   private validateV3DutchOutputs(outputs: V3DutchOutput[], outputOverrides: BigNumber[]): OrderValidationResponse {
@@ -466,10 +462,6 @@ export class OffChainUniswapXOrderValidator {
         valid: false,
         errorString: `Invalid number of outputs: 0`,
       }
-    }
-    const outputTokensValidation = this.validateOutputTokensMatch(outputs)
-    if (!outputTokensValidation.valid) {
-      return outputTokensValidation
     }
     if (outputOverrides.length != outputs.length) {
       return {
@@ -527,9 +519,7 @@ export class OffChainUniswapXOrderValidator {
         }
       }
     }
-    return {
-      valid: true,
-    }
+    return this.validateOutputTokensMatch(outputs)
   }
 
   private validateMpsPerPriorityFeeWei(mpsPerPriorityFeeWei: BigNumber): OrderValidationResponse {
@@ -551,10 +541,6 @@ export class OffChainUniswapXOrderValidator {
         valid: false,
         errorString: `Invalid number of outputs: 0`,
       }
-    }
-    const outputTokensValidation = this.validateOutputTokensMatch(priorityOutputs)
-    if (!outputTokensValidation.valid) {
-      return outputTokensValidation
     }
     for (const output of priorityOutputs) {
       const { token, recipient, amount, mpsPerPriorityFeeWei } = output
@@ -587,9 +573,7 @@ export class OffChainUniswapXOrderValidator {
         }
       }
     }
-    return {
-      valid: true,
-    }
+    return this.validateOutputTokensMatch(priorityOutputs)
   }
 
   private validateHash(orderHash: string): OrderValidationResponse {
@@ -614,6 +598,9 @@ export class OffChainUniswapXOrderValidator {
    * priced against a total that mixes assets, and the filler is obligated to pay a token
    * that was never quoted. Multi-output orders are still fine: fee outputs use the same
    * token as the swapper output.
+   *
+   * Runs after each output's own token address is validated, so outputs[0].token is a
+   * real address before it becomes the token the others are compared against.
    */
   private validateOutputTokensMatch(outputs: { token: string }[]): OrderValidationResponse {
     const expectedToken = outputs[0].token
@@ -739,10 +726,6 @@ export class OffChainUniswapXOrderValidator {
         errorString: `Invalid number of outputs: 0`,
       }
     }
-    const outputTokensValidation = this.validateOutputTokensMatch(outputs)
-    if (!outputTokensValidation.valid) {
-      return outputTokensValidation
-    }
     for (const output of outputs) {
       const { token, recipient, minAmount } = output
       if (FieldValidator.isValidEthAddress().validate(token).error) {
@@ -766,8 +749,6 @@ export class OffChainUniswapXOrderValidator {
         }
       }
     }
-    return {
-      valid: true,
-    }
+    return this.validateOutputTokensMatch(outputs)
   }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -642,6 +642,29 @@
               "$ref": "#/components/schemas/OrderOutput"
             }
           },
+          "effectiveInput": {
+            "description": "`input` with `cosignerData.inputOverride` applied: the amount the filler actually receives. The reactor uses the override in place of `startAmount` whenever it is non-zero, so `input` alone does not describe the fill.",
+            "type": "object",
+            "properties": {
+              "token": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "startAmount": {
+                "$ref": "#/components/schemas/Amount"
+              },
+              "endAmount": {
+                "$ref": "#/components/schemas/Amount"
+              }
+            },
+            "required": ["token", "startAmount", "endAmount"]
+          },
+          "effectiveOutputs": {
+            "description": "`outputs` with `cosignerData.outputOverrides` applied: the amounts the filler actually pays. Amounts still decay to `endAmount` across the cosigner's decay window, and a non-exclusive filler pays `cosignerData.exclusivityOverrideBps` on top of every output.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderOutput"
+            }
+          },
           "cosignerData": {
             "type": "object",
             "properties": {
@@ -746,6 +769,56 @@
             "required": ["token", "startAmount"]
           },
           "outputs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "token": {
+                  "$ref": "#/components/schemas/Address"
+                },
+                "startAmount": {
+                  "$ref": "#/components/schemas/Amount"
+                },
+                "curve": {
+                  "$ref": "#/components/schemas/NonlinearDutchDecayCurve"
+                },
+                "recipient": {
+                  "$ref": "#/components/schemas/Address"
+                },
+                "minAmount": {
+                  "$ref": "#/components/schemas/Amount"
+                },
+                "adjustmentPerGweiBaseFee": {
+                  "$ref": "#/components/schemas/Amount"
+                }
+              },
+              "required": ["token", "startAmount", "recipient"]
+            }
+          },
+          "effectiveInput": {
+            "description": "`input` with `cosignerData.inputOverride` applied: the amount the filler actually receives. The reactor uses the override in place of `startAmount` whenever it is non-zero, so `input` alone does not describe the fill.",
+            "type": "object",
+            "properties": {
+              "token": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "startAmount": {
+                "$ref": "#/components/schemas/Amount"
+              },
+              "curve": {
+                "$ref": "#/components/schemas/NonlinearDutchDecayCurve"
+              },
+              "maxAmount": {
+                "$ref": "#/components/schemas/Amount"
+              },
+              "adjustmentPerGweiBaseFee": {
+                "$ref": "#/components/schemas/Amount"
+              }
+            },
+            "required": ["token", "startAmount"]
+          },
+          "effectiveOutputs": {
+            "description": "`outputs` with `cosignerData.outputOverrides` applied: the amounts the filler actually pays. Amounts still decay along `curve` from `cosignerData.decayStartBlock`, are adjusted by `adjustmentPerGweiBaseFee`, and a non-exclusive filler pays `cosignerData.exclusivityOverrideBps` on top of every output.",
             "type": "array",
             "items": {
               "type": "object",

--- a/test/unit/models/DutchV2Order.test.ts
+++ b/test/unit/models/DutchV2Order.test.ts
@@ -7,6 +7,8 @@ import { SDKDutchOrderV2Factory } from '../../factories/SDKDutchOrderV2Factory'
 import { MOCK_SIGNATURE } from '../../test-data'
 import { mock } from 'jest-mock-extended'
 import { Logger } from '@aws-lambda-powertools/logger'
+import { BigNumber } from 'ethers'
+import { Tokens } from '../fixtures'
 
 describe('DutchV2 Model', () => {
   const log = mock<Logger>()
@@ -79,5 +81,61 @@ describe('DutchV2 Model', () => {
       expect(o).toEqual(order.inner.info.cosignerData.outputOverrides[i].toString())
     })
     expect(order.createdAt).toEqual(100)
+  })
+
+  describe('toGetResponse effective amounts', () => {
+    // Fillers price off these fields, so they must report what the reactor moves rather
+    // than the signed base amounts. Overrides are only applied when non-zero.
+    const order = () =>
+      new DutchV2Order(
+        SDKDutchOrderV2Factory.buildDutchV2Order(ChainId.MAINNET, {
+          input: { token: Tokens.MAINNET.USDC, startAmount: '2000000', endAmount: '2000000' },
+          outputs: [
+            { token: Tokens.MAINNET.WETH, startAmount: '1000000000000000000', endAmount: '900000000000000000' },
+            { token: Tokens.MAINNET.WETH, startAmount: '1000000000000000', endAmount: '900000000000000' },
+          ],
+          cosignerData: {
+            inputOverride: '1500000',
+            outputOverrides: ['1100000000000000000', '1000000000000000'],
+          },
+        }),
+        MOCK_SIGNATURE,
+        ChainId.MAINNET,
+        ORDER_STATUS.OPEN
+      )
+
+    test('applies inputOverride and outputOverrides', () => {
+      const response = order().toGetResponse()
+
+      expect(response.effectiveInput).toEqual({
+        token: Tokens.MAINNET.USDC,
+        startAmount: '1500000',
+        endAmount: '2000000',
+      })
+      expect(response.effectiveOutputs?.map((o) => o.startAmount)).toEqual([
+        '1100000000000000000',
+        '1000000000000000',
+      ])
+      expect(response.effectiveOutputs?.map((o) => o.endAmount)).toEqual(['900000000000000000', '900000000000000'])
+    })
+
+    test('falls back to the signed amounts when an override is zero', () => {
+      const inner = order().inner
+      inner.info.cosignerData.inputOverride = BigNumber.from(0)
+      inner.info.cosignerData.outputOverrides = [BigNumber.from(0), BigNumber.from(0)]
+      const response = new DutchV2Order(inner, MOCK_SIGNATURE, ChainId.MAINNET, ORDER_STATUS.OPEN).toGetResponse()
+
+      expect(response.effectiveInput?.startAmount).toEqual(inner.info.input.startAmount.toString())
+      expect(response.effectiveOutputs?.map((o) => o.startAmount)).toEqual(
+        inner.info.outputs.map((o) => o.startAmount.toString())
+      )
+    })
+
+    test('leaves the signed input and outputs untouched', () => {
+      const response = order().toGetResponse()
+
+      expect(response.input.startAmount).toEqual('2000000')
+      expect(response.outputs.map((o) => o.startAmount)).toEqual(['1000000000000000000', '1000000000000000'])
+    })
   })
 })

--- a/test/unit/models/DutchV3Order.test.ts
+++ b/test/unit/models/DutchV3Order.test.ts
@@ -7,6 +7,7 @@ import { MOCK_SIGNATURE } from '../../test-data'
 import { DutchV3Order } from '../../../lib/models/DutchV3Order'
 import { mock } from 'jest-mock-extended'
 import { Logger } from '@aws-lambda-powertools/logger'
+import { Tokens } from '../fixtures'
 
 describe('DutchV3 Model', () => {
   const log = mock<Logger>()
@@ -95,5 +96,53 @@ describe('DutchV3 Model', () => {
       expect(o).toEqual(order.inner.info.cosignerData.outputOverrides[i].toString())
     })
     expect(order.createdAt).toEqual(100)
+  })
+
+  describe('toGetResponse effective amounts', () => {
+    // Fillers price off these fields, so they must report what the reactor moves rather
+    // than the signed base amounts. Overrides are only applied when non-zero.
+    const order = (inputOverride: string, outputOverrides: bigint[]) =>
+      new DutchV3Order(
+        SDKDutchOrderV3Factory.buildDutchV3Order(ChainId.ARBITRUM_ONE, {
+          input: { token: Tokens.ARBITRUM_ONE.USDC, startAmount: '2000000', maxAmount: '2000000' },
+          outputs: [
+            { token: Tokens.ARBITRUM_ONE.WETH, startAmount: '1000000000000000000', minAmount: '900000000000000000' },
+            { token: Tokens.ARBITRUM_ONE.WETH, startAmount: '1000000000000000', minAmount: '900000000000000' },
+          ],
+          cosignerData: { inputOverride, outputOverrides },
+        }),
+        MOCK_SIGNATURE,
+        ChainId.ARBITRUM_ONE,
+        ORDER_STATUS.OPEN
+      )
+
+    test('applies inputOverride and outputOverrides', () => {
+      const response = order('1500000', [BigInt('1100000000000000000'), BigInt('1000000000000000')]).toGetResponse()
+
+      expect(response.effectiveInput?.startAmount).toEqual('1500000')
+      expect(response.effectiveInput?.maxAmount).toEqual('2000000')
+      expect(response.effectiveOutputs?.map((o) => o.startAmount)).toEqual([
+        '1100000000000000000',
+        '1000000000000000',
+      ])
+      expect(response.effectiveOutputs?.map((o) => o.minAmount)).toEqual(['900000000000000000', '900000000000000'])
+    })
+
+    test('falls back to the signed amounts when an override is zero', () => {
+      const response = order('0', [BigInt(0), BigInt(0)]).toGetResponse()
+
+      expect(response.effectiveInput?.startAmount).toEqual('2000000')
+      expect(response.effectiveOutputs?.map((o) => o.startAmount)).toEqual([
+        '1000000000000000000',
+        '1000000000000000',
+      ])
+    })
+
+    test('leaves the signed input and outputs untouched', () => {
+      const response = order('1500000', [BigInt('1100000000000000000'), BigInt('1000000000000000')]).toGetResponse()
+
+      expect(response.input.startAmount).toEqual('2000000')
+      expect(response.outputs.map((o) => o.startAmount)).toEqual(['1000000000000000000', '1000000000000000'])
+    })
   })
 })

--- a/test/unit/util/order-validator.test.ts
+++ b/test/unit/util/order-validator.test.ts
@@ -1,4 +1,4 @@
-import { DutchOrder, OrderType, REACTOR_ADDRESS_MAPPING } from '@uniswap/uniswapx-sdk'
+import { CosignedV2DutchOrder, DutchOrder, OrderType, REACTOR_ADDRESS_MAPPING } from '@uniswap/uniswapx-sdk'
 import dotenv from 'dotenv'
 import { BigNumber } from 'ethers'
 import { ChainId } from '../../../lib/util/chain'
@@ -7,6 +7,8 @@ import { OffChainUniswapXOrderValidator } from '../../../lib/util/OffChainUniswa
 import { SDKDutchOrderFactory } from '../../factories/SDKDutchOrderV1Factory'
 import { SDKDutchOrderV2Factory } from '../../factories/SDKDutchOrderV2Factory'
 import { SDKDutchOrderV3Factory } from '../../factories/SDKDutchOrderV3Factory'
+import { SDKPriorityOrderFactory } from '../../factories/SDKPriorityOrderFactory'
+import { Tokens } from '../fixtures'
 
 dotenv.config()
 
@@ -540,6 +542,152 @@ describe('Testing off chain validation', () => {
     expect(validationResp).toEqual({
       valid: false,
       errorString: 'Invalid outputOverride < startAmount',
+    })
+  })
+
+  it('Should throw when outputs pay different tokens', () => {
+    const order = SDKDutchOrderV3Factory.buildDutchV3Order(ChainId.ARBITRUM_ONE, {
+      cosigner: process.env.LABS_COSIGNER,
+      outputs: [{ token: Tokens.ARBITRUM_ONE.WETH }, { token: Tokens.ARBITRUM_ONE.USDC }],
+      cosignerData: { outputOverrides: [BigInt(0), BigInt(0)] },
+    })
+    order.info.deadline = CURRENT_TIME + ONE_DAY
+    const validationResp = validationProvider.validate(order)
+    expect(validationResp).toEqual({
+      valid: false,
+      errorString: `Invalid output token ${Tokens.ARBITRUM_ONE.USDC}: all outputs must use ${Tokens.ARBITRUM_ONE.WETH}`,
+    })
+  })
+
+  it('Should throw when outputOverrides length does not match outputs', () => {
+    const order = SDKDutchOrderV3Factory.buildDutchV3Order(ChainId.ARBITRUM_ONE, {
+      cosigner: process.env.LABS_COSIGNER,
+      outputs: [{}, {}],
+      cosignerData: { outputOverrides: [BigInt(0), BigInt(0)] },
+    })
+    order.info.cosignerData.outputOverrides = [BigNumber.from(0)]
+    order.info.deadline = CURRENT_TIME + ONE_DAY
+    const validationResp = validationProvider.validate(order)
+    expect(validationResp).toEqual({
+      valid: false,
+      errorString: 'Invalid outputOverrides length 1: expected 2',
+    })
+  })
+})
+
+// The SDK types outputs as readonly. Parsing an attacker-supplied encodedOrder yields the
+// same shapes with none of the builder's invariants, so mutation is the closest fixture.
+const mutableOutputs = (order: CosignedV2DutchOrder) =>
+  order.info.outputs as unknown as { token: string; startAmount: BigNumber; endAmount: BigNumber }[]
+
+// A CosignedV2DutchOrder is classified as Dutch_V2, so it used to fall through every
+// output branch of the validator and reach the repository unvalidated.
+describe('Testing v2 order validation', () => {
+  const v2ValidationProvider = new OffChainUniswapXOrderValidator(() => Date.now() / 1000, ONE_DAY_IN_SECONDS)
+
+  const buildV2 = (overrides: Parameters<typeof SDKDutchOrderV2Factory.buildDutchV2Order>[1] = {}) =>
+    SDKDutchOrderV2Factory.buildDutchV2Order(ChainId.MAINNET, {
+      cosigner: process.env.LABS_COSIGNER,
+      ...overrides,
+    })
+
+  // A swapper output plus a fee output in the same token. V2DutchOrderBuilder rejects
+  // amounts the reactor accepts (zero overrides, endAmount > startAmount), so the invalid
+  // cases below mutate a built order, which is also what parsing an attacker-supplied
+  // encodedOrder produces.
+  const buildTwoOutputV2 = () =>
+    buildV2({
+      outputs: [
+        { token: Tokens.MAINNET.WETH, startAmount: '1000000000000000000', endAmount: '900000000000000000' },
+        { token: Tokens.MAINNET.WETH, startAmount: '1000000000000000', endAmount: '900000000000000' },
+      ],
+      cosignerData: { outputOverrides: ['1000000000000000000', '1000000000000000'] },
+    })
+
+  it('Should return valid for a fee output in the same token as the swapper output', () => {
+    expect(v2ValidationProvider.validate(buildTwoOutputV2())).toEqual({ valid: true })
+  })
+
+  it('Should return valid when a fee output override is left at zero', () => {
+    const order = buildTwoOutputV2()
+    order.info.cosignerData.outputOverrides = [order.info.outputs[0].startAmount, BigNumber.from(0)]
+    expect(v2ValidationProvider.validate(order)).toEqual({ valid: true })
+  })
+
+  it('Should throw when outputs pay different tokens', () => {
+    const order = buildTwoOutputV2()
+    mutableOutputs(order)[1].token = Tokens.MAINNET.USDC
+    expect(v2ValidationProvider.validate(order)).toEqual({
+      valid: false,
+      errorString: `Invalid output token ${Tokens.MAINNET.USDC}: all outputs must use ${Tokens.MAINNET.WETH}`,
+    })
+  })
+
+  it('Should throw invalid endAmount > startAmount', () => {
+    const order = buildV2()
+    mutableOutputs(order)[0].endAmount = order.info.outputs[0].startAmount.add(1)
+    expect(v2ValidationProvider.validate(order)).toEqual({
+      valid: false,
+      errorString: 'Invalid endAmount > startAmount',
+    })
+  })
+
+  it('Should throw invalid output token', () => {
+    const order = buildV2()
+    mutableOutputs(order)[0].token = '0xfoo'
+    expect(v2ValidationProvider.validate(order)).toEqual({
+      valid: false,
+      errorString: 'Invalid output token 0xfoo',
+    })
+  })
+
+  it('Should throw invalid output override if less than startAmount', () => {
+    const order = buildV2()
+    // The reactor reverts with InvalidCosignerOutput on this order
+    order.info.cosignerData.outputOverrides = [order.info.outputs[0].startAmount.sub(1)]
+    expect(v2ValidationProvider.validate(order)).toEqual({
+      valid: false,
+      errorString: 'Invalid outputOverride < startAmount',
+    })
+  })
+
+  it('Should throw when outputOverrides length does not match outputs', () => {
+    const order = buildV2()
+    order.info.cosignerData.outputOverrides = []
+    expect(v2ValidationProvider.validate(order)).toEqual({
+      valid: false,
+      errorString: 'Invalid outputOverrides length 0: expected 1',
+    })
+  })
+})
+
+describe('Testing output tokens across order types', () => {
+  it('Should throw for a v1 Dutch order whose outputs pay different tokens', () => {
+    const order = SDKDutchOrderFactory.buildDutchOrder(ChainId.MAINNET, {
+      outputs: [{ token: Tokens.MAINNET.WETH }, { token: Tokens.MAINNET.USDC }],
+    })
+    const validationResp = new OffChainUniswapXOrderValidator(
+      () => Date.now() / 1000,
+      ONE_DAY_IN_SECONDS
+    ).validate(order)
+    expect(validationResp).toEqual({
+      valid: false,
+      errorString: `Invalid output token ${Tokens.MAINNET.USDC}: all outputs must use ${Tokens.MAINNET.WETH}`,
+    })
+  })
+
+  it('Should throw for a priority order whose outputs pay different tokens', () => {
+    const order = SDKPriorityOrderFactory.buildPriorityOrder(ChainId.MAINNET, {
+      cosigner: process.env.LABS_PRIORITY_COSIGNER,
+      outputs: [{ token: Tokens.MAINNET.WETH }, { token: Tokens.MAINNET.USDC }],
+    })
+    const validationResp = new OffChainUniswapXOrderValidator(
+      () => Date.now() / 1000,
+      ONE_DAY_IN_SECONDS
+    ).validate(order)
+    expect(validationResp).toEqual({
+      valid: false,
+      errorString: `Invalid output token ${Tokens.MAINNET.USDC}: all outputs must use ${Tokens.MAINNET.WETH}`,
     })
   })
 })

--- a/test/unit/util/order-validator.test.ts
+++ b/test/unit/util/order-validator.test.ts
@@ -7,6 +7,7 @@ import { OffChainUniswapXOrderValidator } from '../../../lib/util/OffChainUniswa
 import { SDKDutchOrderFactory } from '../../factories/SDKDutchOrderV1Factory'
 import { SDKDutchOrderV2Factory } from '../../factories/SDKDutchOrderV2Factory'
 import { SDKDutchOrderV3Factory } from '../../factories/SDKDutchOrderV3Factory'
+import { SDKHybridOrderFactory } from '../../factories/SDKHybridOrderFactory'
 import { SDKPriorityOrderFactory } from '../../factories/SDKPriorityOrderFactory'
 import { Tokens } from '../fixtures'
 
@@ -214,6 +215,24 @@ describe('Testing off chain validation', () => {
         input: {
           token: INPUT_TOKEN_ADDRESS,
           startAmount: BigNumber.from(1).shl(256),
+          endAmount: BigNumber.from(1).shl(256),
+        },
+      })
+      const validationResp = validationProvider.validate(order)
+      expect(validationResp).toEqual({
+        errorString:
+          'Invalid input amount: 115792089237316195423570985008687907853269984665640564039457584007913129639936',
+        valid: false,
+      })
+    })
+
+    // A bad endAmount used to return the (valid) startAmount result, reporting the order
+    // as valid and skipping output, override and hash validation below it.
+    it('invalid amount: only endAmount too big', async () => {
+      const order = newOrder({
+        input: {
+          token: INPUT_TOKEN_ADDRESS,
+          startAmount: BigNumber.from(1),
           endAmount: BigNumber.from(1).shl(256),
         },
       })
@@ -666,6 +685,25 @@ describe('Testing output tokens across order types', () => {
     const order = SDKDutchOrderFactory.buildDutchOrder(ChainId.MAINNET, {
       outputs: [{ token: Tokens.MAINNET.WETH }, { token: Tokens.MAINNET.USDC }],
     })
+    const validationResp = new OffChainUniswapXOrderValidator(
+      () => Date.now() / 1000,
+      ONE_DAY_IN_SECONDS
+    ).validate(order)
+    expect(validationResp).toEqual({
+      valid: false,
+      errorString: `Invalid output token ${Tokens.MAINNET.USDC}: all outputs must use ${Tokens.MAINNET.WETH}`,
+    })
+  })
+
+  it('Should throw for a hybrid order whose outputs pay different tokens', () => {
+    // Hybrid is only deployed on Unichain Sepolia, and the factory hardcodes a placeholder
+    // reactor that never matches REACTOR_ADDRESS_MAPPING, so point it at the real one.
+    const order = SDKHybridOrderFactory.buildHybridOrder(ChainId.UNICHAIN_SEPOLIA, {
+      outputs: [{ token: Tokens.MAINNET.WETH }, { token: Tokens.MAINNET.USDC }],
+    })
+    ;(order.info as { reactor: string }).reactor = REACTOR_ADDRESS_MAPPING[ChainId.UNICHAIN_SEPOLIA][
+      OrderType.Hybrid
+    ] as string
     const validationResp = new OffChainUniswapXOrderValidator(
       () => Date.now() / 1000,
       ONE_DAY_IN_SECONDS


### PR DESCRIPTION
Found while reviewing a bug bounty report (#847) against the V2 hard-RFQ path. Two separate problems, both in this repo.

## 1. Output validation never ran for Dutch V2

`OffChainUniswapXOrderValidator.validate()` classifies a `CosignedV2DutchOrder` as `OrderType.Dutch_V2`, but the branch that calls `validateDutchOutputs` was gated on `orderType == OrderType.Dutch`. That condition is never true for a V2 order, so V2 orders reached the repository with **no output validation at all**: no token address check, no uint256 range checks, no `endAmount <= startAmount`. Confirmed against the SDK before the fix: a V2 order with `startAmount: 1, endAmount: 999` returned `{valid: true}`.

Fixed the gate, and added the V2 equivalent of the checks V3 already has on cosigner overrides (array length matches outputs, and a non-zero override must be `>= startAmount`) so we stop storing orders that `V2DutchOrderReactor._updateWithCosignerAmounts` will revert on.

## 2. Outputs may no longer span multiple tokens

Every output of an order must now pay `outputs[0].token`. RFQ prices an order as one `(tokenIn, tokenOut, amount)` tuple where `tokenOut` is `outputs[0].token`, and the cosigner sums output start amounts into a single scalar to compare against the quote, so an order whose outputs span multiple tokens gets priced against a total that mixes assets. Multi-output orders are unaffected, since fee outputs use the same token as the swapper output.

This is wired into all four output validators, so it covers **every order type we accept**: Dutch V1, Limit (a `DutchOrder` classified as `OrderType.Dutch`), Dutch V2, Dutch V3, Priority and Hybrid. There is no on-chain equivalent of this rule, so it is a new hard 400 at `POST /order` for a shape the reactors would fill. To make that observable, off-chain validation failures now emit an `OffchainValidationFailure` metric and a log line with the reason, order hash and swapper. Previously the rejection returned a 400 and left no trace on our side. Worth watching that metric after deploy; I'm confident no live integrator sends heterogeneous outputs, but the metric is what would prove it.

## 3. `GET /orders` reported the signed amounts, not the fill amounts

`input`/`outputs` are what the swapper signed. The reactor substitutes `cosignerData.inputOverride` and `cosignerData.outputOverrides[i]` for `startAmount` whenever they are non-zero, so neither the base fields nor `cosignerData` on its own tells a filler what a fill actually moves. Dutch V2 and V3 responses now carry `effectiveInput` and `effectiveOutputs` with the overrides already applied.

**No breaking change.** `input`, `outputs` and `cosignerData` are untouched and byte-identical to before; `encodedOrder` was already complete. The two new fields are additive and optional in both the TS types and the joi response schemas, so existing filler integrations are unaffected. `swagger.json` documents them (the sync test in `test/unit/swagger.test.ts` requires it).

## Testing

`yarn test` green, 579 tests. New coverage: V2 same-token rejection, V2 `endAmount > startAmount`, V2 invalid output token, V2 override `< startAmount`, V2 override length mismatch, V2 zero-override still valid, V3, Priority and Hybrid same-token rejection, V3 override length mismatch, an input `endAmount` regression test, and `effectiveInput`/`effectiveOutputs` for V2 and V3 including the zero-override fallback and the base fields staying untouched. The invalid V2 fixtures mutate a built order because `V2DutchOrderBuilder` enforces invariants the reactor does not, which is also what parsing a caller-supplied `encodedOrder` produces.

## Follow-up commit after review

- The same-token check now runs after each output's own address is validated. Checking first made an invalid `outputs[0].token` the "expected" token, so `[{token: '0xfoo'}, {token: WETH}]` named the valid output as the offender and echoed the garbage back as the expected value.
- Fixed a pre-existing bypass three lines above the V2 gate: an invalid input `endAmount` returned `inputStartAmountValidation`, which is known-valid at that point, so the order validated successfully and skipped output validation, the override checks and the hash check. Latent (only non-uint256 values trip it, which ABI decoding cannot produce) but it is the same class of bug this PR closes.

## Out of scope

- The RFQ quote request itself still omits the output vector (`HardQuoteRequest.toCleanJSON` in `uniswapx-parameterization-api` sends one `tokenOut` plus `numOutputs`, and `totalOutputAmountStart` raw-sums every `startAmount`). This PR makes the service reject such an order at `POST /order`, which stops it reaching fillers, but the parameterization API should reject it before KMS signing too. Separate PR.
- The legacy untyped `GET /orders` response (no `orderType` param) returns raw DynamoDB entities and does not gain the new fields.
- The filler webhook payload is unchanged. It carries `encodedOrder`, which already contains every output and the full override array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)