### PR TITLE
feat: alarm and test for order tracking silently stopping

### DIFF
--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -597,6 +597,85 @@ export class LambdaStack extends cdk.NestedStack {
       sev3PostOrder4xxRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
     }
 
+    // Post-persist failures: the order was accepted and stored, but the
+    // follow-on work (starting the status-tracking step function) threw.
+    // UniswapXOrderService swallows that error on purpose so an accepted order
+    // is never reported as rejected, which means this counter is the ONLY
+    // signal that tracking is broken — the request still returns 201 and no
+    // 4xx/5xx alarm moves.
+    const postOrderPostPersistFailure = new Metric({
+      namespace: 'Uniswap',
+      metricName: 'PostOrderPostPersistFailure',
+      // Emitted by lib/handlers/post-order/injector.ts, which sets this dimension.
+      dimensionsMap: { Service: 'UniswapXService' },
+      unit: cdk.aws_cloudwatch.Unit.COUNT,
+      statistic: 'sum',
+      period: Duration.minutes(5),
+    })
+
+    const sev3PostOrderPostPersistFailure = new Alarm(this, `${SERVICE_NAME}-SEV3-PostOrderPostPersistFailure`, {
+      alarmName: `${SERVICE_NAME}-SEV3-${props.stage}-PostOrderPostPersistFailure`,
+      alarmDescription:
+        'Orders are being accepted but their post-persist processing is failing (most likely status-tracking step functions are not starting). Requests still succeed, so no error-rate alarm will fire for this.',
+      metric: postOrderPostPersistFailure,
+      threshold: 5,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+      // IGNORE is right here: no datapoints means no failures were emitted.
+      // The "tracking stopped entirely" case is covered by the step function
+      // ExecutionsStarted heartbeat alarm, which uses BREACHING.
+      treatMissingData: TreatMissingData.IGNORE,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    })
+
+    // Heartbeat: order tracking has stopped starting entirely.
+    //
+    // The step function alarms in step-function-stack are RATE alarms over
+    // failed/started with TreatMissingData.IGNORE, so when nothing starts at
+    // all they have no datapoints and hold their last state — OK. They detect
+    // "executions are failing" but are blind to "executions stopped happening",
+    // which is what a broken state machine ARN or a bad deploy looks like.
+    //
+    // Alarms on our own counter rather than AWS/States ExecutionsStarted
+    // because the latter is per-state-machine, and summing one metric per
+    // chain exceeds CloudWatch's 10-metric cap for math-expression alarms as
+    // the chain list grows. This counter is already aggregate.
+    //
+    // PROD only: beta has no steady organic order flow, so an hourly heartbeat
+    // there would alarm on idleness rather than breakage. Beta is covered by
+    // the synth assertions and the post-deploy e2e suite instead.
+    if (props.stage === STAGE.PROD) {
+      const orderTrackerStarted = new Metric({
+        namespace: 'Uniswap',
+        metricName: 'OrderTrackerStarted',
+        dimensionsMap: { Service: 'UniswapXService' },
+        unit: cdk.aws_cloudwatch.Unit.COUNT,
+        statistic: 'sum',
+        period: Duration.hours(1),
+      })
+
+      const sev2NoOrderTrackersStarted = new Alarm(this, `${SERVICE_NAME}-SEV2-NoOrderTrackersStarted`, {
+        alarmName: `${SERVICE_NAME}-SEV2-${props.stage}-NoOrderTrackersStarted`,
+        alarmDescription:
+          'No order-status-tracking step function has started on any chain for an hour. Order statuses will only resolve via the slower reaper backstop, and SFN-path fill analytics are not emitted.',
+        metric: orderTrackerStarted,
+        threshold: 1,
+        evaluationPeriods: 1,
+        datapointsToAlarm: 1,
+        // BREACHING, not IGNORE: absence of data IS the failure being detected.
+        treatMissingData: TreatMissingData.BREACHING,
+        comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+      })
+
+      if (chatBotTopic) {
+        sev2NoOrderTrackersStarted.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
+      }
+    }
+
+    if (chatBotTopic) {
+      sev3PostOrderPostPersistFailure.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
+    }
+
     // 5xx error-rate alarms per endpoint. Each endpoint emits a `<Endpoint>Request` counter
     // and a `<Endpoint>Status5XX` counter via embedded metrics in the handler's afterResponseHook.
     // Two-tier alarm so we get both a slow-burn and a fast catastrophic signal:

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -108,6 +108,7 @@ export class StepFunctionStack extends cdk.NestedStack {
       })
 
       this.chainIdToStatusTrackingStateMachineArn[chainId] = stateMachine.attrArn
+      this.chainIdToStatusTrackingStateMachineName[chainId] = stateMachine.attrName
 
       const METRIC_DIMENSION_MAP = {
         StateMachineArn: stateMachine.attrArn,
@@ -217,5 +218,6 @@ export class StepFunctionStack extends cdk.NestedStack {
         sev3ExpiredRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
       }
     }
+
   }
 }

