### PR TITLE
fix: populate the state machine name map so order tracking starts again

### DIFF
--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -108,6 +108,7 @@ export class StepFunctionStack extends cdk.NestedStack {
       })
 
       this.chainIdToStatusTrackingStateMachineArn[chainId] = stateMachine.attrArn
+      this.chainIdToStatusTrackingStateMachineName[chainId] = stateMachine.attrName
 
       const METRIC_DIMENSION_MAP = {
         StateMachineArn: stateMachine.attrArn,

--- a/test/unit/stacks/step-function-stack.test.ts
+++ b/test/unit/stacks/step-function-stack.test.ts
@@ -1,0 +1,38 @@
+import * as cdk from 'aws-cdk-lib'
+import { StepFunctionStack } from '../../../bin/stacks/step-function-stack'
+import { SUPPORTED_CHAINS } from '../../../lib/util/chain'
+import { STAGE } from '../../../lib/util/stage'
+
+describe('StepFunctionStack', () => {
+  const buildStack = (): StepFunctionStack => {
+    const app = new cdk.App()
+    const parent = new cdk.Stack(app, 'TestParent')
+    const lambdaRole = new cdk.aws_iam.Role(parent, 'TestLambdaRole', {
+      assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+    })
+    return new StepFunctionStack(parent, 'TestStepFunctionStack', {
+      envVars: {},
+      stage: STAGE.BETA,
+      lambdaRole,
+    })
+  }
+
+  it('publishes a status-tracking state machine name for every supported chain', () => {
+    const stack = buildStack()
+    for (const chainId of SUPPORTED_CHAINS) {
+      const name = stack.chainIdToStatusTrackingStateMachineName[chainId]
+      expect(name).toBeDefined()
+      // A missing map entry interpolated into lambda-stack's STATE_MACHINE_NAMES
+      // env var becomes the literal string "undefined", which silently breaks
+      // order tracking at runtime.
+      expect(name).not.toContain('undefined')
+    }
+  })
+
+  it('keeps the name map aligned with the ARN map', () => {
+    const stack = buildStack()
+    expect(Object.keys(stack.chainIdToStatusTrackingStateMachineName).sort()).toEqual(
+      Object.keys(stack.chainIdToStatusTrackingStateMachineArn).sort()
+    )
+  })
+})


### PR DESCRIPTION
## Problem

The recent change that compacted per-chain state machine ARNs into a single `STATE_MACHINE_NAMES` env var declared `chainIdToStatusTrackingStateMachineName` on `StepFunctionStack` but never populated it. At synth time every map lookup returned `undefined`, and string interpolation turned that into the literal text `"undefined"`, so the deployed env looks like:

```
STATE_MACHINE_NAMES = {"1":"undefined","10":"undefined",...}
```

At runtime `getStateMachineArn()` builds an ARN ending in `:stateMachine:undefined` and `StartExecution` fails with `StateMachineDoesNotExist`. The failure is swallowed by the intentional post-persist catch (accepted orders must not be reported as rejected), so since this deployed, no status-tracking step function has been started for any newly posted order on any chain. Order statuses still resolve, but only when the reaper backstop reaches them — tens of minutes instead of seconds — and reaper-resolved fills skip the fill analytics event that the SFN path emits.

## Fix

One line: populate the name map from `CfnStateMachine.attrName` next to the existing ARN map assignment. (`attrName` is the CloudFormation `Fn::GetAtt Name` attribute, per the original change's intent — the ARN cannot be sliced at synth time because it is an unresolved token.)

## Testing

- New regression test constructs `StepFunctionStack` and asserts the name map has an entry for every supported chain, none of them `"undefined"`, and that it stays key-aligned with the ARN map. It fails on main (name map is empty) and passes with the fix.
- Full unit suite: 568/568 passing, 51/51 suites.
- `yarn build` (tsc) clean; eslint clean on touched files.

## Deploy note

Once this deploys, newly posted orders get trackers again immediately. Orders posted while the bug was live never got an execution and will continue to be resolved by the reaper; no backfill required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
