### PR TITLE
feat: page incident.io from CloudWatch alarms and alarm on the metrics that led the outage

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Environment (`.env`):
 
 CI runs lint, unit tests, and `rdme openapi:validate` against the swagger.
 
+## Alerting
+
+CloudWatch alarms live in `api-stack` (API Gateway 5xx/4xx/latency), `lambda-stack` (per-endpoint
+5xx rates, Get Orders Lambda throttles, notification and step-function error rates) and
+`dynamo-stack` (table throttles/errors and read throttles on the hot Orders GSIs). Every alarm
+notifies through `bin/stacks/alerting.ts`: the Slack chatbot topic on ALARM, and the incident.io
+CloudWatch connector on ALARM **and** OK. incident.io only resolves an alert on OK and folds later
+ALARMs into an unresolved one, so an alarm without an OK action pages exactly once, ever. The
+connector endpoint is a credential (the alert-source id in the URL authorizes the caller) and is
+read from Secrets Manager via `INCIDENT_IO_CLOUDWATCH_ENDPOINT_SECRET_ARN` in `bin/app.ts`; it must
+never be committed.
+
 ## Sharp edges
 
 - **The public edge rewrites paths.** `api.uniswap.org/v2/orders` maps to this stack's

--- a/bin/app.ts
+++ b/bin/app.ts
@@ -18,6 +18,11 @@ import { IndexCapacityConfig, TableCapacityConfig } from './stacks/dynamo-stack'
 
 dotenv.config()
 