--- a/lib/services/UniswapXOrderService.ts
+++ b/lib/services/UniswapXOrderService.ts
@@ -315,6 +315,12 @@ export class UniswapXOrderService {
       },
       stateMachineArn
     )
+    // Success heartbeat. The post-persist catch in createOrder swallows any
+    // failure here so an accepted order is never reported as rejected, which
+    // means the request-level metrics look identical whether tracking started
+    // or not. This counter going to zero is the only aggregate signal that it
+    // stopped, and lambda-stack alarms on its absence.
+    metrics.putMetric('OrderTrackerStarted', 1, Unit.Count)
   }
 
   public async getDutchV2AndDutchOrders(

--- a/test/unit/stacks/lambda-stack.test.ts
+++ b/test/unit/stacks/lambda-stack.test.ts
@@ -1,0 +1,76 @@
+import * as cdk from 'aws-cdk-lib'
+import { Template } from 'aws-cdk-lib/assertions'
+import { LambdaStack } from '../../../bin/stacks/lambda-stack'
+import { SUPPORTED_CHAINS } from '../../../lib/util/chain'
+import { STAGE } from '../../../lib/util/stage'
+
+// Synthesizing LambdaStack bundles every handler with esbuild, which is slow.
+jest.setTimeout(300 * 1000)
+
+describe('LambdaStack env vars', () => {
+  const buildTemplate = (stage: STAGE) => {
+    const app = new cdk.App()
+    const parent = new cdk.Stack(app, 'TestParent', { env: { account: '123456789012', region: 'us-east-2' } })
+    const kmsKey = new cdk.aws_kms.Key(parent, 'TestKey')
+    const stack = new LambdaStack(parent, 'TestLambdaStack', {
+      provisionedConcurrency: 0,
+      stage,
+      envVars: {},
+      kmsKey,
+      tableCapacityConfig: {} as never,
+    })
+    return Template.fromStack(stack)
+  }
+
+  const postOrderEnv = (t: Template): Record<string, unknown> => {
+    const fns = t.findResources('AWS::Lambda::Function')
+    const entry = Object.entries(fns).find(([id]) => id.startsWith('PostOrder'))
+    expect(entry).toBeDefined()
+    return (entry![1] as any).Properties.Environment.Variables
+  }
+
+  it('publishes a STATE_MACHINE_NAMES entry per chain with no "undefined" values', () => {
+    const vars = postOrderEnv(buildTemplate(STAGE.BETA))
+    const names = vars.STATE_MACHINE_NAMES
+
+    // The value is a CloudFormation Fn::Join over Fn::GetAtt tokens, so assert
+    // on the serialized intrinsic rather than a plain string.
+    const serialized = JSON.stringify(names)
+
+    // The original incident: the CDK read an unpopulated map, so every chain
+    // interpolated to the literal string "undefined" and every StartExecution
+    // failed against :stateMachine:undefined.
+    expect(serialized).not.toContain('undefined')
+    expect(serialized).toContain('Fn::GetAtt')
+
+    // One "<chainId>":" fragment per supported chain.
+    for (const chainId of SUPPORTED_CHAINS) {
+      expect(serialized).toContain(`\\"${chainId}\\":\\"`)
+    }
+  })
+
+  it('does not publish one env var per chain', () => {
+    const vars = postOrderEnv(buildTemplate(STAGE.BETA))
+    // The per-chain STATE_MACHINE_ARN_<chainId> shape is what exhausted the
+    // 4KB environment limit. Deployed sizes depend on token values resolved at
+    // deploy time and cannot be measured here, so guard the shape instead.
+    const perChainKeys = Object.keys(vars).filter((k) => /^STATE_MACHINE_ARN_/.test(k))
+    expect(perChainKeys).toEqual([])
+  })
+
+  it('alarms in prod when no order trackers start, treating missing data as breaching', () => {
+    buildTemplate(STAGE.PROD).hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: `GoudaService-SEV2-${STAGE.PROD}-NoOrderTrackersStarted`,
+      TreatMissingData: 'breaching',
+      ComparisonOperator: 'LessThanThreshold',
+      Threshold: 1,
+    })
+  })
+
+  it('alarms on post-persist failures, the only signal that tracking broke', () => {
+    buildTemplate(STAGE.BETA).hasResourceProperties('AWS::CloudWatch::Alarm', {
+      AlarmName: `GoudaService-SEV3-${STAGE.BETA}-PostOrderPostPersistFailure`,
+      MetricName: 'PostOrderPostPersistFailure',
+    })
+  })
+})

