### PR TITLE
chore: remove the insufficient-funds log subscription to the active-order feed

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -204,9 +204,6 @@ export class APIPipeline extends Stack {
         DL_REACTOR_TENDERLY: tenderlySecrets.secretValueFromJson('DL_REACTOR_TENDERLY').toString(),
         PERMIT2_TENDERLY: tenderlySecrets.secretValueFromJson('PERMIT2_TENDERLY').toString(),
         FILL_EVENT_DESTINATION_ARN: resourceArnSecret.secretValueFromJson('FILL_EVENT_DESTINATION_ARN_BETA').toString(),
-        ACTIVE_ORDER_EVENT_DESTINATION_ARN: resourceArnSecret
-          .secretValueFromJson('ACTIVE_ORDER_EVENT_DESTINATION_ARN_BETA')
-          .toString(),
         POSTED_ORDER_DESTINATION_ARN: resourceArnSecret.secretValueFromJson('POSTED_ORDER_DESTINATION_BETA').toString(),
         UNIMIND_RESPONSE_DESTINATION_ARN: resourceArnSecret
           .secretValueFromJson('UNIMIND_RESPONSE_DESTINATION_ARN_BETA')
@@ -259,9 +256,6 @@ export class APIPipeline extends Stack {
         ...jsonRpcUrls,
         RPC_HEADER_SECRET: rpcHeaderSecret,
         FILL_EVENT_DESTINATION_ARN: resourceArnSecret.secretValueFromJson('FILL_EVENT_DESTINATION_ARN_PROD').toString(),
-        ACTIVE_ORDER_EVENT_DESTINATION_ARN: resourceArnSecret
-          .secretValueFromJson('ACTIVE_ORDER_EVENT_DESTINATION_ARN_PROD')
-          .toString(),
         POSTED_ORDER_DESTINATION_ARN: resourceArnSecret.secretValueFromJson('POSTED_ORDER_DESTINATION_PROD').toString(),
         UNIMIND_RESPONSE_DESTINATION_ARN: resourceArnSecret
           .secretValueFromJson('UNIMIND_RESPONSE_DESTINATION_ARN_PROD')

--- a/bin/constants.ts
+++ b/bin/constants.ts
@@ -13,5 +13,4 @@ export const FILTER_PATTERNS = {
   UNIMIND_RESPONSE: `{ $.eventType = "${ANALYTICS_EVENTS.UNIMIND_RESPONSE}" }`,
   UNIMIND_PARAMETER_UPDATE: `{ $.eventType = "${ANALYTICS_EVENTS.UNIMIND_PARAMETER_UPDATE}" }`,
   TERMINAL_ORDER_STATE: '{ $.orderInfo.orderStatus = "filled" || $.orderInfo.orderStatus = "cancelled" }',
-  INSUFFICIENT_FUNDS: '{ $.orderInfo.orderStatus = "insufficient-funds" }',
 } as const

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -74,15 +74,6 @@ export class StepFunctionStack extends cdk.NestedStack {
         filterPattern: FILTER_PATTERNS.TERMINAL_ORDER_STATE,
         logGroupName: checkStatusFunction.logGroup.logGroupName,
       })
-
-      new aws_logs.CfnSubscriptionFilter(this, 'nonTerminalSub', {
-        destinationArn: checkDefined(
-          props.envVars['ACTIVE_ORDER_EVENT_DESTINATION_ARN'],
-          'ACTIVE_ORDER_EVENT_DESTINATION_ARN is undefined'
-        ),
-        filterPattern: FILTER_PATTERNS.INSUFFICIENT_FUNDS,
-        logGroupName: checkStatusFunction.logGroup.logGroupName,
-      })
     }
 
     // We define a separate sfn for each chain so we can easily use step function metrics per chain


### PR DESCRIPTION
## Why

Uniswap/uniswapx-parameterization-api#489 removes the "active orders" analytics path on the consumer side: the CloudWatch Logs destination `activeOrderEventDestination` and the Firehose stream and bucket behind it. That stream never delivered a record since it was created in March 2024 (missing IAM grant, bucket stayed empty), so the team chose to remove it rather than fix it.

This repo is the only producer for that destination. This PR removes the producer side so nothing keeps pointing at a destination that no longer exists.

## What's removed

- `bin/stacks/step-function-stack.ts`: the `nonTerminalSub` subscription filter on the CheckOrderStatus lambda's log group (matched `orderInfo.orderStatus = "insufficient-funds"`). Added in #406.
- `bin/app.ts`: the `ACTIVE_ORDER_EVENT_DESTINATION_ARN` env var for the beta and prod pipeline stages, which was the only reader of the secret keys below.
- `bin/constants.ts`: the `FILTER_PATTERNS.INSUFFICIENT_FUNDS` pattern, which only that filter used.

Not touched:
- `TerminalStateSub` (filled/cancelled events to `FILL_EVENT_DESTINATION_ARN`) is live and consumed.
- The lambda's logging is unchanged. It still emits the insufficient-funds status events; only the forwarding goes.
- `ANALYTICS_EVENTS.INSUFFICIENT_FUNDS` in `lib/util/analytics-events.ts` was added by #619 as a general event name, is unrelated to this filter (which matched on order status, not `eventType`), and is left as is.

## Secret keys that become unused (manual cleanup, not done here)

In the `gouda-resource-arns` secret in the pipeline account (`arn:aws:secretsmanager:us-east-2:644039819003:secret:gouda-resource-arns-wF51FW`):
- `ACTIVE_ORDER_EVENT_DESTINATION_ARN_BETA`
- `ACTIVE_ORDER_EVENT_DESTINATION_ARN_PROD`

Nothing in Secrets Manager or AWS is deleted by this PR; the deploy removes the subscription filter.

## Verification

- `yarn build`, `yarn lint` (0 errors), `yarn test` (54 suites, 654 tests, pass).
- `cdk synth` on main and on this branch, templates diffed with asset hashes normalized. The infra delta is exactly:
  - `AWS::Logs::SubscriptionFilter` `nonTerminalSub` removed from the beta and prod `GoudaServiceSfnStack` templates.
  - `ACTIVE_ORDER_EVENT_DESTINATION_ARN` removed from every Lambda environment and from the Reaper ECS task definition in beta and prod (13 env entries per stage).
  - No change to the top-level `GoudaServiceStack` resources, or to any other resource.
- One expected side effect: Lambda code asset hashes (and so `AWS::Lambda::Version` logical IDs) change in every stack, because `lib/Logging.ts` and `lib/Metrics.ts` import `SERVICE_NAME` from `bin/constants.ts`, which puts `FILTER_PATTERNS` into every bundle. Diffing the bundles shows the removed `INSUFFICIENT_FUNDS` string is the only difference.

Integration and e2e tests were not run (need Java / a deployed API); no code they exercise changed.

## Merge order

Independent of #489. Either interim state is harmless: with the consumer gone first, the filter fails to deliver as it always has; with this merged first, the destination simply receives nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