+// Complete ARN of the Secrets Manager secret holding incident.io's CloudWatch alert-source URL
+// (create it next to the other pipeline secrets, then fill this in). Kept out of the secret
+// value itself so rotating the URL never touches this file.
+const INCIDENT_IO_CLOUDWATCH_ENDPOINT_SECRET_ARN = ''
+
 export class APIStage extends Stage {
   public readonly url: CfnOutput
 
@@ -29,6 +34,7 @@ export class APIStage extends Stage {
       getOrdersReservedConcurrency?: number
       getOrdersThrottlePerFiveMins?: number
       chatbotSNSArn?: string
+      incidentIoCloudWatchEndpoint?: string
       internalApiKey?: string
       stage: string
       envVars: { [key: string]: string }
@@ -42,6 +48,7 @@ export class APIStage extends Stage {
       getOrdersReservedConcurrency,
       getOrdersThrottlePerFiveMins,
       chatbotSNSArn,
+      incidentIoCloudWatchEndpoint,
       internalApiKey,
       stage,
       env,
@@ -58,6 +65,7 @@ export class APIStage extends Stage {
       getOrdersThrottlePerFiveMins,
       internalApiKey,
       chatbotSNSArn,
+      incidentIoCloudWatchEndpoint,
       stage,
       envVars,
       tableCapacityConfig,
@@ -165,6 +173,18 @@ export class APIPipeline extends Stack {
       secretCompleteArn: 'arn:aws:secretsmanager:us-east-2:644039819003:secret:param-api/prod/cosignerAddress-tgNwAd',
     })
 
+    // incident.io's CloudWatch alert-source URL. The alert-source id in the path is the
+    // credential: anyone holding the URL can raise or resolve alerts, so it lives in Secrets
+    // Manager (JSON key `endpoint`, including the ?team=&service= routing params) and never in
+    // this public repo. Empty ARN => no incident.io topic is created and alarms stay Slack-only.
+    const incidentIoCloudWatchEndpoint = INCIDENT_IO_CLOUDWATCH_ENDPOINT_SECRET_ARN
+      ? sm.Secret.fromSecretAttributes(this, 'incident-io-cloudwatch-endpoint', {
+          secretCompleteArn: INCIDENT_IO_CLOUDWATCH_ENDPOINT_SECRET_ARN,
+        })
+          .secretValueFromJson('endpoint')
+          .toString()
+      : undefined
+
     const labsPriorityCosignerBeta = sm.Secret.fromSecretAttributes(this, 'labs-priority-cosigner-beta', {
       secretCompleteArn:
         'arn:aws:secretsmanager:us-east-2:644039819003:secret:beta-priority-labs-cosigner-address-cwej2J',
@@ -251,6 +271,7 @@ export class APIPipeline extends Stack {
       getOrdersThrottlePerFiveMins: 1200,
       internalApiKey: internalApiKey.secretValue.toString(),
       chatbotSNSArn: 'arn:aws:sns:us-east-2:644039819003:SlackChatbotTopic',
+      incidentIoCloudWatchEndpoint,
       stage: STAGE.PROD,
       envVars: {
         ...jsonRpcUrls,

--- a/bin/stacks/alerting.ts
+++ b/bin/stacks/alerting.ts
@@ -1,0 +1,44 @@
+import { Alarm } from 'aws-cdk-lib/aws-cloudwatch'
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions'
+import * as aws_sns from 'aws-cdk-lib/aws-sns'
+import { Construct } from 'constructs'
+
+/**
+ * SNS topics that alarms notify. Passed between nested stacks as ARN strings.
+ *
+ * Slack (the chatbot topic) gets ALARM transitions only: an OK message per recovery is noise
+ * in a channel. incident.io gets ALARM *and* OK: it only resolves an alert on OK, and while an
+ * alert is unresolved it folds every later ALARM into that first alert. Without OK actions the
+ * connector receives exactly one page in its lifetime, which is how the Sep 2 Get Orders outage
+ * fired three CloudWatch alarms and paged nobody.
+ */
+export interface AlarmTopics {
+  chatbotSNSArn?: string
+  incidentIoSNSArn?: string
+}
+
+export class AlarmNotifier {
+  private readonly alarmActions: SnsAction[] = []
+  private readonly okActions: SnsAction[] = []
+
+  constructor(scope: Construct, topics: AlarmTopics) {
+    if (topics.chatbotSNSArn) {
+      this.alarmActions.push(
+        new SnsAction(aws_sns.Topic.fromTopicArn(scope, 'ChatbotAlarmTopic', topics.chatbotSNSArn))
+      )
+    }
+    if (topics.incidentIoSNSArn) {
+      const action = new SnsAction(aws_sns.Topic.fromTopicArn(scope, 'IncidentIoAlarmTopic', topics.incidentIoSNSArn))
+      this.alarmActions.push(action)
+      this.okActions.push(action)
+    }
+  }
+
+  /** Attach every configured ALARM and OK action. Safe to call with no topics configured. */
+  public wire(...alarms: Alarm[]): void {
+    for (const alarm of alarms) {
+      this.alarmActions.forEach((action) => alarm.addAlarmAction(action))
+      this.okActions.forEach((action) => alarm.addOkAction(action))
+    }
+  }
+}

--- a/bin/stacks/api-stack.ts
+++ b/bin/stacks/api-stack.ts
@@ -3,10 +3,10 @@ import { CfnOutput, Duration } from 'aws-cdk-lib'
 import * as aws_apigateway from 'aws-cdk-lib/aws-apigateway'
 import { MethodLoggingLevel } from 'aws-cdk-lib/aws-apigateway'
 import * as aws_cloudwatch from 'aws-cdk-lib/aws-cloudwatch'
-import * as aws_cloudwatch_actions from 'aws-cdk-lib/aws-cloudwatch-actions'
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam'
 import * as aws_logs from 'aws-cdk-lib/aws-logs'
 import * as aws_sns from 'aws-cdk-lib/aws-sns'
+import * as aws_sns_subscriptions from 'aws-cdk-lib/aws-sns-subscriptions'
 import * as aws_waf from 'aws-cdk-lib/aws-wafv2'
 import { Construct } from 'constructs'
 import { STAGE, logRetentionDays } from '../../lib/util/stage'
@@ -14,6 +14,7 @@ import { SERVICE_NAME } from '../constants'
 import { DashboardStack } from './dashboard-stack'
 import { IndexCapacityConfig, TableCapacityConfig } from './dynamo-stack'
 import { KmsStack } from './kms-stack'
+import { AlarmNotifier } from './alerting'
 import { LambdaStack } from './lambda-stack'
 
 export class APIStack extends cdk.Stack {
@@ -29,6 +30,10 @@ export class APIStack extends cdk.Stack {
       getOrdersThrottlePerFiveMins?: number
       internalApiKey?: string
       chatbotSNSArn?: string
+      // incident.io CloudWatch alert-source URL (with ?team=&service= routing params), as a Secrets
+      // Manager dynamic reference. When set, an SNS topic subscribed to it is created here and
+      // every alarm notifies it on ALARM and OK.
+      incidentIoCloudWatchEndpoint?: string
       stage: string
       envVars: { [key: string]: string }
       tableCapacityConfig: TableCapacityConfig
@@ -42,6 +47,7 @@ export class APIStack extends cdk.Stack {
       getOrdersReservedConcurrency,
       getOrdersThrottlePerFiveMins,
       chatbotSNSArn,
+      incidentIoCloudWatchEndpoint,
       stage,
       provisionedConcurrency,
       internalApiKey,
@@ -51,6 +57,24 @@ export class APIStack extends cdk.Stack {
 
     // KMS initialization
     const kmsStack = new KmsStack(this, `${SERVICE_NAME}PostOrderCosignerKey`)
+
+    // incident.io's CloudWatch connector: a plain SNS topic with an HTTPS subscription to the
+    // alert-source endpoint (raw message delivery off, as incident.io requires). Alarms in every
+    // nested stack publish to it on ALARM and OK. The endpoint arrives as a Secrets Manager
+    // dynamic reference, so the protocol cannot be inferred from the string and is set explicitly.
+    let incidentIoSNSArn: string | undefined
+    if (incidentIoCloudWatchEndpoint) {
+      const incidentIoTopic = new aws_sns.Topic(this, `${SERVICE_NAME}IncidentIoCloudWatchAlerts`, {
+        topicName: `${SERVICE_NAME}-CloudWatch-alerts-incident-io`,
+        displayName: 'CloudWatch alerts for incident.io',
+      })
+      incidentIoTopic.addSubscription(
+        new aws_sns_subscriptions.UrlSubscription(incidentIoCloudWatchEndpoint, {
+          protocol: aws_sns.SubscriptionProtocol.HTTPS,
+        })
+      )
+      incidentIoSNSArn = incidentIoTopic.topicArn
+    }
 
     const {
       getOrdersLambdaAlias,
@@ -77,6 +101,7 @@ export class APIStack extends cdk.Stack {
       tableCapacityConfig,
       indexCapacityConfig,
       chatbotSNSArn,
+      incidentIoSNSArn,
     })
 
     const accessLogGroup = new aws_logs.LogGroup(this, `${SERVICE_NAME}APIGAccessLogs`, {
@@ -512,14 +537,13 @@ export class APIStack extends cdk.Stack {
       evaluationPeriods: 3,
     })
 
-    if (chatbotSNSArn) {
-      const chatBotTopic = aws_sns.Topic.fromTopicArn(this, `${SERVICE_NAME}ChatbotTopic`, chatbotSNSArn)
-      apiAlarm5xxSev2.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      apiAlarm5xxSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      apiAlarm4xxSev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      apiAlarmLatencySev3.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      apiAlarmLatencySev2.addAlarmAction(new aws_cloudwatch_actions.SnsAction(chatBotTopic))
-    }
+    new AlarmNotifier(this, { chatbotSNSArn, incidentIoSNSArn }).wire(
+      apiAlarm5xxSev2,
+      apiAlarm5xxSev3,
+      apiAlarm4xxSev3,
+      apiAlarmLatencySev3,
+      apiAlarmLatencySev2
+    )
 
     const dynamoPolicy = new PolicyStatement({
       actions: ['dynamodb:PutItem', 'dynamodb:GetItem'],

--- a/bin/stacks/dynamo-stack.ts
+++ b/bin/stacks/dynamo-stack.ts
@@ -7,6 +7,7 @@ import { Operation } from 'aws-cdk-lib/aws-dynamodb'
 import { Construct } from 'constructs'
 import { TABLE_KEY } from '../../lib/config/dynamodb'
 import { SERVICE_NAME } from '../constants'
+import { AlarmNotifier } from './alerting'
 
 type CapacityOptions = {
   readCapacity?: number
@@ -43,6 +44,7 @@ export type TableCapacityConfig = {
 
 export type DynamoStackProps = {
   chatbotSNSArn?: string
+  incidentIoSNSArn?: string
   tableCapacityConfig: TableCapacityConfig
   indexCapacityConfig?: IndexCapacityConfig
 } & cdk.NestedStackProps
@@ -58,7 +60,8 @@ export class DynamoStack extends cdk.NestedStack {
   constructor(scope: Construct, id: string, props: DynamoStackProps) {
     super(scope, id, props)
 
-    const { chatbotSNSArn, tableCapacityConfig, indexCapacityConfig } = props
+    const { chatbotSNSArn, incidentIoSNSArn, tableCapacityConfig, indexCapacityConfig } = props
+    const notifier = new AlarmNotifier(this, { chatbotSNSArn, incidentIoSNSArn })
 
     /* orders table */
     const ordersTable = new aws_dynamo.Table(this, `${SERVICE_NAME}OrdersTable`, {
@@ -123,8 +126,9 @@ export class DynamoStack extends cdk.NestedStack {
     })
     this.nonceTable = nonceTable
 
-    this.alarmsPerTable(this.nonceTable, 'Nonces', chatbotSNSArn)
-    this.alarmsPerTable(this.ordersTable, 'Orders', chatbotSNSArn)
+    this.alarmsPerTable(this.nonceTable, 'Nonces', tableCapacityConfig.nonce, notifier)
+    this.alarmsPerTable(this.ordersTable, 'Orders', tableCapacityConfig.order, notifier)
+    this.hotIndexAlarms(this.ordersTable, 'Orders', notifier)
 
     const quoteMetadataTable = new aws_dynamo.Table(this, `${SERVICE_NAME}QuoteMetadataTable`, {
       tableName: 'QuoteMetadata',
@@ -139,7 +143,7 @@ export class DynamoStack extends cdk.NestedStack {
     })
     this.quoteMetadataTable = quoteMetadataTable
 
-    this.alarmsPerTable(this.quoteMetadataTable, 'QuoteMetadata', chatbotSNSArn)
+    this.alarmsPerTable(this.quoteMetadataTable, 'QuoteMetadata', tableCapacityConfig.quoteMetadata, notifier)
 
     const unimindParametersTable = new aws_dynamo.Table(this, `${SERVICE_NAME}UnimindParametersTable`, {
       tableName: 'UnimindParameters',
@@ -154,7 +158,12 @@ export class DynamoStack extends cdk.NestedStack {
     })
     this.unimindParametersTable = unimindParametersTable
 
-    this.alarmsPerTable(this.unimindParametersTable, 'UnimindParameters', chatbotSNSArn)
+    this.alarmsPerTable(
+      this.unimindParametersTable,
+      'UnimindParameters',
+      tableCapacityConfig.unimindParameters,
+      notifier
+    )
 
     // Dynamos built-in PointInTimeRecovery retention is max 35 days.
     // In addition to PITR being enabled on the tables we do a monthly backup
@@ -170,20 +179,41 @@ export class DynamoStack extends cdk.NestedStack {
     })
   }
 
-  private alarmsPerTable(table: aws_dynamo.Table, name: string, chatbotSNSArn?: string): void {
-    const readCapacityAlarm = new aws_cloudwatch.Alarm(this, `${SERVICE_NAME}-SEV3-${name}-ReadCapacityAlarm`, {
-      alarmName: `${SERVICE_NAME}-SEV3-${name}-ReadCapacityAlarm`,
-      metric: table.metricConsumedReadCapacityUnits(),
-      threshold: 80,
-      evaluationPeriods: 2,
-    })
+  private alarmsPerTable(
+    table: aws_dynamo.Table,
+    name: string,
+    capacity: TableCapacityOptions,
+    notifier: AlarmNotifier
+  ): void {
+    // Consumed-capacity alarms only mean something against a provisioned ceiling. On a
+    // pay-per-request table there is no ceiling and the old "80 units per 5 minutes" was always
+    // exceeded, so the Orders alarms sat in ALARM permanently. On a provisioned table the same
+    // 80-unit threshold was just as permanently exceeded (Nonces alarmed from June on), so the
+    // threshold is now 80% of the provisioned capacity summed over the 5-minute period.
+    if (capacity.billingMode !== aws_dynamo.BillingMode.PAY_PER_REQUEST) {
+      const period = cdk.Duration.minutes(5)
+      const eightyPercentOver = (unitsPerSecond: number) => 0.8 * unitsPerSecond * period.toSeconds()
+      notifier.wire(
+        new aws_cloudwatch.Alarm(this, `${SERVICE_NAME}-SEV3-${name}-ReadCapacityAlarm`, {
+          alarmName: `${SERVICE_NAME}-SEV3-${name}-ReadCapacityAlarm`,
+          metric: table.metricConsumedReadCapacityUnits({ period, statistic: 'Sum' }),
+          threshold: eightyPercentOver(capacity.readCapacity ?? 5),
+          evaluationPeriods: 2,
+        }),
+        new aws_cloudwatch.Alarm(this, `${SERVICE_NAME}-SEV3-${name}-WriteCapacityAlarm`, {
+          alarmName: `${SERVICE_NAME}-SEV3-${name}-WriteCapacityAlarm`,
+          metric: table.metricConsumedWriteCapacityUnits({ period, statistic: 'Sum' }),
+          threshold: eightyPercentOver(capacity.writeCapacity ?? 5),
+          evaluationPeriods: 2,
+        })
+      )
+    }
 
-    const writeCapacityAlarm = new aws_cloudwatch.Alarm(this, `${SERVICE_NAME}-SEV3-${name}-WriteCapacityAlarm`, {
-      alarmName: `${SERVICE_NAME}-SEV3-${name}-WriteCapacityAlarm`,
-      metric: table.metricConsumedWriteCapacityUnits(),
-      threshold: 80,
-      evaluationPeriods: 2,
-    })
+    // DynamoDB only publishes ThrottledRequests / SystemErrors when they are non-zero, so a
+    // quiet table produces no datapoints. The default (treat missing as missing) freezes the
+    // alarm in whatever state it last had, which left the Orders throttle alarms stuck in
+    // ALARM for weeks. Missing must mean healthy.
+    const quietIsHealthy = { treatMissingData: aws_cloudwatch.TreatMissingData.NOT_BREACHING }
 
     const readThrottleAlarm = new aws_cloudwatch.Alarm(this, `${SERVICE_NAME}-SEV3-${name}-ReadThrottlesAlarm`, {
       alarmName: `${SERVICE_NAME}-SEV3-${name}-ReadThrottlesAlarm`,
@@ -201,6 +231,7 @@ export class DynamoStack extends cdk.NestedStack {
       }),
       threshold: 10,
       evaluationPeriods: 2,
+      ...quietIsHealthy,
     })
 
     const writeThrottleAlarm = new aws_cloudwatch.Alarm(this, `${SERVICE_NAME}-SEV3-${name}-WriteThrottlesAlarm`, {
@@ -219,6 +250,7 @@ export class DynamoStack extends cdk.NestedStack {
       }),
       threshold: 10,
       evaluationPeriods: 2,
+      ...quietIsHealthy,
     })
 
     const systemErrorsAlarm = new aws_cloudwatch.Alarm(this, `${SERVICE_NAME}-SEV3-${name}-SystemErrorsAlarm`, {
@@ -237,6 +269,7 @@ export class DynamoStack extends cdk.NestedStack {
       }),
       threshold: 10,
       evaluationPeriods: 2,
+      ...quietIsHealthy,
     })
 
     const userErrorsAlarm = new aws_cloudwatch.Alarm(this, `${SERVICE_NAME}-SEV3-${name}-UserErrorsAlarm`, {
@@ -244,16 +277,42 @@ export class DynamoStack extends cdk.NestedStack {
       metric: table.metricUserErrors(),
       threshold: 10,
       evaluationPeriods: 2,
+      ...quietIsHealthy,
     })
 
-    if (chatbotSNSArn) {
-      const chatBotTopic = cdk.aws_sns.Topic.fromTopicArn(this, 'ChatbotTopic', chatbotSNSArn)
-      userErrorsAlarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      systemErrorsAlarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      writeThrottleAlarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      readThrottleAlarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      writeCapacityAlarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      readCapacityAlarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
+    notifier.wire(userErrorsAlarm, systemErrorsAlarm, writeThrottleAlarm, readThrottleAlarm)
+  }
+
+  /**
+   * Read throttles on the GSIs the Get Orders cache serves. The table-level ThrottledRequests
+   * alarms above did not move on Sep 2 while these indexes were rejecting over a million reads
+   * every five minutes: a single hot partition key throttles at the index, and that is where the
+   * signal is. Zero in steady state, so any sustained count is an incident.
+   */
+  private hotIndexAlarms(table: aws_dynamo.Table, name: string, notifier: AlarmNotifier): void {
+    const hotIndexes = [
+      `${TABLE_KEY.CHAIN_ID_ORDER_STATUS}-${TABLE_KEY.CREATED_AT}-all`,
+      `${TABLE_KEY.ORDER_STATUS}-${TABLE_KEY.CREATED_AT}-all`,
+      `${TABLE_KEY.CHAIN_ID}-${TABLE_KEY.CREATED_AT}-all`,
+    ]
+    for (const index of hotIndexes) {
+      notifier.wire(
+        new aws_cloudwatch.Alarm(this, `${SERVICE_NAME}-SEV2-${name}-${index}-ReadThrottles`, {
+          alarmName: `${SERVICE_NAME}-SEV2-${name}-GSI-${index}-ReadThrottles`,
+          metric: new aws_cloudwatch.Metric({
+            namespace: 'AWS/DynamoDB',
+            metricName: 'ReadThrottleEvents',
+            dimensionsMap: { TableName: table.tableName, GlobalSecondaryIndexName: index },
+            statistic: 'Sum',
+            period: cdk.Duration.minutes(5),
+          }),
+          threshold: 1000,
+          evaluationPeriods: 2,
+          datapointsToAlarm: 2,
+          comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+          treatMissingData: aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+        })
+      )
     }
   }
 }

--- a/bin/stacks/lambda-stack.ts
+++ b/bin/stacks/lambda-stack.ts
@@ -14,6 +14,7 @@ import * as path from 'path'
 import { SUPPORTED_CHAINS } from '../../lib/util/chain'
 import { STAGE, logRetentionDays } from '../../lib/util/stage'
 import { SERVICE_NAME, FILTER_PATTERNS } from '../constants'
+import { AlarmNotifier } from './alerting'
 import { CronStack } from './cron-stack'
 import { DynamoStack, IndexCapacityConfig, TableCapacityConfig } from './dynamo-stack'
 import { StepFunctionStack } from './step-function-stack'
@@ -35,6 +36,7 @@ export interface LambdaStackProps extends cdk.NestedStackProps {
   tableCapacityConfig: TableCapacityConfig
   indexCapacityConfig?: IndexCapacityConfig
   chatbotSNSArn?: string
+  incidentIoSNSArn?: string
 }
 export class LambdaStack extends cdk.NestedStack {
   public readonly postOrderLambda: aws_lambda_nodejs.NodejsFunction
@@ -69,6 +71,7 @@ export class LambdaStack extends cdk.NestedStack {
       tableCapacityConfig,
       indexCapacityConfig,
       chatbotSNSArn,
+      incidentIoSNSArn,
     } = props
 
     const lambdaName = `${SERVICE_NAME}Lambda`
@@ -122,6 +125,8 @@ export class LambdaStack extends cdk.NestedStack {
     const databaseStack = new DynamoStack(this, `${SERVICE_NAME}DynamoStack`, {
       tableCapacityConfig,
       indexCapacityConfig,
+      chatbotSNSArn,
+      incidentIoSNSArn,
     })
 
     new ReaperStack(this, `${SERVICE_NAME}ReaperStack`, {
@@ -136,6 +141,7 @@ export class LambdaStack extends cdk.NestedStack {
         ...props.envVars,
       },
       lambdaRole: lambdaRole,
+      chatbotSNSArn,
     })
     this.chainIdToStatusTrackingStateMachineArn = sfnStack.chainIdToStatusTrackingStateMachineArn
     this.checkStatusFunction = sfnStack.checkStatusFunction
@@ -564,10 +570,21 @@ export class LambdaStack extends cdk.NestedStack {
       // TODO: Add unimind-related targets
     }
 
-    let chatBotTopic: cdk.aws_sns.ITopic | undefined
-    if (chatbotSNSArn) {
-      chatBotTopic = cdk.aws_sns.Topic.fromTopicArn(this, `${SERVICE_NAME}ChatbotTopic`, chatbotSNSArn)
-    }
+    const notifier = new AlarmNotifier(this, { chatbotSNSArn, incidentIoSNSArn })
+
+    // Reserved concurrency turns a Get Orders poll storm into Lambda throttles instead of a
+    // DynamoDB throttle spiral. Sustained throttling is the earliest signal that the endpoint is
+    // over its ceiling: on Sep 2 it led the API 5xx rate by five minutes.
+    const getOrdersThrottlesAlarm = new Alarm(this, `${SERVICE_NAME}-SEV2-GetOrders-LambdaThrottles`, {
+      alarmName: `${SERVICE_NAME}-SEV2-GetOrders-LambdaThrottles`,
+      metric: this.getOrdersLambda.metricThrottles({ period: Duration.minutes(5), statistic: 'sum' }),
+      threshold: 1000,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+      treatMissingData: TreatMissingData.NOT_BREACHING,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+    })
+    notifier.wire(getOrdersThrottlesAlarm)
 
     const postOrder4xxRateMetric = new MathExpression({
       expression: '(por4xx/por) * 100',
@@ -608,10 +625,7 @@ export class LambdaStack extends cdk.NestedStack {
       datapointsToAlarm: 2,
     })
 
-    if (chatBotTopic) {
-      sev2PostOrder4xxRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      sev3PostOrder4xxRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-    }
+    notifier.wire(sev2PostOrder4xxRate, sev3PostOrder4xxRate)
 
     // 5xx error-rate alarms per endpoint. Each endpoint emits a `<Endpoint>Request` counter
     // and a `<Endpoint>Status5XX` counter via embedded metrics in the handler's afterResponseHook.
@@ -678,10 +692,7 @@ export class LambdaStack extends cdk.NestedStack {
         comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
       })
 
-      if (chatBotTopic) {
-        sustainedAlarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-        catastrophicAlarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      }
+      notifier.wire(sustainedAlarm, catastrophicAlarm)
     }
 
     for (const chainId of SUPPORTED_CHAINS) {
@@ -726,10 +737,7 @@ export class LambdaStack extends cdk.NestedStack {
         comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       })
 
-      if (chatBotTopic) {
-        sev2OrderNotificationErrorRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-        sev3OrderNotificationErrorRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      }
+      notifier.wire(sev2OrderNotificationErrorRate, sev3OrderNotificationErrorRate)
     }
 
     /* cron stack */

--- a/bin/stacks/step-function-stack.ts
+++ b/bin/stacks/step-function-stack.ts
@@ -9,6 +9,7 @@ import { checkDefined } from '../../lib/preconditions/preconditions'
 import { SUPPORTED_CHAINS } from '../../lib/util/chain'
 import { STAGE, logRetentionDays } from '../../lib/util/stage'
 import { SERVICE_NAME, FILTER_PATTERNS } from '../constants'
+import { AlarmNotifier } from './alerting'
 import orderStatusTrackingStateMachine from '../definitions/order-tracking-sfn.json'
 
 export class StepFunctionStack extends cdk.NestedStack {
@@ -30,6 +31,7 @@ export class StepFunctionStack extends cdk.NestedStack {
   ) {
     super(parent, name, props)
     const { stage, chatbotSNSArn } = props
+    const notifier = new AlarmNotifier(this, { chatbotSNSArn })
 
     const stateMachineRole = new cdk.aws_iam.Role(this, `StepFunctionRole`, {
       assumedBy: new cdk.aws_iam.ServicePrincipal('states.amazonaws.com'),
@@ -201,13 +203,10 @@ export class StepFunctionStack extends cdk.NestedStack {
         comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       })
 
-      if (chatbotSNSArn) {
-        const chatBotTopic = cdk.aws_sns.Topic.fromTopicArn(this, 'ChatbotTopic', chatbotSNSArn)
-        sev2ErrorRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-        sev3ErrorRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-        sev2ExpiredRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-        sev3ExpiredRate.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(chatBotTopic))
-      }
+      // Slack only, deliberately. Several per-chain error-rate alarms sit in ALARM for long
+      // stretches (low-volume chains with a handful of failures read as a high rate), and wiring
+      // them to incident.io before the thresholds are tuned would page on every flap.
+      notifier.wire(sev2ErrorRate, sev3ErrorRate, sev2ExpiredRate, sev3ExpiredRate)
     }
   }
 }

--- a/test/unit/stacks/dynamo-stack.test.ts
+++ b/test/unit/stacks/dynamo-stack.test.ts
@@ -1,0 +1,119 @@
+import * as cdk from 'aws-cdk-lib'
+import { Template } from 'aws-cdk-lib/assertions'
+import { DynamoStack, TableCapacityConfig } from '../../../bin/stacks/dynamo-stack'
+
+const CHATBOT = 'arn:aws:sns:us-east-2:111111111111:SlackChatbotTopic'
+const INCIDENT_IO = 'arn:aws:sns:us-east-2:222222222222:CloudWatch-alerts-incident-io'
+
+const onDemand: TableCapacityConfig = {
+  order: { billingMode: cdk.aws_dynamodb.BillingMode.PAY_PER_REQUEST },
+  limitOrder: { billingMode: cdk.aws_dynamodb.BillingMode.PAY_PER_REQUEST },
+  relayOrder: { billingMode: cdk.aws_dynamodb.BillingMode.PAY_PER_REQUEST },
+  nonce: { billingMode: cdk.aws_dynamodb.BillingMode.PAY_PER_REQUEST },
+  quoteMetadata: { billingMode: cdk.aws_dynamodb.BillingMode.PAY_PER_REQUEST },
+  unimindParameters: { billingMode: cdk.aws_dynamodb.BillingMode.PAY_PER_REQUEST },
+}
+
+type AlarmResource = {
+  Properties: {
+    AlarmName: string
+    AlarmActions?: unknown[]
+    OKActions?: unknown[]
+    TreatMissingData?: string
+    Threshold?: number
+    Period?: number
+    Statistic?: string
+    Metrics?: { MetricStat?: { Metric: { MetricName: string; Dimensions?: { Name: string; Value: unknown }[] } } }[]
+    MetricName?: string
+    Dimensions?: { Name: string; Value: unknown }[]
+  }
+}
+
+describe('DynamoStack alarms', () => {
+  const build = (topics: { chatbotSNSArn?: string; incidentIoSNSArn?: string } = {}) => {
+    const app = new cdk.App()
+    const parent = new cdk.Stack(app, 'TestParent', { env: { account: '111111111111', region: 'us-east-2' } })
+    const stack = new DynamoStack(parent, 'TestDynamo', { tableCapacityConfig: onDemand, ...topics })
+    const alarms = Object.values(Template.fromStack(stack).findResources('AWS::CloudWatch::Alarm')) as AlarmResource[]
+    return { stack, alarms }
+  }
+  const byName = (alarms: AlarmResource[], needle: string) =>
+    alarms.filter((a) => JSON.stringify(a.Properties.AlarmName).includes(needle))
+
+  it('notifies incident.io on ALARM and OK, and Slack on ALARM only', () => {
+    const { alarms } = build({ chatbotSNSArn: CHATBOT, incidentIoSNSArn: INCIDENT_IO })
+    expect(alarms.length).toBeGreaterThan(0)
+    for (const alarm of alarms) {
+      const alarmActions = JSON.stringify(alarm.Properties.AlarmActions ?? [])
+      const okActions = JSON.stringify(alarm.Properties.OKActions ?? [])
+      expect(alarmActions).toContain(CHATBOT)
+      expect(alarmActions).toContain(INCIDENT_IO)
+      // incident.io only resolves an alert on OK; without it every later ALARM is folded into
+      // the first one and pages nobody.
+      expect(okActions).toContain(INCIDENT_IO)
+      expect(okActions).not.toContain(CHATBOT)
+    }
+  })
+
+  it('still synthesizes with no topics configured', () => {
+    const { alarms } = build()
+    expect(alarms.length).toBeGreaterThan(0)
+    for (const alarm of alarms) {
+      expect(alarm.Properties.AlarmActions ?? []).toHaveLength(0)
+    }
+  })
+
+  it('creates no consumed-capacity alarms for pay-per-request tables', () => {
+    // "80 units per 5 minutes" is always exceeded on an on-demand table, so these sat in ALARM
+    // forever and could never transition to notify anything.
+    const { alarms } = build()
+    expect(byName(alarms, 'CapacityAlarm')).toHaveLength(0)
+  })
+
+  it('alarms provisioned tables at 80% of their capacity over the period, not at 80 units', () => {
+    const provisioned: TableCapacityConfig = {
+      ...onDemand,
+      nonce: { billingMode: cdk.aws_dynamodb.BillingMode.PROVISIONED, readCapacity: 2000, writeCapacity: 1000 },
+    }
+    const app = new cdk.App()
+    const parent = new cdk.Stack(app, 'TestParent', { env: { account: '111111111111', region: 'us-east-2' } })
+    const stack = new DynamoStack(parent, 'TestDynamo', { tableCapacityConfig: provisioned })
+    const alarms = Object.values(Template.fromStack(stack).findResources('AWS::CloudWatch::Alarm')) as AlarmResource[]
+
+    const capacity = byName(alarms, 'CapacityAlarm')
+    expect(capacity.map((a) => a.Properties.AlarmName).sort()).toEqual([
+      'GoudaService-SEV3-Nonces-ReadCapacityAlarm',
+      'GoudaService-SEV3-Nonces-WriteCapacityAlarm',
+    ])
+    const read = byName(alarms, 'Nonces-ReadCapacityAlarm')[0]
+    const write = byName(alarms, 'Nonces-WriteCapacityAlarm')[0]
+    // 80% x 2000 RCU/s x 300 s
+    expect(read.Properties.Threshold).toEqual(480000)
+    expect(write.Properties.Threshold).toEqual(240000)
+    expect(read.Properties.Statistic).toEqual('Sum')
+    expect(read.Properties.Period).toEqual(300)
+  })
+
+  it('treats missing throttle and error datapoints as healthy', () => {
+    // DynamoDB only publishes ThrottledRequests / SystemErrors when non-zero; the default
+    // "missing" handling froze the Orders alarms in ALARM for weeks after the throttling stopped.
+    const { alarms } = build()
+    for (const alarm of [...byName(alarms, 'ThrottlesAlarm'), ...byName(alarms, 'SystemErrorsAlarm')]) {
+      expect(alarm.Properties.TreatMissingData).toEqual('notBreaching')
+    }
+  })
+
+  it('alarms on read throttles for each hot GSI of the Orders table', () => {
+    const { alarms } = build({ incidentIoSNSArn: INCIDENT_IO })
+    const gsiAlarms = byName(alarms, 'GSI-')
+    const indexes = gsiAlarms
+      .map((a) => a.Properties.Dimensions?.find((d) => d.Name === 'GlobalSecondaryIndexName')?.Value)
+      .sort()
+    expect(indexes).toEqual(['chainId-createdAt-all', 'chainId_orderStatus-createdAt-all', 'orderStatus-createdAt-all'])
+    for (const alarm of gsiAlarms) {
+      expect(alarm.Properties.MetricName).toEqual('ReadThrottleEvents')
+      expect(alarm.Properties.TreatMissingData).toEqual('notBreaching')
+      expect(JSON.stringify(alarm.Properties.OKActions)).toContain(INCIDENT_IO)
+    }
+  })
+})


### PR DESCRIPTION
## Why

During the Sep 2 Get Orders outage (INC-389) three CloudWatch alarms fired in this account (`SEV2-5XXAlarm` and `SEV3-5XXAlarm` at 15:05 UTC, `SEV2-5XX-GetOrders` at 15:14 UTC) and nobody was paged. Verified with view-only access:

- Every alarm's only action was the Slack chatbot SNS topic. No incident.io, no pager. The account has zero SNS topics of its own and no subscription to incident.io's CloudWatch connector.
- No alarm had an OK action. incident.io only resolves an alert on OK and folds every later ALARM into an unresolved one, so even a correctly subscribed connector would page exactly once in its lifetime.
- `DynamoStack` and `StepFunctionStack` were constructed without the chatbot topic, so their alarms had no actions at all.
- The Orders DynamoDB alarms had been stuck in ALARM since Aug 19 and 24: consumed-capacity alarms because "80 units per 5 minutes" is always exceeded on a pay-per-request table, throttle/system-error alarms because DynamoDB publishes those metrics only when non-zero and the default missing-data handling freezes the alarm in its last state.
- The metrics that moved first, GSI `ReadThrottleEvents` (1.0 to 2.1M per 5 min from 14:50) and Get Orders Lambda `Throttles` (concurrency pinned at the account limit from 14:50), had no alarm. The table-level `ThrottledRequests` alarm never saw the GSI throttling. `SEV2-5XX-GetOrders-Catastrophic` (>90%) never fired at 95% errors because it ratios handler-emitted metrics and a throttled Lambda emits nothing.

## What

**incident.io connector** (`api-stack.ts`, `bin/app.ts`): when `INCIDENT_IO_CLOUDWATCH_ENDPOINT_SECRET_ARN` is set, an SNS topic `GoudaService-CloudWatch-alerts-incident-io` is created with an HTTPS subscription to the alert-source URL read from that secret (raw message delivery off, per incident.io's instructions). Prod only; beta stays Slack-only. With the ARN empty (as in this PR) no topic is created and nothing changes on the incident.io side.

**The alert-source URL is a credential.** The id in its path is all that authorizes a caller, and this repo is public, so the URL is never committed: it lives in Secrets Manager as JSON `{"endpoint": "https://api.incident.io/v2/alert_events/cloudwatch/<id>?team=Trading%20Execution&service=uniswapx-service"}` next to the other pipeline secrets, and the CDK embeds it as a dynamic reference, so it does not appear in the synthesized templates either.

**`AlarmNotifier`** (`bin/stacks/alerting.ts`): one place that wires alarm actions. Slack chatbot on ALARM; incident.io on ALARM **and** OK. Used by `api-stack`, `lambda-stack`, `dynamo-stack` and `step-function-stack`.

**Coverage fixes**
- `DynamoStack` receives both topics (had none).
- `StepFunctionStack` receives the Slack topic (had none). Deliberately **not** wired to incident.io: several per-chain error-rate alarms sit in ALARM for long stretches on low-volume chains and would page on every flap until their thresholds are tuned.

**New SEV2 alarms**, both paging incident.io, `treatMissingData: notBreaching`, 2 of 2 five-minute datapoints over 1000:
- `GoudaService-SEV2-GetOrders-LambdaThrottles`. On Sep 2 this would have fired at ~15:00, five minutes before the 5xx alarms. In steady state it is zero except for a single 9,361-throttle bucket today when a burst hit the new reserved-concurrency cap, which is the cap doing its job and correctly does not trip a 2-of-2 alarm.
- `GoudaService-SEV2-Orders-GSI-<index>-ReadThrottles` for `chainId_orderStatus`, `orderStatus` and `chainId` `-createdAt-all`, the three partitions the Get Orders cache serves. Zero in steady state.

**Stuck-alarm fixes**
- Consumed-capacity alarms are created only for provisioned tables, and their threshold is 80% of provisioned capacity summed over the 5-minute period instead of a flat 80 units. On prod that removes the permanently-alarming Orders and UnimindParameters capacity alarms (pay-per-request) and retunes the Nonces and QuoteMetadata ones (provisioned at 2000 RCU / 1000 WCU) from 80 units to 480,000 read / 240,000 write units per period; the Nonces read alarm had been in ALARM since June.
- Throttle, system-error and user-error alarms use `treatMissingData: notBreaching`.

## Synth check (prod assembly)

With a placeholder secret ARN: 165 alarms, 81 notify Slack + incident.io with OK actions, 84 (step-function) notify Slack only, 0 have no actions; one SNS topic, one HTTPS subscription whose endpoint is a `{{resolve:secretsmanager:...}}` dynamic reference. With the ARN empty (this PR as-is): no topic, all alarms Slack-only, i.e. the current behaviour plus the DynamoDB and step-function alarms finally notifying Slack.

## Testing

- New `test/unit/stacks/dynamo-stack.test.ts`: every alarm has Slack on ALARM and incident.io on ALARM+OK; synthesizes with no topics; no capacity alarms on pay-per-request tables; throttle/error alarms are `notBreaching`; a GSI read-throttle alarm exists per hot index.
- `cdk synth` of the pipeline stack passes; 659 unit tests pass; tsc and eslint clean.

## Before merging

An earlier revision of this branch committed the alert-source URL in plain text; that revision was force-pushed away but the URL was public for a few hours. **Rotate the CloudWatch alert source in incident.io** (delete and recreate it, or regenerate its endpoint) before wiring anything up.

## Setup after merge

1. Create the secret in the pipeline account (644039819003), JSON with key `endpoint` holding the **new** alert-source URL including `?team=Trading%20Execution&service=uniswapx-service`, with the same cross-account resource policy as `uniswapx-internal-api-key`.
2. Put its complete ARN in `INCIDENT_IO_CLOUDWATCH_ENDPOINT_SECRET_ARN` in `bin/app.ts` (a one-line follow-up PR) and deploy.
3. The SNS subscription should show **Confirmed**; incident.io confirms automatically. If it shows PendingConfirmation, refresh once.
4. Send a test per incident.io's instructions: `aws cloudwatch set-alarm-state --alarm-name GoudaService-SEV2-GetOrders-LambdaThrottles --state-value ALARM --state-reason test`, then the same with `OK`, and confirm an alert appears and resolves under the "Trading Execution" team.
5. Check the incident.io CloudWatch alert source for any long-lived open alert from this service that a missing OK left dangling.

## Not in this PR

- Tuning the step-function per-chain alarms so they can page.
- A Catastrophic-style alarm that is not blind to Lambda throttling (the new Throttles alarm covers the case in practice).
- The Trading Datadog monitor's 30-minute window, which put its page an hour after the failure began; that monitor lives in `Uniswap/backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