--- a/test/unit/stacks/step-function-stack.test.ts
+++ b/test/unit/stacks/step-function-stack.test.ts
@@ -1,0 +1,38 @@
+import * as cdk from 'aws-cdk-lib'
+import { StepFunctionStack } from '../../../bin/stacks/step-function-stack'
+import { SUPPORTED_CHAINS } from '../../../lib/util/chain'
+import { STAGE } from '../../../lib/util/stage'
+
+describe('StepFunctionStack', () => {
+  const buildStack = (): StepFunctionStack => {
+    const app = new cdk.App()
+    const parent = new cdk.Stack(app, 'TestParent', { env: { account: '123456789012', region: 'us-east-2' } })
+    const lambdaRole = new cdk.aws_iam.Role(parent, 'TestLambdaRole', {
+      assumedBy: new cdk.aws_iam.ServicePrincipal('lambda.amazonaws.com'),
+    })
+    return new StepFunctionStack(parent, 'TestStepFunctionStack', {
+      envVars: {},
+      stage: STAGE.BETA,
+      lambdaRole,
+    })
+  }
+
+  it('publishes a state machine name for every supported chain', () => {
+    const stack = buildStack()
+    for (const chainId of SUPPORTED_CHAINS) {
+      // A missing entry interpolates into lambda-stack's STATE_MACHINE_NAMES
+      // env var as the literal string "undefined", producing an ARN ending in
+      // :stateMachine:undefined. StartExecution then fails, and the post-persist
+      // catch swallows it, so order tracking stops silently.
+      expect(stack.chainIdToStatusTrackingStateMachineName[chainId]).toBeDefined()
+    }
+  })
+
+  it('keeps the name map key-aligned with the ARN map', () => {
+    const stack = buildStack()
+    expect(Object.keys(stack.chainIdToStatusTrackingStateMachineName).sort()).toEqual(
+      Object.keys(stack.chainIdToStatusTrackingStateMachineArn).sort()
+    )
+  })
+
+})


### PR DESCRIPTION
Order tracking stopped starting on every chain for a day and nothing detected it. Three independent gaps allowed that; this closes all three.

## 1. No alarm on the only signal that existed

`UniswapXOrderService` swallows post-persist failures deliberately — an accepted order must never be reported as rejected. So when tracking breaks, requests still return 201 and no 4xx/5xx alarm moves. `PostOrderPostPersistFailure` was emitted for every order on every chain and appeared **exactly once in the repo**: the `putMetric` call. Nothing alarmed on it, nothing dashboarded it.

Adds a SEV3 on it.

## 2. No alarm for tracking stopping entirely

The step function alarms are *rate* alarms over `100*((throttled+failed+timedOut+aborted)/started)` with `treatMissingData: IGNORE`. When zero executions start, the expression has no datapoints and `IGNORE` holds them at their last state — **OK**. They detect "executions are failing" and are structurally blind to "executions stopped happening", which is what a broken ARN or bad deploy actually looks like.

Adds a SEV2 heartbeat with `TreatMissingData.BREACHING`, mirroring the existing `LoopCompleted` alarm in `status-stack`.

Two design notes:

- **Alarms on a new `OrderTrackerStarted` counter, not `AWS/States` `ExecutionsStarted`.** The AWS metric is per-state-machine, and summing one metric per chain hits CloudWatch's **10-metric cap** for math-expression alarms — I tried it and CDK rejects it outright at 21 chains. Our own counter is aggregate by construction and needs no maintenance as chains are added.
- **Prod only.** Beta has no steady organic order flow, so an hourly heartbeat there would alarm on idleness rather than breakage. Beta is covered by the synth tests below plus the post-deploy e2e suite.

## 3. No test of the CDK at all

`bin/` had zero test coverage, so a map that was *declared but never populated* type-checked (an index signature returns `string`, not `string | undefined`, without `noUncheckedIndexedAccess`), synthesized, and deployed.

Adds synth tests covering **both sides of the seam**:

- `StepFunctionStack` publishes a name for every supported chain, and the name map stays key-aligned with the ARN map.
- `LambdaStack`'s `STATE_MACHINE_NAMES` contains no `"undefined"`, has an entry per chain, and never regresses to the per-chain `STATE_MACHINE_ARN_<chainId>` shape that exhausted the 4KB limit in the first place.

**Verified they fail for the right reason:** removing the name-map assignment fails exactly 3 of them and nothing else. A guard nobody has watched go red isn't a guard.

## Tests

558 pass. The 14 remaining failures are pre-existing — clean `main` reports the identical 14 (`field-validator` / `order-validator`, `LABS_COSIGNER`). `tsc` clean, eslint no new errors.

## On CD gating — worth reading before adding more

I went in expecting to have to add integ tests and gate CD on them. Both already exist:

- `bin/app.ts`'s `addIntegTests` adds a post-deploy `CodeBuildStep` running `yarn test:e2e` to **both** the beta and prod stages via `addPost`. A beta failure fails the pipeline, so prod promotion is already blocked.
- The e2e suite already asserts outcomes that **depend on the step function firing** — `order.test.ts:543` expects an order to reach `expired`, and `:588`/`:602` expect `filled`. `waitAndGetOrderStatus`'s own comment says *"We have to wait for the sfn to fire."*

So this bug should have failed beta e2e and blocked prod. That leaves an open question I could not answer without pipeline access: did the e2e run and fail (in which case CD worked and only beta was affected), or did something let it through? Worth confirming before adding redundant gating.

What the synth tests above genuinely add is **speed and locality**: they catch this class in CI in seconds, pre-deploy, instead of after a beta deploy plus a four-minute e2e wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
