### PR TITLE
fix: raise the Get Orders query cache TTL from 250ms to 500ms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Required for deployment:
 - `FAILED_EVENT_DESTINATION_ARN` - Failed event SNS ARN
 
 Optional:
-- `GET_ORDERS_CACHE_TTL_MS` - TTL for the read-path query cache on the get-orders/get-limit-orders Lambdas (default 250; set to `0` to disable the cache).
+- `GET_ORDERS_CACHE_TTL_MS` - TTL for the read-path query cache on the get-orders/get-limit-orders Lambdas (default 500; set to `0` to disable the cache).
 
 For tests:
 - `UNISWAP_API` - Deployed API URL (e2e tests)

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -211,7 +211,7 @@ export class APIPipeline extends Stack {
           .toString(),
         THROTTLE_PER_FIVE_MINS: '3000',
         // Get Orders query cache TTL. Set to '0' and deploy to disable the cache.
-        GET_ORDERS_CACHE_TTL_MS: '250',
+        GET_ORDERS_CACHE_TTL_MS: '500',
         REGION: 'us-east-2', //needed in checkOrderStatusHandler to kick off step function retries
         LABS_COSIGNER: labsCosignerBeta.secretValue.toString(),
         LABS_PRIORITY_COSIGNER: labsPriorityCosignerBeta.secretValue.toString(),
@@ -256,7 +256,7 @@ export class APIPipeline extends Stack {
           .toString(),
         THROTTLE_PER_FIVE_MINS: '3000',
         // Get Orders query cache TTL. Set to '0' and deploy to disable the cache.
-        GET_ORDERS_CACHE_TTL_MS: '250',
+        GET_ORDERS_CACHE_TTL_MS: '500',
         REGION: 'us-east-2', //needed in checkOrderStatusHandler to kick off step function retries
         LABS_COSIGNER: labsCosignerProd.secretValue.toString(),
         LABS_PRIORITY_COSIGNER: labsPriorityCosignerProd.secretValue.toString(),

--- a/lib/repositories/QueryCache.ts
+++ b/lib/repositories/QueryCache.ts
@@ -5,7 +5,7 @@ type CacheEntry<T> = {
   value: T
 }
 
-const DEFAULT_QUERY_CACHE_TTL_MS = 250
+const DEFAULT_QUERY_CACHE_TTL_MS = 500
 
 // Set GET_ORDERS_CACHE_TTL_MS=0 to disable the query cache without a code change.
 export function queryCacheTtlFromEnv(): number {

--- a/test/unit/repositories/QueryCache.test.ts
+++ b/test/unit/repositories/QueryCache.test.ts
@@ -1,4 +1,4 @@
-import { QueryCache } from '../../../lib/repositories/QueryCache'
+import { QueryCache, queryCacheTtlFromEnv } from '../../../lib/repositories/QueryCache'
 
 describe('QueryCache', () => {
   it('returns a stored value inside the TTL window', () => {
@@ -84,5 +84,37 @@ describe('QueryCache', () => {
 
     expect(cache.size).toEqual(0)
     expect(cache.get('a', 1_000)).toBeUndefined()
+  })
+})
+
+describe('queryCacheTtlFromEnv', () => {
+  const original = process.env.GET_ORDERS_CACHE_TTL_MS
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.GET_ORDERS_CACHE_TTL_MS
+    } else {
+      process.env.GET_ORDERS_CACHE_TTL_MS = original
+    }
+  })
+
+  it('defaults to 500ms when the env var is unset', () => {
+    delete process.env.GET_ORDERS_CACHE_TTL_MS
+    expect(queryCacheTtlFromEnv()).toEqual(500)
+  })
+
+  it('honours an explicit override', () => {
+    process.env.GET_ORDERS_CACHE_TTL_MS = '1000'
+    expect(queryCacheTtlFromEnv()).toEqual(1000)
+  })
+
+  it('treats zero as an explicit disable, not a fallback', () => {
+    process.env.GET_ORDERS_CACHE_TTL_MS = '0'
+    expect(queryCacheTtlFromEnv()).toEqual(0)
+  })
+
+  it('falls back to the default on a non-numeric value', () => {
+    process.env.GET_ORDERS_CACHE_TTL_MS = 'fast'
+    expect(queryCacheTtlFromEnv()).toEqual(500)
   })
 })


### PR DESCRIPTION
## What

Bumps the read-path query cache TTL from 250ms to 500ms in all three places it lives: the code default in `QueryCache.ts`, the `GET_ORDERS_CACHE_TTL_MS` env var for the beta and prod stacks in `bin/app.ts`, and the `CLAUDE.md` docs line. Adds unit tests pinning the default and the env-override / `0` kill-switch behaviour of `queryCacheTtlFromEnv`.

## Why

During the 2026-09-02 GET /orders brownout the cache (from #696) was working as designed at a 77–80% hit rate, but the residual miss rate was still ~1,700 DynamoDB queries/s against the `chainId_orderStatus-createdAt-all` GSI. That floor is set by container count, not request count: every warm container refreshes each hot key every TTL, so misses/s ≈ containers × (1000 / TTL). With ~350 containers at 250ms that is ~1,400/s before CheckOrderStatus traffic. At 500ms it is ~700/s.

Combined with the per-query cost (~3.7 RCU with one open order in the page, growing ~0.4 RCU per additional open order) this roughly doubles the number of simultaneously-open orders on a hot chain the GSI partition can absorb before throttling. Today that threshold was about three open orders on chain 4663.

Cost: fillers can see a new order up to 500ms late instead of 250ms.

## What this does not fix

- The cache still degrades as concurrency rises. At the tip-over concurrency went 350 → 10,000 and the hit rate fell from 80% to 4% within ten minutes, because each container then saw fewer than one request per TTL. A shared cache (API Gateway stage cache, DAX, or ElastiCache) is needed for a hard cap.
- Reserved concurrency on GetOrders is still needed so a GetOrders overload cannot starve CheckOrderStatus; that starvation is what turned today's throttle into a self-sustaining loop.
- SDK default retries (10, exponential) are what stretch a throttled request to ~17s and inflate concurrency; capping retries and serving stale on `ThrottlingException` is the follow-up that prevents the cascade.

## Test plan

- [x] `yarn jest test/unit/repositories/QueryCache.test.ts test/unit/repositories/query-cache-integration.test.ts` — 23 passed
- [x] eslint + prettier clean on changed files
- [ ] After deploy: `GetOrdersQueryCacheMiss` should drop by roughly half at unchanged traffic; `ConsumedReadCapacityUnits` on `chainId_orderStatus-createdAt-all` should follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
