### PR TITLE
feat: dashboard section for the Get Orders cache and capacity controls

### DIFF
--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -454,6 +454,7 @@ export class APIStack extends cdk.Stack {
       getUnimindLambdaName: getUnimindLambda.functionName,
       chainIdToStatusTrackingStateMachineArn,
       orderStatusLambdaName: checkStatusFunction.functionName,
+      getOrdersReservedConcurrency,
     })
 
     const apiAlarm5xxSev2 = new aws_cloudwatch.Alarm(this, `${SERVICE_NAME}-SEV2-5XXAlarm`, {

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -784,6 +784,9 @@ export class DashboardStack extends cdk.NestedStack {
             x: 16,
             type: 'metric',
             properties: {
+              // WAF only counts a request under a rule's metric when the rule matches, and for a
+              // block rule that means blocked, so there is no per-rule "allowed" series. The
+              // service's own request count is the denominator instead: requests that got through.
               metrics: [
                 [
                   'AWS/WAFV2',
@@ -796,14 +799,20 @@ export class DashboardStack extends cdk.NestedStack {
                   region,
                   { label: 'ip-get-orders blocked' },
                 ],
-                ['.', 'AllowedRequests', '.', '.', '.', '.', '.', '.', { label: 'ip-get-orders allowed' }],
+                [
+                  METRIC_NAMESPACE,
+                  'GetOrdersRequest',
+                  'Service',
+                  'UniswapXService',
+                  { label: 'GetOrders requests served' },
+                ],
               ],
               view: 'timeSeries',
               stacked: false,
               region,
               stat: 'Sum',
               period: 300,
-              title: 'WAF ip-get-orders Blocked vs Allowed | 5min',
+              title: 'WAF ip-get-orders Blocked vs Requests Served | 5min',
             },
           },
           {

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -271,7 +271,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 24,
-            y: 38,
+            y: 44,
             x: 0,
             type: 'log',
             properties: {
@@ -285,7 +285,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 24,
-            y: 44,
+            y: 50,
             x: 0,
             type: 'log',
             properties: {
@@ -303,7 +303,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 24,
-            y: 50,
+            y: 56,
             x: 0,
             type: 'log',
             properties: {
@@ -412,7 +412,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 12,
-            y: 32,
+            y: 38,
             x: 0,
             type: 'metric',
             properties: {
@@ -432,7 +432,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 12,
-            y: 32,
+            y: 38,
             x: 12,
             type: 'metric',
             properties: {
@@ -451,7 +451,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 12,
-            y: 56,
+            y: 62,
             x: 0,
             type: 'metric',
             properties: {
@@ -471,7 +471,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 12,
-            y: 56,
+            y: 62,
             x: 12,
             type: 'metric',
             properties: {
@@ -488,7 +488,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 12,
-            y: 62,
+            y: 68,
             x: 0,
             type: 'metric',
             properties: {
@@ -508,7 +508,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 12,
-            y: 62,
+            y: 68,
             x: 12,
             type: 'metric',
             properties: {
@@ -525,7 +525,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 12,
-            y: 68,
+            y: 74,
             x: 0,
             type: 'metric',
             properties: {
@@ -551,7 +551,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 1,
             width: 24,
-            y: 74,
+            y: 80,
             x: 0,
             type: 'text',
             properties: {
@@ -561,7 +561,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 12,
-            y: 75,
+            y: 81,
             x: 0,
             type: 'metric',
             properties: {
@@ -591,7 +591,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 12,
-            y: 75,
+            y: 81,
             x: 12,
             type: 'metric',
             properties: {
@@ -619,7 +619,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 8,
-            y: 81,
+            y: 87,
             x: 0,
             type: 'metric',
             properties: {
@@ -640,7 +640,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 8,
-            y: 81,
+            y: 87,
             x: 8,
             type: 'metric',
             properties: {
@@ -675,7 +675,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 8,
-            y: 81,
+            y: 87,
             x: 16,
             type: 'metric',
             properties: {
@@ -705,7 +705,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 8,
-            y: 87,
+            y: 93,
             x: 0,
             type: 'metric',
             properties: {
@@ -742,7 +742,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 8,
-            y: 87,
+            y: 93,
             x: 8,
             type: 'metric',
             properties: {
@@ -780,7 +780,7 @@ export class DashboardStack extends cdk.NestedStack {
           {
             height: 6,
             width: 8,
-            y: 87,
+            y: 93,
             x: 16,
             type: 'metric',
             properties: {

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -542,7 +542,7 @@ export class DashboardStack extends cdk.NestedStack {
               stat: 'p90',
             },
           },
-          // --- Get Orders cache and capacity (PR #702) ---
+          // --- Get Orders cache and capacity ---
           // The get-orders query cache is per execution environment, so DynamoDB reads on a
           // hot partition scale with environment count; these widgets show the hit rate, how
           // much traffic bypasses the cache, whether partitions have outgrown one page, and the

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -9,9 +9,11 @@ import { SERVICE_NAME } from '../constants'
 
 export const METRIC_NAMESPACE = 'Uniswap'
 
-// The GSIs the polling endpoints read; see lib/repositories/util.ts getTableIndices.
+// The three GSIs the query cache serves (the enum-keyed partitions); see getTableIndices and
+// CACHEABLE_INDEXES in the repository.
 const CHAIN_STATUS_GSI = `${TABLE_KEY.CHAIN_ID_ORDER_STATUS}-${TABLE_KEY.CREATED_AT}-all`
 const STATUS_GSI = `${TABLE_KEY.ORDER_STATUS}-${TABLE_KEY.CREATED_AT}-all`
+const CHAIN_GSI = `${TABLE_KEY.CHAIN_ID}-${TABLE_KEY.CREATED_AT}-all`
 
 export type LambdaWidget = {
   type: string
@@ -720,6 +722,7 @@ export class DashboardStack extends cdk.NestedStack {
                   { label: 'Orders chainId_orderStatus' },
                 ],
                 ['.', '.', '.', '.', '.', STATUS_GSI, { label: 'Orders orderStatus' }],
+                ['.', '.', '.', '.', '.', CHAIN_GSI, { label: 'Orders chainId' }],
                 [
                   '.',
                   '.',
@@ -730,6 +733,7 @@ export class DashboardStack extends cdk.NestedStack {
                   { label: 'LimitOrders chainId_orderStatus' },
                 ],
                 ['.', '.', '.', '.', '.', STATUS_GSI, { label: 'LimitOrders orderStatus' }],
+                ['.', '.', '.', '.', '.', CHAIN_GSI, { label: 'LimitOrders chainId' }],
               ],
               view: 'timeSeries',
               stacked: false,
@@ -758,6 +762,7 @@ export class DashboardStack extends cdk.NestedStack {
                   { label: 'Orders chainId_orderStatus' },
                 ],
                 ['.', '.', '.', '.', '.', STATUS_GSI, { label: 'Orders orderStatus' }],
+                ['.', '.', '.', '.', '.', CHAIN_GSI, { label: 'Orders chainId' }],
                 [
                   '.',
                   '.',
@@ -768,6 +773,7 @@ export class DashboardStack extends cdk.NestedStack {
                   { label: 'LimitOrders chainId_orderStatus' },
                 ],
                 ['.', '.', '.', '.', '.', STATUS_GSI, { label: 'LimitOrders orderStatus' }],
+                ['.', '.', '.', '.', '.', CHAIN_GSI, { label: 'LimitOrders chainId' }],
               ],
               view: 'timeSeries',
               stacked: false,

--- a/bin/stacks/dashboard-stack.ts
+++ b/bin/stacks/dashboard-stack.ts
@@ -2,10 +2,16 @@ import * as cdk from 'aws-cdk-lib'
 import * as aws_cloudwatch from 'aws-cdk-lib/aws-cloudwatch'
 import { Construct } from 'constructs'
 import * as _ from 'lodash'
+import { TABLE_KEY } from '../../lib/config/dynamodb'
+import { TABLE_NAMES } from '../../lib/repositories/util'
 import { SUPPORTED_CHAINS } from '../../lib/util/chain'
 import { SERVICE_NAME } from '../constants'
 
 export const METRIC_NAMESPACE = 'Uniswap'
+
+// The GSIs the polling endpoints read; see lib/repositories/util.ts getTableIndices.
+const CHAIN_STATUS_GSI = `${TABLE_KEY.CHAIN_ID_ORDER_STATUS}-${TABLE_KEY.CREATED_AT}-all`
+const STATUS_GSI = `${TABLE_KEY.ORDER_STATUS}-${TABLE_KEY.CREATED_AT}-all`
 
 export type LambdaWidget = {
   type: string
@@ -24,6 +30,8 @@ export interface DashboardProps extends cdk.NestedStackProps {
   getUnimindLambdaName: string
   orderStatusLambdaName: string
   chainIdToStatusTrackingStateMachineArn: { [key: string]: string }
+  // Drawn as a line on the Get Orders concurrency chart when set.
+  getOrdersReservedConcurrency?: number
 }
 
 export class DashboardStack extends cdk.NestedStack {
@@ -35,7 +43,9 @@ export class DashboardStack extends cdk.NestedStack {
       chainIdToStatusTrackingStateMachineArn,
       orderStatusLambdaName,
       postOrderLambdaName,
+      getOrdersLambdaName,
       getUnimindLambdaName,
+      getOrdersReservedConcurrency,
     } = props
     const region = cdk.Stack.of(this).region
 
@@ -530,6 +540,270 @@ export class DashboardStack extends cdk.NestedStack {
               title: 'DutchV2 Notification Record Staleness',
               period: 300,
               stat: 'p90',
+            },
+          },
+          // --- Get Orders cache and capacity (PR #702) ---
+          // The get-orders query cache is per execution environment, so DynamoDB reads on a
+          // hot partition scale with environment count; these widgets show the hit rate, how
+          // much traffic bypasses the cache, whether partitions have outgrown one page, and the
+          // three ceilings that contain a throttle spiral: reserved concurrency, GSI throttles
+          // and the WAF rate rule.
+          {
+            height: 1,
+            width: 24,
+            y: 74,
+            x: 0,
+            type: 'text',
+            properties: {
+              markdown: '# Get Orders Cache & Capacity',
+            },
+          },
+          {
+            height: 6,
+            width: 12,
+            y: 75,
+            x: 0,
+            type: 'metric',
+            properties: {
+              metrics: [
+                [{ expression: '100 * goh / (goh + gom)', label: 'GetOrders hit rate %', id: 'gohr', region }],
+                [{ expression: '100 * gloh / (gloh + glom)', label: 'GetLimitOrders hit rate %', id: 'glohr', region }],
+                [
+                  METRIC_NAMESPACE,
+                  'GetOrdersQueryCacheHit',
+                  'Service',
+                  'UniswapXService',
+                  { id: 'goh', visible: false, region },
+                ],
+                ['.', 'GetOrdersQueryCacheMiss', '.', '.', { id: 'gom', visible: false, region }],
+                ['.', 'GetLimitOrdersQueryCacheHit', '.', '.', { id: 'gloh', visible: false, region }],
+                ['.', 'GetLimitOrdersQueryCacheMiss', '.', '.', { id: 'glom', visible: false, region }],
+              ],
+              view: 'timeSeries',
+              stacked: false,
+              region,
+              stat: 'Sum',
+              period: 300,
+              title: 'Query Cache Hit Rate | 5min',
+              yAxis: { left: { min: 0, max: 100 } },
+            },
+          },
+          {
+            height: 6,
+            width: 12,
+            y: 75,
+            x: 12,
+            type: 'metric',
+            properties: {
+              // Miss = one DynamoDB read of a cached partition. Uncacheable = a read that
+              // bypassed the cache (cursor, sort, or a caller-keyed partition). BaseTruncated =
+              // a filler/swapper query that fell back to its own GSI because the partition no
+              // longer fits one page.
+              metrics: [
+                [METRIC_NAMESPACE, 'GetOrdersQueryCacheHit', 'Service', 'UniswapXService', { label: 'GetOrders Hit' }],
+                ['.', 'GetOrdersQueryCacheMiss', '.', '.', { label: 'GetOrders Miss' }],
+                ['.', 'GetOrdersQueryCacheUncacheable', '.', '.', { label: 'GetOrders Uncacheable' }],
+                ['.', 'GetOrdersQueryCacheBaseTruncated', '.', '.', { label: 'GetOrders BaseTruncated' }],
+                ['.', 'GetLimitOrdersQueryCacheHit', '.', '.', { label: 'GetLimitOrders Hit' }],
+                ['.', 'GetLimitOrdersQueryCacheMiss', '.', '.', { label: 'GetLimitOrders Miss' }],
+                ['.', 'GetLimitOrdersQueryCacheUncacheable', '.', '.', { label: 'GetLimitOrders Uncacheable' }],
+              ],
+              view: 'timeSeries',
+              stacked: false,
+              region,
+              stat: 'Sum',
+              period: 300,
+              title: 'Query Cache Reads by Outcome | 5min',
+            },
+          },
+          {
+            height: 6,
+            width: 8,
+            y: 81,
+            x: 0,
+            type: 'metric',
+            properties: {
+              // Distinct live keys in one execution environment. Bounded by the enum-keyed
+              // partitions (statuses x chains); a climb here means the key space leaked.
+              metrics: [
+                [METRIC_NAMESPACE, 'GetOrdersQueryCacheSize', 'Service', 'UniswapXService', { label: 'GetOrders' }],
+                ['.', 'GetLimitOrdersQueryCacheSize', '.', '.', { label: 'GetLimitOrders' }],
+              ],
+              view: 'timeSeries',
+              stacked: false,
+              region,
+              stat: 'Maximum',
+              period: 300,
+              title: 'Query Cache Live Keys per Environment (max)',
+            },
+          },
+          {
+            height: 6,
+            width: 8,
+            y: 81,
+            x: 8,
+            type: 'metric',
+            properties: {
+              // Truncated: a cached partition held more rows than one page, so the single-page
+              // contract is hiding rows. Alarm-worthy for open partitions.
+              metrics: [
+                [
+                  METRIC_NAMESPACE,
+                  'GetOrdersQueryCacheTruncated',
+                  'Service',
+                  'UniswapXService',
+                  { label: 'GetOrders Truncated' },
+                ],
+                ['.', 'GetOrdersQueryCacheCapacityEviction', '.', '.', { label: 'GetOrders CapacityEviction' }],
+                ['.', 'GetLimitOrdersQueryCacheTruncated', '.', '.', { label: 'GetLimitOrders Truncated' }],
+                [
+                  '.',
+                  'GetLimitOrdersQueryCacheCapacityEviction',
+                  '.',
+                  '.',
+                  { label: 'GetLimitOrders CapacityEviction' },
+                ],
+              ],
+              view: 'timeSeries',
+              stacked: false,
+              region,
+              stat: 'Sum',
+              period: 300,
+              title: 'Query Cache Truncated Pages & Capacity Evictions | 5min',
+            },
+          },
+          {
+            height: 6,
+            width: 8,
+            y: 81,
+            x: 16,
+            type: 'metric',
+            properties: {
+              metrics: [
+                [
+                  'AWS/Lambda',
+                  'ConcurrentExecutions',
+                  'FunctionName',
+                  getOrdersLambdaName,
+                  { stat: 'Maximum', label: 'Concurrent executions (max)' },
+                ],
+                ['.', 'Throttles', '.', '.', { stat: 'Sum', label: 'Throttles', yAxis: 'right' }],
+              ],
+              view: 'timeSeries',
+              stacked: false,
+              region,
+              stat: 'Maximum',
+              period: 60,
+              title: 'Get Orders Lambda Concurrency & Throttles',
+              ...(getOrdersReservedConcurrency !== undefined && {
+                annotations: {
+                  horizontal: [{ label: 'Reserved concurrency', value: getOrdersReservedConcurrency }],
+                },
+              }),
+            },
+          },
+          {
+            height: 6,
+            width: 8,
+            y: 87,
+            x: 0,
+            type: 'metric',
+            properties: {
+              metrics: [
+                [
+                  'AWS/DynamoDB',
+                  'ConsumedReadCapacityUnits',
+                  'TableName',
+                  TABLE_NAMES.Orders,
+                  'GlobalSecondaryIndexName',
+                  CHAIN_STATUS_GSI,
+                  { label: 'Orders chainId_orderStatus' },
+                ],
+                ['.', '.', '.', '.', '.', STATUS_GSI, { label: 'Orders orderStatus' }],
+                [
+                  '.',
+                  '.',
+                  '.',
+                  TABLE_NAMES.LimitOrders,
+                  '.',
+                  CHAIN_STATUS_GSI,
+                  { label: 'LimitOrders chainId_orderStatus' },
+                ],
+                ['.', '.', '.', '.', '.', STATUS_GSI, { label: 'LimitOrders orderStatus' }],
+              ],
+              view: 'timeSeries',
+              stacked: false,
+              region,
+              stat: 'Sum',
+              period: 300,
+              title: 'Hot GSI Consumed Read Capacity | 5min',
+            },
+          },
+          {
+            height: 6,
+            width: 8,
+            y: 87,
+            x: 8,
+            type: 'metric',
+            properties: {
+              // The failure this whole section exists to prevent.
+              metrics: [
+                [
+                  'AWS/DynamoDB',
+                  'ReadThrottleEvents',
+                  'TableName',
+                  TABLE_NAMES.Orders,
+                  'GlobalSecondaryIndexName',
+                  CHAIN_STATUS_GSI,
+                  { label: 'Orders chainId_orderStatus' },
+                ],
+                ['.', '.', '.', '.', '.', STATUS_GSI, { label: 'Orders orderStatus' }],
+                [
+                  '.',
+                  '.',
+                  '.',
+                  TABLE_NAMES.LimitOrders,
+                  '.',
+                  CHAIN_STATUS_GSI,
+                  { label: 'LimitOrders chainId_orderStatus' },
+                ],
+                ['.', '.', '.', '.', '.', STATUS_GSI, { label: 'LimitOrders orderStatus' }],
+              ],
+              view: 'timeSeries',
+              stacked: false,
+              region,
+              stat: 'Sum',
+              period: 300,
+              title: 'Hot GSI Read Throttles | 5min',
+            },
+          },
+          {
+            height: 6,
+            width: 8,
+            y: 87,
+            x: 16,
+            type: 'metric',
+            properties: {
+              metrics: [
+                [
+                  'AWS/WAFV2',
+                  'BlockedRequests',
+                  'WebACL',
+                  `${SERVICE_NAME}IPThrottling`,
+                  'Rule',
+                  'ip-get-orders',
+                  'Region',
+                  region,
+                  { label: 'ip-get-orders blocked' },
+                ],
+                ['.', 'AllowedRequests', '.', '.', '.', '.', '.', '.', { label: 'ip-get-orders allowed' }],
+              ],
+              view: 'timeSeries',
+              stacked: false,
+              region,
+              stat: 'Sum',
+              period: 300,
+              title: 'WAF ip-get-orders Blocked vs Allowed | 5min',
             },
           },
           {

--- a/test/unit/stacks/dashboard-stack.test.ts
+++ b/test/unit/stacks/dashboard-stack.test.ts
@@ -59,7 +59,7 @@ describe('DashboardStack', () => {
     expect(body).toContain('"AWS/WAFV2","BlockedRequests","WebACL","GoudaServiceIPThrottling","Rule","ip-get-orders"')
   })
 
-  it('places every widget inside the 24-column grid and the cache section overlaps nothing', () => {
+  it('places every widget inside the 24-column grid with no overlaps', () => {
     const widgets = mainDashboardWidgets(build())
     const overlaps = (a: Widget, b: Widget) =>
       a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height
@@ -68,15 +68,36 @@ describe('DashboardStack', () => {
     for (const w of widgets) {
       expect(w.x + w.width).toBeLessThanOrEqual(24)
     }
-    // The legacy layout has one known collision ("Orders Filled" spans the row the two
-    // "... by Chain" widgets share; CloudWatch pushes them down). Guard the new section only.
-    const section = widgets.filter((w) => w.y >= 74)
-    expect(section.length).toBeGreaterThan(0)
-    for (const a of section) {
-      for (const b of widgets) {
-        if (a === b) continue
+    for (let i = 0; i < widgets.length; i++) {
+      for (let j = i + 1; j < widgets.length; j++) {
+        const a = widgets[i]
+        const b = widgets[j]
         expect({ a: name(a), b: name(b), overlap: overlaps(a, b) }).toEqual({ a: name(a), b: name(b), overlap: false })
       }
     }
+  })
+
+  it('keeps the cache and capacity charts in their own section below everything else', () => {
+    const widgets = mainDashboardWidgets(build())
+    const header = widgets.find((w) => w.properties.markdown === '# Get Orders Cache & Capacity')
+    expect(header).toBeDefined()
+    const bottom = (w: Widget) => w.y + w.height
+    const others = widgets.filter((w) => w !== header && w.y < header!.y)
+    // Nothing from earlier sections reaches into the cache section.
+    expect(Math.max(...others.map(bottom))).toBeLessThanOrEqual(header!.y)
+    // Every widget at or below the header is one of ours.
+    const section = widgets.filter((w) => w !== header && w.y >= header!.y)
+    expect(section.map((w) => w.properties.title).sort()).toEqual(
+      [
+        'Query Cache Hit Rate | 5min',
+        'Query Cache Reads by Outcome | 5min',
+        'Query Cache Live Keys per Environment (max)',
+        'Query Cache Truncated Pages & Capacity Evictions | 5min',
+        'Get Orders Lambda Concurrency & Throttles',
+        'Hot GSI Consumed Read Capacity | 5min',
+        'Hot GSI Read Throttles | 5min',
+        'WAF ip-get-orders Blocked vs Allowed | 5min',
+      ].sort()
+    )
   })
 })

--- a/test/unit/stacks/dashboard-stack.test.ts
+++ b/test/unit/stacks/dashboard-stack.test.ts
@@ -1,0 +1,76 @@
+import * as cdk from 'aws-cdk-lib'
+import { Template } from 'aws-cdk-lib/assertions'
+import { DashboardStack } from '../../../bin/stacks/dashboard-stack'
+
+type Widget = { x: number; y: number; width: number; height: number; properties: { title?: string; markdown?: string } }
+
+describe('DashboardStack', () => {
+  const build = (): DashboardStack => {
+    const app = new cdk.App()
+    // A concrete region keeps the dashboard body a plain JSON string rather than an Fn::Join.
+    const parent = new cdk.Stack(app, 'TestParent', { env: { account: '111111111111', region: 'us-east-2' } })
+    return new DashboardStack(parent, 'TestDashboard', {
+      apiName: 'test-api',
+      postOrderLambdaName: 'post-order-fn',
+      getOrdersLambdaName: 'get-orders-fn',
+      getNonceLambdaName: 'get-nonce-fn',
+      getUnimindLambdaName: 'get-unimind-fn',
+      orderStatusLambdaName: 'order-status-fn',
+      chainIdToStatusTrackingStateMachineArn: {},
+      getOrdersReservedConcurrency: 3000,
+    })
+  }
+
+  const mainDashboardWidgets = (stack: DashboardStack): Widget[] => {
+    const dashboards = Template.fromStack(stack).findResources('AWS::CloudWatch::Dashboard')
+    const main = Object.values(dashboards).find((r) => r.Properties.DashboardName.endsWith('ServiceDashboard'))
+    expect(main).toBeDefined()
+    expect(typeof main!.Properties.DashboardBody).toBe('string')
+    return JSON.parse(main!.Properties.DashboardBody).widgets
+  }
+
+  it('charts the Get Orders query cache, concurrency cap, hot GSIs and WAF rule', () => {
+    const body = JSON.stringify(mainDashboardWidgets(build()))
+
+    for (const metric of [
+      'GetOrdersQueryCacheHit',
+      'GetOrdersQueryCacheMiss',
+      'GetOrdersQueryCacheSize',
+      'GetOrdersQueryCacheUncacheable',
+      'GetOrdersQueryCacheTruncated',
+      'GetOrdersQueryCacheBaseTruncated',
+      'GetOrdersQueryCacheCapacityEviction',
+      'GetLimitOrdersQueryCacheHit',
+      'GetLimitOrdersQueryCacheMiss',
+    ]) {
+      expect(body).toContain(metric)
+    }
+    expect(body).toContain('"AWS/Lambda","ConcurrentExecutions","FunctionName","get-orders-fn"')
+    expect(body).toContain('"label":"Reserved concurrency","value":3000')
+    expect(body).toContain(
+      '"ReadThrottleEvents","TableName","Orders","GlobalSecondaryIndexName","chainId_orderStatus-createdAt-all"'
+    )
+    expect(body).toContain('"AWS/WAFV2","BlockedRequests","WebACL","GoudaServiceIPThrottling","Rule","ip-get-orders"')
+  })
+
+  it('places every widget inside the 24-column grid and the cache section overlaps nothing', () => {
+    const widgets = mainDashboardWidgets(build())
+    const overlaps = (a: Widget, b: Widget) =>
+      a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height
+    const name = (w: Widget) => w.properties.title ?? w.properties.markdown ?? `${w.x},${w.y}`
+
+    for (const w of widgets) {
+      expect(w.x + w.width).toBeLessThanOrEqual(24)
+    }
+    // The legacy layout has one known collision ("Orders Filled" spans the row the two
+    // "... by Chain" widgets share; CloudWatch pushes them down). Guard the new section only.
+    const section = widgets.filter((w) => w.y >= 74)
+    expect(section.length).toBeGreaterThan(0)
+    for (const a of section) {
+      for (const b of widgets) {
+        if (a === b) continue
+        expect({ a: name(a), b: name(b), overlap: overlaps(a, b) }).toEqual({ a: name(a), b: name(b), overlap: false })
+      }
+    }
+  })
+})

--- a/test/unit/stacks/dashboard-stack.test.ts
+++ b/test/unit/stacks/dashboard-stack.test.ts
@@ -57,6 +57,8 @@ describe('DashboardStack', () => {
       '"ReadThrottleEvents","TableName","Orders","GlobalSecondaryIndexName","chainId_orderStatus-createdAt-all"'
     )
     expect(body).toContain('"AWS/WAFV2","BlockedRequests","WebACL","GoudaServiceIPThrottling","Rule","ip-get-orders"')
+    // A block rule never emits AllowedRequests; the served-request count is the denominator.
+    expect(body).not.toContain('"AllowedRequests"')
   })
 
   it('places every widget inside the 24-column grid with no overlaps', () => {
@@ -96,7 +98,7 @@ describe('DashboardStack', () => {
         'Get Orders Lambda Concurrency & Throttles',
         'Hot GSI Consumed Read Capacity | 5min',
         'Hot GSI Read Throttles | 5min',
-        'WAF ip-get-orders Blocked vs Allowed | 5min',
+        'WAF ip-get-orders Blocked vs Requests Served | 5min',
       ].sort()
     )
   })

--- a/test/unit/stacks/dashboard-stack.test.ts
+++ b/test/unit/stacks/dashboard-stack.test.ts
@@ -56,6 +56,10 @@ describe('DashboardStack', () => {
     expect(body).toContain(
       '"ReadThrottleEvents","TableName","Orders","GlobalSecondaryIndexName","chainId_orderStatus-createdAt-all"'
     )
+    // All three cacheable GSIs, on both tables, in both the RCU and the throttle widgets.
+    for (const gsi of ['chainId_orderStatus-createdAt-all', 'orderStatus-createdAt-all', 'chainId-createdAt-all']) {
+      expect(body.split(`"${gsi}"`).length - 1).toBeGreaterThanOrEqual(4)
+    }
     expect(body).toContain('"AWS/WAFV2","BlockedRequests","WebACL","GoudaServiceIPThrottling","Rule","ip-get-orders"')
     // A block rule never emits AllowedRequests; the served-request count is the denominator.
     expect(body).not.toContain('"AllowedRequests"')

--- a/test/unit/stacks/dashboard-stack.test.ts
+++ b/test/unit/stacks/dashboard-stack.test.ts
@@ -45,6 +45,12 @@ describe('DashboardStack', () => {
     ]) {
       expect(body).toContain(metric)
     }
+    // Size is a per-environment gauge; only its Max is meaningful across the fleet.
+    const sizeWidget = mainDashboardWidgets(build()).find((w) =>
+      JSON.stringify(w).includes('GetOrdersQueryCacheSize')
+    ) as (Widget & { properties: { stat: string } }) | undefined
+    expect(sizeWidget?.properties.stat).toEqual('Maximum')
+    expect(JSON.stringify(sizeWidget)).toContain('GetLimitOrdersQueryCacheSize')
     expect(body).toContain('"AWS/Lambda","ConcurrentExecutions","FunctionName","get-orders-fn"')
     expect(body).toContain('"label":"Reserved concurrency","value":3000')
     expect(body).toContain(


### PR DESCRIPTION
## What

Adds a **Get Orders Cache & Capacity** section to the bottom of the `GoudaServiceDashboard` with the metrics introduced in #702, so the cache's behaviour and the three ceilings that contain a throttle spiral are visible in one place.

| Widget | Metrics | Read it as |
|---|---|---|
| Query Cache Hit Rate | `GetOrdersQueryCacheHit/Miss`, `GetLimitOrdersQueryCacheHit/Miss` | Share of list reads served from memory, per endpoint |
| Query Cache Reads by Outcome | `Hit`, `Miss`, `Uncacheable`, `BaseTruncated` | Miss = one DynamoDB read of a cached partition. Uncacheable = bypassed the cache (cursor, sort, caller-keyed partition). BaseTruncated = filler/swapper query that fell back to its own GSI |
| Query Cache Live Keys per Environment (max) | `GetOrdersQueryCacheSize`, `GetLimitOrdersQueryCacheSize` | Distinct live keys in one execution environment. Bounded by enum partitions; a climb means the key space leaked |
| Truncated Pages & Capacity Evictions | `Truncated`, `CapacityEviction` | Truncated = a partition holds more rows than one page, so the single-page contract is hiding rows. Alarm-worthy for `open` |
| Get Orders Lambda Concurrency & Throttles | `AWS/Lambda ConcurrentExecutions` (max), `Throttles` | Reserved concurrency drawn as a horizontal line (3000 prod / 100 beta) |
| Hot GSI Consumed Read Capacity | `AWS/DynamoDB ConsumedReadCapacityUnits` on the three cacheable GSIs (`chainId_orderStatus`, `orderStatus`, `chainId`, each `-createdAt-all`), Orders + LimitOrders | Load on the partitions that throttled in INC-389 |
| Hot GSI Read Throttles | `AWS/DynamoDB ReadThrottleEvents`, same GSIs | The failure this all exists to prevent |
| WAF ip-get-orders Blocked vs Requests Served | `AWS/WAFV2 BlockedRequests` for the rule, `GetOrdersRequest` as the denominator | How often the per-IP limit bites. A block rule never emits AllowedRequests, so the service's own request count stands in |

`DashboardStack` takes an optional `getOrdersReservedConcurrency`, passed from `api-stack.ts`, for the annotation line.

## Testing

- New `test/unit/stacks/dashboard-stack.test.ts` pins the metric names, the reserved-concurrency annotation, the Maximum statistic on the cache-size widget, and the GSI and WAF dimensions. It also requires every widget to fit the 24-column grid with **zero overlaps** and the cache charts to be the only widgets under their section header.
- The legacy layout had one collision: "Orders Filled" spanned the row shared by the two "... by Chain" widgets at y=32, so CloudWatch reflowed everything beneath it. Those two move to their own row and everything below shifts down six rows, so the new section (starting at y=80) is a clean block with nothing from earlier sections reaching into it. No widget content changed.
- `cdk synth` of the pipeline stack: the prod dashboard body contains the cache widgets, the reserved-concurrency line at 3000, the GSI throttle widget and the WAF widget.
- `tsc --noEmit` clean, eslint 0 errors.

## Notes

`GetOrdersQueryCacheSize` is per execution environment and bounded by the TTL, so it reads as "distinct partitions this environment served in the last 500ms", typically a handful, not fleet-wide cardinality. Fleet-wide distinct keys come from the miss log: `filter msg = "Query cache miss" | stats count_distinct(partitionKey)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



